### PR TITLE
Add missing _node map_ argument for recursive call.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3504,7 +3504,7 @@
             <li>Initialize a new <a class="changed">dictionary</a> <var>result</var> consisting of a single member
               <code>@list</code> whose value is initialized to an empty <a>array</a>.</li>
             <li>Recursively call this algorithm passing the value of <var>element</var>'s
-              <code>@list</code> member for <var>element</var>, <var>active graph</var>,
+              <code>@list</code> member for <var>element</var>, <var>node map</var>, <var>active graph</var>,
               <var>active subject</var>, <var>active property</var>, and
               <var>result</var> for <var>list</var>.</li>
             <li class="changed">If <var>list</var> is <code>null</code>,


### PR DESCRIPTION
Fixes #10.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/19.html" title="Last updated on Aug 15, 2018, 12:05 AM GMT (35bf4a7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/19/a335fba...35bf4a7.html" title="Last updated on Aug 15, 2018, 12:05 AM GMT (35bf4a7)">Diff</a>