### PR TITLE
Fix manifest baseIri URLs.

### DIFF
--- a/tests/fromRdf-manifest.jsonld
+++ b/tests/fromRdf-manifest.jsonld
@@ -4,7 +4,7 @@
   "@type": "mf:Manifest",
   "name": "Transform RDF to JSON-LD",
   "description": "Transform RDF to JSON-LD tests take N-Quads input and use object comparison.",
-  "baseIri": "https://w3c.github.io/json-ld-api/tests/fromRdf/",
+  "baseIri": "https://w3c.github.io/json-ld-api/tests/",
   "sequence": [
     {
       "@id": "#t0001",

--- a/tests/remote-doc-manifest.jsonld
+++ b/tests/remote-doc-manifest.jsonld
@@ -4,7 +4,7 @@
   "@type": "mf:Manifest",
   "name": "Remote document",
   "description": "Tests appropriate document loading behavior as defined in the API",
-  "baseIri": "https://w3c.github.io/json-ld-api/tests/remote-doc/",
+  "baseIri": "https://w3c.github.io/json-ld-api/tests/",
   "sequence": [
     {
       "@id": "#t0001",

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -4,7 +4,7 @@
   "@type": "mf:Manifest",
   "name": "Transform JSON-LD to RDF",
   "description": "JSON-LD to RDF tests generate RDF Datasets and use RDF Dataset Isomorphism comparison.",
-  "baseIri": "https://w3c.github.io/json-ld-api/tests/toRdf/",
+  "baseIri": "https://w3c.github.io/json-ld-api/tests/",
   "sequence": [
     {
       "@id": "#t0001",


### PR DESCRIPTION
Remove duplicate extra trailing path segments so relative resource URLs
can be properly constructed.

This was causing issues in jsonld.js and makes baseIri usage uniform with the other manifests.