### PR TITLE
Improve example checking and generate example files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,5 +7,6 @@ end
 
 desc "Extract Examples"
 task :examples  do
-  sh %(bundle exec common/extract-examples.rb --example-dir examples index.html)
+  sh %(rm -rf examples yaml trig)
+  sh %(bundle exec common/extract-examples.rb --example-dir examples --yaml-dir yaml --trig-dir trig index.html)
 end

--- a/common/common.js
+++ b/common/common.js
@@ -1,5 +1,5 @@
 /* Web Payments Community Group common spec JavaScript */
-var jsonld = {
+const jsonld = {
   // Add as the respecConfig localBiblio variable
   // Extend or override global respec references
   localBiblio: {
@@ -59,32 +59,33 @@ var jsonld = {
 // the termlist is in a block of class "termlist", so make sure that
 // has an ID and put that ID into the termLists array so we can
 // interrogate all of the included termlists later.
-var termNames = [] ;
-var termLists = [] ;
-var termsReferencedByTerms = [] ;
+const termNames = [] ;
+const termLists = [] ;
+const termsReferencedByTerms = [] ;
 
 function restrictReferences(utils, content) {
-    var base = document.createElement("div");
-    base.innerHTML = content;
+  const base = document.createElement("div");
+  base.innerHTML = content;
 
-    // New new logic:
-    //
-    // 1. build a list of all term-internal references
-    // 2. When ready to process, for each reference INTO the terms,
-    // remove any terms they reference from the termNames array too.
-    $.each(base.querySelectorAll("dfn:not(.preserve)"), function(i, item) {
-        var $t = $(item) ;
-        var titles = $t.getDfnTitles();
-        var n = $t.makeID("dfn", titles[0]);
-        if (n) {
-            termNames[n] = $t.parent() ;
-        }
-    });
+  // New new logic:
+  //
+  // 1. build a list of all term-internal references
+  // 2. When ready to process, for each reference INTO the terms,
+  // remove any terms they reference from the termNames array too.
+  const noPreserve = base.querySelectorAll("dfn:not(.preserve)");
+  for (const item of noPreserve) {
+    const $t = $(item) ;
+    const titles = $t.getDfnTitles();
+    const n = $t.makeID("dfn", titles[0]);
+    if (n) {
+      termNames[n] = $t.parent();
+    }
+  }
 
-    var $container = $(".termlist", base) ;
-    var containerID = $container.makeID("", "terms") ;
-    termLists.push(containerID) ;
-    return (base.innerHTML);
+  const $container = $(".termlist", base) ;
+  const containerID = $container.makeID("", "terms") ;
+  termLists.push(containerID) ;
+  return (base.innerHTML);
 }
 
 // add a handler to come in after all the definitions are resolved
@@ -95,100 +96,92 @@ function restrictReferences(utils, content) {
 // consider it an internal reference and ignore it.
 
 function internalizeTermListReferences() {
-    // all definitions are linked; find any internal references
-    $(".termlist a.internalDFN").each(function() {
-        var $r = $(this);
-        var id = $r.attr('href');
-        var idref = id.replace(/^#/,"") ;
-        if (termNames[idref]) {
-            // this is a reference to another term
-            // what is the idref of THIS term?
-            var $def = $r.closest('dd') ;
-            if ($def.length) {
-                var $p = $def.prev('dt').find('dfn') ;
-                var tid = $p.attr('id') ;
-                if (tid) {
-                    if (termsReferencedByTerms[tid]) {
-                        termsReferencedByTerms[tid].push(idref);
-                    } else {
-                        termsReferencedByTerms[tid] = [] ;
-                        termsReferencedByTerms[tid].push(idref);
-                    }
-                }
-            }
+  // all definitions are linked; find any internal references
+  const internalTerms = document.querySelectorAll(".termlist a.internalDFN");
+  for (const item of internalTerms) {
+    const idref = item.getAttribute('href').replace(/^#/,"") ;
+    if (termNames[idref]) {
+      // this is a reference to another term
+      // what is the idref of THIS term?
+      const def = item.closest('dd');
+      if (def) {
+        const tid = def.previousElementSibling
+          .querySelector('dfn')
+          .getAttribute('id');
+        if (tid) {
+          if (termsReferencedByTerms[tid]) {
+            termsReferencedByTerms[tid].push(idref);
+          } else {
+            termsReferencedByTerms[tid] = [] ;
+            termsReferencedByTerms[tid].push(idref);
+          }
         }
-    });
+      }
+    }
+  }
 
-    // clearRefs is recursive.  Walk down the tree of
-    // references to ensure that all references are resolved.
-    var clearRefs = function(theTerm) {
-        if ( termsReferencedByTerms[theTerm] ) {
-            $.each(termsReferencedByTerms[theTerm], function(i, item) {
-                if (termNames[item]) {
-                    delete termNames[item];
-                    clearRefs(item);
-                }
-            });
-        };
-        // make sure this term doesn't get removed
-        if (termNames[theTerm]) {
-            delete termNames[theTerm];
+  // clearRefs is recursive.  Walk down the tree of
+  // references to ensure that all references are resolved.
+  const clearRefs = function(theTerm) {
+    if ( termsReferencedByTerms[theTerm] ) {
+      for (const item of termsReferencedByTerms[theTerm]) {
+        if (termNames[item]) {
+            delete termNames[item];
+            clearRefs(item);
         }
+      }
     };
+    // make sure this term doesn't get removed
+    if (termNames[theTerm]) {
+      delete termNames[theTerm];
+    }
+  };
 
-    // now termsReferencedByTerms has ALL terms that
-    // reference other terms, and a list of the
-    // terms that they reference
-    $("a.internalDFN").each(function () {
-        var $item = $(this) ;
-        var t = $item.attr('href');
-        var r = t.replace(/^#/,"") ;
-        if (r === 'dictionary') {
-          var rr = r;
-        }
-        // if the item is outside the term list
-        if ( ! $item.closest('dl.termlist').length ) {
-            clearRefs(r);
-        }
-    });
+  // now termsReferencedByTerms has ALL terms that
+  // reference other terms, and a list of the
+  // terms that they reference
+  const internalRefs = document.querySelectorAll("a.internalDFN");
+  for (const item of internalRefs) {
+    const idref = item.getAttribute('href').replace(/^#/,"") ;
+    // if the item is outside the term list
+    if ( !item.closest('dl.termlist') ) {
+      clearRefs(idref);
+    }
+  }
 
-    // delete any terms that were not referenced.
-    Object.keys(termNames).forEach(function(term) {
-        var $p = $("#"+term) ;
-        if ($p) {
-            var tList = $p.getDfnTitles();
-            $p.parent().next().remove();
-            $p.remove() ;
-            tList.forEach(function( item ) {
-                if (respecConfig.definitionMap[item]) {
-                    delete respecConfig.definitionMap[item];
-                }
-            });
+  // delete any terms that were not referenced.
+  for (const term of Object.keys(termNames)) {
+    const $p = $("#"+term) ;
+    if ($p && !$p.empty()) {
+      const tList = $p.getDfnTitles();
+      $p.parent().next().remove();
+      $p.remove() ;
+      for (const item of tList) {
+        if (respecConfig.definitionMap[item]) {
+            delete respecConfig.definitionMap[item];
         }
-    });
+      }
+    }
+  }
 }
 
 function _esc(s) {
-    s = s.replace(/&/g,'&amp;');
-    s = s.replace(/>/g,'&gt;');
-    s = s.replace(/"/g,'&quot;');
-    s = s.replace(/</g,'&lt;');
-    return s;
+  return s.replace(/&/g,'&amp;')
+    .replace(/>/g,'&gt;')
+    .replace(/"/g,'&quot;')
+    .replace(/</g,'&lt;');
 }
 
 function updateExample(doc, content) {
   // perform transformations to make it render and prettier
-  content = unComment(doc, content);
-  content = _esc(content);
-  content = content.replace(/\*\*\*\*([^*]*)\*\*\*\*/g, '<span class="hl-bold">$1</span>');
-  content = content.replace(/####([^#]*)####/g, '<span class="comment">$1</span>');
-  return content ;
+  return _esc(unComment(doc, content))
+    .replace(/\*\*\*\*([^*]*)\*\*\*\*/g, '<span class="hl-bold">$1</span>')
+    .replace(/####([^#]*)####/g, '<span class="comment">$1</span>');
 }
 
 
 function unComment(doc, content) {
   // perform transformations to make it render and prettier
-  content = content.replace(/<!--/, '');
-  content = content.replace(/-->/, '');
-  return content ;
+  return content.replace(/<!--/, '')
+    .replace(/-->/, '');
 }

--- a/common/extract-examples.rb
+++ b/common/extract-examples.rb
@@ -1,138 +1,385 @@
 #!/usr/bin/env ruby
 # Extracts examples from a ReSpec document, verifies that example titles are unique. Numbering attempts to replicate that used by ReSpec. Examples in script elements, which are not visibile, may be used for describing the results of related examples
+#
+# Transformations from JSON-LD
+# - @data-frame identifies the title of the frame used to process the example
+# - @data-frame-for identifies the source to apply this frame to, verifies that the no errors are encountered
+# - @data-context identifies the title of the context used to process the example
+# - @data-context-for identifies the source to apply this context to, verifies that the no errors are encountered
+# - @data-result-for identifies the title of the source which should result in the content. May be used along with @data-frame or @data-context
+# - @data-options indicates the comma-separated option/value pairs to pass to the processor
 require 'getoptlong'
 require 'json'
 require 'nokogiri'
 require 'linkeddata'
 require 'fileutils'
 require 'colorize'
+require 'yaml'
 
-example_dir = nil
+PREFIXES = {
+  dc:     "http://purl.org/dc/terms/",
+  cred:   "https://w3id.org/credentials#",
+  ex:     "http://example.org/",
+  foaf:   "http://xmlns.com/foaf/0.1/",
+  prov:   "http://www.w3.org/ns/prov#",
+  rdf:    "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+  schema: "http://schema.org/",
+  xsd:    "http://www.w3.org/2001/XMLSchema#"
+}
+example_dir = yaml_dir = trig_dir = verbose = number = nil
+
 opts = GetoptLong.new(
-  ["--example-dir", GetoptLong::REQUIRED_ARGUMENT]
+  ["--example-dir",   GetoptLong::REQUIRED_ARGUMENT],
+  ["--yaml-dir",      GetoptLong::REQUIRED_ARGUMENT],
+  ["--trig-dir",      GetoptLong::REQUIRED_ARGUMENT],
+  ["--verbose", '-v', GetoptLong::NO_ARGUMENT],
+  ["--number", '-n',  GetoptLong::REQUIRED_ARGUMENT],
 )
 opts.each do |opt, arg|
   case opt
-  when '--example-dir'  then example_dir = arg
+  when '--example-dir'  then example_dir = arg && FileUtils::mkdir_p(arg)
+  when '--yaml-dir'     then yaml_dir = arg && FileUtils::mkdir_p(arg)
+  when '--trig-dir'     then trig_dir = arg && FileUtils::mkdir_p(arg)
+  when '--verbose'      then verbose = true
+  when '--number'       then number = arg.to_i
   end
 end
 
 num_errors = 0
 
+# Justify and remove leading and trailing blank lines from str
+# Remove highlighting and commented out sections
+def justify(str)
+  str = str.
+    sub(/^\s*<!--\s*$/, '').
+    sub(/^\s*-->\s*$/, '').
+    gsub('****', '').
+    gsub(/####([^#]*)####/, '')
+
+  # remove blank lines
+  lines = str.split("\n").reject {|s| s =~ /\A\s*\z/}
+
+  # count minimum leading space
+  leading = lines.map {|s| s.length - s.lstrip.length}.min
+
+  # remove leading blank space
+  lines.map {|s| s[leading..-1]}.join("\n")
+end
+
 ARGV.each do |input|
-  $stdout.puts "\ninput: #{input}"
-  example_number = 0
+  $stderr.puts "\ninput: #{input}"
+  example_number = 1 # Account for imported Example 1 in typographical conventions
   examples = {}
   errors = []
   warnings = []
 
   File.open(input, "r") do |f|
     doc = Nokogiri::HTML.parse(f.read)
-    doc.css(".example").each do |element|
-      warn = false
-      example_number += 1 if element.name == "pre"
+    doc.css(".example, .illegal-example").each do |element|
+      error = nil
+      warn = nil
+      example_number += 1 if %w(pre aside).include?(element.name)
 
-      if element.attr('data-ignore') || element.name == "table"
-        $stdout.write "i".colorize(:yellow)
+      if (title = element.attr('title').to_s).empty?
+        error = "Example #{example_number} at line #{element.line} has no title"
         next
       end
 
-      if (title = element.attr('title')).to_s.empty?
-        errors << "Example #{example_number} at line #{element.line} has no title"
-        $stdout.write "F".colorize(:red)
-        next
+      if examples[title]
+        warn = "Example #{example_number} at line #{element.line} uses duplicate title: #{title}"
       end
 
-      if examples.any? {|n, ex| ex[:title] == title}
-        warnings << "Example #{example_number} at line #{element.line} uses duplicate title: #{title}"
-        warn = true
-      end
-
-      content = element.inner_html.
-        sub(/^\s*<!--\s*/m, '').
-        sub(/s*-->\s*$/m, '').
-        gsub('****', '').
-        gsub(/####([^#]*)####/, '')
+      content = justify(element.inner_html)
 
       ext = case element.attr('data-content-type')
-      when nil, '' then "json"
+      when nil, '', 'application/ld+json' then "jsonld"
+      when 'application/json' then 'json'
+      when 'application/ld-frame+json' then 'jsonldf'
       when 'application/n-quads', 'nq' then 'nq'
       when 'text/html', 'html' then 'html'
       when 'text/turtle', 'ttl' then 'ttl'
+      when 'application/trig', 'trig' then 'trig'
       else 'txt'
       end
 
-      # Perform example syntactic validation based on extension
-      case ext
-      when 'json'
-        begin
-          ::JSON.parse(content)
-        rescue JSON::ParserError => e
-          errors << "Example #{example_number} at line #{element.line} parse error: #{e.message}"
-          $stdout.write "F".colorize(:red)
-          next
-        end
-      when 'html'
-        begin
-          doc = Nokogiri::HTML.parse(content) {|c| c.strict}
-          doc.errors.each do |e|
-            errors << "Example #{example_number} at line #{element.line} parse error: #{e}"
-          end
-          unless doc.errors.empty?
-            $stdout.write "F".colorize(:red)
-            next
-          end
-        rescue Nokogiri::XML::SyntaxError => e
-          errors << "Example #{example_number} at line #{element.line} parse error: #{e.message}"
-          $stdout.write "F".colorize(:red)
-          next
-        end
-      when 'ttl'
-        begin
-          reader_errors = []
-          RDF::Turtle::Reader.new(content, logger: reader_errors) {|r| r.validate!}
-        rescue
-          reader_errors.each do |e|
-            errors << "Example #{example_number} at line #{element.line} parse error: #{e}"
-          end
-          $stdout.write "F".colorize(:red)
-          next
-        end
-      when 'nq'
-        begin
-          reader_errors = []
-          RDF::NQuads::Reader.new(content, logger: reader_errors) {|r| r.validate!}
-        rescue
-          reader_errors.each do |e|
-            errors << "Example #{example_number} at line #{element.line} parse error: #{e}"
-          end
-          $stdout.write "F".colorize(:red)
-          next
-        end
-      end
+      fn = "example-#{"%03d" % example_number}-#{title.gsub(/[^\w]+/, '-')}.#{ext}"
+      examples[title] = {
+        title: title,
+        filename: fn,
+        content: content,
+        content_type: element.attr('data-content-type'),
+        number: example_number,
+        ext: ext,
+        context_for: element.attr('data-context-for'),
+        context: element.attr('data-context'),
+        ignore: element.attr('data-ignore'),
+        flatten: element.attr('data-flatten'),
+        compact: element.attr('data-compact'),
+        fromRdf: element.attr('data-from-rdf'),
+        toRdf: element.attr('data-to-rdf'),
+        frame_for: element.attr('data-frame-for'),
+        frame: element.attr('data-frame'),
+        result_for: element.attr('data-result-for'),
+        options: element.attr('data-options'),
+        element: element.name,
+        line: element.line,
+        warn: warn,
+        error: error,
+      }
+      #puts "example #{example_number}: #{content}"
+    end
+  end
 
-      case element.name
-      when "pre"
-        fn = "example-#{"%03d" % example_number}-#{title.gsub(/[^\w]+/, '-')}.#{ext}"
-        examples[example_number] = {
-          title: title,
-          filename: fn,
-          content: content
-        }
-        #puts "example #{example_number}: #{content}"
-      when "script"
-        # Validate the previous example appropriately
-      else
-        errors << "Example #{example_number} at line #{element.line} has unknown element type #{element.name}"
+  # Process API functions for
+  examples.values.sort_by {|ex| ex[:number]}.each do |ex|
+    next if number && number != ex[:number]
+
+    args = []
+    content = ex[:content]
+
+    $stderr.puts "example #{ex[:number]}: #{ex.select{|k,v| k != :content}.to_json(JSON::LD::JSON_STATE)}" if verbose
+    $stderr.puts "content: #{ex[:content]}" if verbose
+
+    if ex[:ignore] || ex[:element] == 'table'
+      $stdout.write "i".colorize(:yellow)
+      next
+    end
+
+    if ex[:error]
+      errors << ex[:error]
+      $stdout.write "F".colorize(:red)
+      next
+    end
+
+    if !%w(pre script aside).include?(ex[:element])
+      errors << "Example #{ex[:number]} at line #{ex[:line]} has unknown element type #{ex[:element]}"
+      $stdout.write "F".colorize(:red)
+      next
+    end
+
+    # Perform example syntactic validation based on extension
+    case ex[:ext]
+    when 'json', 'jsonld', 'jsonldf'
+      begin
+        ::JSON.parse(content)
+      rescue JSON::ParserError => exception
+        errors << "Example #{ex[:number]} at line #{ex[:line]} parse error: #{exception.message}"
+        $stdout.write "F".colorize(:red)
+        next
+      end
+    when 'html'
+      begin
+        doc = Nokogiri::HTML.parse(content) {|c| c.strict}
+        doc.errors.each do |er|
+          errors << "Example #{ex[:number]} at line #{ex[:line]} parse error: #{er}"
+        end
+        unless doc.errors.empty?
+          $stdout.write "F".colorize(:red)
+          next
+        end
+      rescue Nokogiri::XML::SyntaxError => exception
+        errors << "Example #{ex[:number]} at line #{ex[:line]} parse error: #{exception.message}"
+        $stdout.write "F".colorize(:red)
+        next
+      end
+    when 'ttl', 'trig'
+      begin
+        reader_errors = []
+        RDF::TriG::Reader.new(content, logger: reader_errors) {|r| r.validate!}
+      rescue
+        reader_errors.each do |er|
+          errors << "Example #{ex[:number]} at line #{ex[:line]} parse error: #{er}"
+        end
+        $stdout.write "F".colorize(:red)
+        next
+      end
+    when 'nq'
+      begin
+        reader_errors = []
+        RDF::NQuads::Reader.new(content, logger: reader_errors) {|r| r.validate!}
+      rescue
+        reader_errors.each do |er|
+          errors << "Example #{ex[:number]} at line #{ex[:line]} parse error: #{er}"
+        end
+        $stdout.write "F".colorize(:red)
+        next
+      end
+    end
+
+    options = ex[:options].to_s.split(',').inject({}) do |memo, pair|
+      k, v = pair.split('=')
+      v = case v
+      when 'true' then true
+      when 'false' then false
+      else v
+      end
+      memo.merge(k.to_sym => v)
+    end
+
+    # Set API to use
+    method = case
+    when ex[:compact] then :compact
+    when ex[:flatten] then :flatten
+    when ex[:fromRdf] then :fromRdf
+    when ex[:toRdf]   then :toRdf
+    when ex[:ext] == 'json' then nil
+    else                   :expand
+    end
+
+    if ex[:frame_for]
+      unless examples[ex[:frame_for]]
+        errors << "Example Frame #{ex[:number]} at line #{ex[:line]} references unknown example ex[:frame_for].inspect"
         $stdout.write "F".colorize(:red)
         next
       end
 
-      if warn
-        $stdout.write "w".colorize(:yellow)
-      else
-        $stdout.write ".".colorize(:green)
+      method = :frame
+      args = [StringIO.new(examples[ex[:frame_for]][:content]), StringIO.new(content), options]
+    elsif ex[:context_for]
+      unless examples[ex[:context_for]]
+        errors << "Example Context #{ex[:number]} at line #{ex[:line]} references unknown example ex[:context_for].inspect"
+        $stdout.write "F".colorize(:red)
+        next
       end
+
+      # Either exapand with this external context, or compact using it
+      case method
+      when :expand
+        options[:externalContext] = StringIO.new(content)
+        args = [StringIO.new(examples[ex[:context_for]][:content]), options]
+      when :compact, :flatten, nil
+        args = [StringIO.new(examples[ex[:context_for]][:content]), StringIO.new(content), options]
+      end
+    elsif ex[:ext] == 'jsonld'
+      # Either exapand with this external context, or compact using it
+      case method
+      when :expand, :toRdf, :fromRdf
+        options[:externalContext] = StringIO.new(ex[:context]) if ex[:context]
+        args = [StringIO.new(content), options]
+      when :compact, :flatten
+        # Fixme how to find context?
+        args = [StringIO.new(content), (StringIO.new(ex[:context]) if ex[:context]), options]
+      end
+    end
+
+    if ex[:result_for]
+      # Source is referenced
+      args[0] = StringIO.new(examples[ex[:result_for]][:content])
+      if ex[:frame] && !examples[ex[:frame]]
+        errors << "Example #{ex[:number]} at line #{ex[:line]} references unknown frame ex[:frame].inspect"
+        $stdout.write "F".colorize(:red)
+        next
+      elsif ex[:frame]
+        method = :frame
+        args = [args[0], StringIO.new(examples[ex[:frame]][:content]), options]
+      end
+
+      if ex[:context] && !examples[ex[:context]]
+        errors << "Example #{ex[:number]} at line #{ex[:line]} references unknown context ex[:context].inspect"
+        $stdout.write "F".colorize(:red)
+        next
+      else
+        case method
+        when :expand, :toRdf, :fromRdf
+          options[:externalContext] = StringIO.new(examples[ex[:context]][:content]) if ex[:context]
+          args = [args[0], options]
+        when :compact, :flatten
+          args = [args[0], ex[:context] ? StringIO.new(examples[ex[:context]][:content]) : nil, options]
+        end
+      end
+    end
+
+    # Save example
+    if example_dir
+      File.open(File.join(example_dir, ex[:filename]), 'w') {|f| f.write(content)}
+    end
+
+    # Save example as YAML
+    if yaml_dir && ex[:filename].match?(/\.json.*$/)
+      fn = ex[:filename].sub(/\.json.*$/, '.yml')
+      File.open(File.join(yaml_dir, fn), 'w') do |f|
+        f.puts "Example #{"%03d" % ex[:number]}: #{ex[:title]}"
+        f.write(::JSON.parse(ex[:content]).to_yaml)
+      end
+    end
+
+    # Generate result
+    begin
+      result = case method
+      when nil then nil
+      when :fromRdf
+        ext = ex[:result_for] ? examples[ex[:result_for]][:ext] : ex[:ext]
+        args[0] = RDF::Reader.for(file_extension: ext).new(args[0])
+        JSON::LD::API.fromRdf(*args)
+      when :toRdf
+        RDF::Dataset.new statements: JSON::LD::API.toRdf(*args)
+      else
+        JSON::LD::API.method(method).call(*args)
+      end
+    rescue
+      errors << "Example #{ex[:number]} at line #{ex[:line]} parse error generating result: #{$!}"
+      $stdout.write "F".colorize(:red)
+      next
+    end
+
+    if verbose
+      if result.is_a?(RDF::Dataset)
+        $stderr.puts "result: " + result.to_trig
+      else
+        $stderr.puts "result: " + result.to_json(JSON::LD::JSON_STATE)
+      end
+    end
+
+    begin
+      if ex[:result_for]
+        # Compare to expected result
+        case ex[:ext]
+        when 'ttl', 'trig', 'nq', 'html'
+          reader = RDF::Reader.for(file_extension: ex[:ext]).new(StringIO.new(content))
+          expected = RDF::Dataset.new(statements: reader)
+          $stderr.puts "expected: " + expected.to_trig if verbose
+          expected_norm = RDF::Normalize.new(expected).map(&:to_nquads)
+          result_norm = RDF::Normalize.new(result).map(&:to_nquads)
+          unless expected_norm == expected_norm
+            errors << "Example #{ex[:number]} at line #{ex[:line]} not isomorphic with #{examples[ex[:result_for]][:number]}"
+            $stdout.write "F".colorize(:red)
+            next
+          end
+        else
+          expected = ::JSON.parse(content)
+          $stderr.puts "expected: " + expected.to_json(JSON::LD::JSON_STATE) if verbose
+          unless result == expected
+            errors << "Example #{ex[:number]} at line #{ex[:line]} not equivalent to #{examples[ex[:result_for]][:number]}"
+            $stdout.write "F".colorize(:red)
+            next
+          end
+        end
+      end
+    rescue
+      errors << "Example #{ex[:number]} at line #{ex[:line]} parse error comparing result: #{$!}"
+      $stdout.write "F".colorize(:red)
+      next
+    end
+
+    # Save example as TriG
+    if trig_dir && (ex[:filename].match?(/\.json.*$/) || result.is_a?(RDF::Enumerable))
+      # Make examples directory
+      FileUtils::mkdir_p(trig_dir)
+      fn = ex[:filename].sub(/\.json.*$/, '.trig')
+      unless result.is_a?(RDF::Enumerable)
+        result = RDF::Dataset.new(statements: JSON::LD::API.toRdf(result))
+      end
+
+      File.open(File.join(trig_dir, fn), 'w') do |f|
+        RDF::TriG::Writer.dump(result,  f, prefixes: PREFIXES)
+      end
+    end
+
+    if ex[:warn]
+      warnings << ex[:warn]
+      $stdout.write "w".colorize(:yellow)
+    else
+      $stdout.write ".".colorize(:green)
     end
   end
 
@@ -141,14 +388,6 @@ ARGV.each do |input|
   $stdout.puts "\nErrors:" unless errors.empty?
   errors.each {|e| $stdout.puts "  #{e}".colorize(:red)}
   num_errors += errors.length
-
-  if example_dir
-    # Make examples directory
-    FileUtils::mkdir_p(example_dir)
-    examples.each do |num, ex|
-      File.open(File.join(example_dir, ex[:filename]), 'w') {|f| f.write(ex[:content])}
-    end
-  end
 end
 
 if num_errors == 0

--- a/examples/example-002-Sample-JSON-LD-document.jsonld
+++ b/examples/example-002-Sample-JSON-LD-document.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "name": "http://xmlns.com/foaf/0.1/name",
+    "knows": "http://xmlns.com/foaf/0.1/knows"
+  },
+  "@id": "http://me.markus-lanthaler.com/",
+  "name": "Markus Lanthaler",
+  "knows": [
+    {
+      "name": "Dave Longley"
+    }
+  ]
+}

--- a/examples/example-003-JSON-LD-documenet-using-only-terms.jsonld
+++ b/examples/example-003-JSON-LD-documenet-using-only-terms.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "name": "http://xmlns.com/foaf/0.1/name",
+    "homepage": {
+      "@id": "http://xmlns.com/foaf/0.1/homepage",
+      "@type": "@id"
+    }
+  },
+  "@id": "http://me.markus-lanthaler.com/",
+  "name": "Markus Lanthaler",
+  "homepage": "http://www.markus-lanthaler.com/"
+}

--- a/examples/example-003-JSON-LD-document-using-only-terms-expanded-.jsonld
+++ b/examples/example-003-JSON-LD-document-using-only-terms-expanded-.jsonld
@@ -1,0 +1,15 @@
+[
+  {
+    "@id": "http://me.markus-lanthaler.com/",
+    "http://xmlns.com/foaf/0.1/homepage": [
+      {
+        "@id": "http://www.markus-lanthaler.com/"
+      }
+    ],
+    "http://xmlns.com/foaf/0.1/name": [
+      {
+        "@value": "Markus Lanthaler"
+      }
+    ]
+  }
+]

--- a/examples/example-004-Sample-JSON-LD-document-using-an-IRI-instead-of-a-term-to-express-a-property.jsonld
+++ b/examples/example-004-Sample-JSON-LD-document-using-an-IRI-instead-of-a-term-to-express-a-property.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "website": "http://xmlns.com/foaf/0.1/homepage"
+  },
+  "@id": "http://me.markus-lanthaler.com/",
+  "http://xmlns.com/foaf/0.1/name": "Markus Lanthaler",
+  "website": { "@id": "http://www.markus-lanthaler.com/" }
+}

--- a/examples/example-005-Expanded-JSON-LD-document-using-an-IRI.jsonld
+++ b/examples/example-005-Expanded-JSON-LD-document-using-an-IRI.jsonld
@@ -1,0 +1,11 @@
+[
+  {
+    "@id": "http://me.markus-lanthaler.com/",
+    "http://xmlns.com/foaf/0.1/name": [
+      { "@value": "Markus Lanthaler" }
+    ],
+    "http://xmlns.com/foaf/0.1/homepage": [
+      { "@id": "http://www.markus-lanthaler.com/" }
+    ]
+  }
+]

--- a/examples/example-006-Expanded-sample-document.jsonld
+++ b/examples/example-006-Expanded-sample-document.jsonld
@@ -1,0 +1,11 @@
+[
+  {
+    "@id": "http://me.markus-lanthaler.com/",
+    "http://xmlns.com/foaf/0.1/name": [
+      { "@value": "Markus Lanthaler" }
+    ],
+    "http://xmlns.com/foaf/0.1/homepage": [
+      { "@id": "http://www.markus-lanthaler.com/" }
+    ]
+  }
+]

--- a/examples/example-007-JSON-LD-context.jsonld
+++ b/examples/example-007-JSON-LD-context.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "name": "http://xmlns.com/foaf/0.1/name",
+    "homepage": {
+      "@id": "http://xmlns.com/foaf/0.1/homepage",
+      "@type": "@id"
+    }
+  }
+}

--- a/examples/example-008-Compacted-sample-document.jsonld
+++ b/examples/example-008-Compacted-sample-document.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "name": "http://xmlns.com/foaf/0.1/name",
+    "homepage": {
+      "@id": "http://xmlns.com/foaf/0.1/homepage",
+      "@type": "@id"
+    }
+  },
+  "@id": "http://me.markus-lanthaler.com/",
+  "name": "Markus Lanthaler",
+  "homepage": "http://www.markus-lanthaler.com/"
+}

--- a/examples/example-009-JSON-LD-document-in-compact-form.jsonld
+++ b/examples/example-009-JSON-LD-document-in-compact-form.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "name": "http://xmlns.com/foaf/0.1/name",
+    "knows": "http://xmlns.com/foaf/0.1/knows"
+  },
+  "@id": "http://me.markus-lanthaler.com/",
+  "name": "Markus Lanthaler",
+  "knows": [
+    {
+      "name": "Dave Longley"
+    }
+  ]
+}

--- a/examples/example-010-Flattened-sample-document-in-expanded-form.jsonld
+++ b/examples/example-010-Flattened-sample-document-in-expanded-form.jsonld
@@ -1,0 +1,17 @@
+[
+  {
+    "@id": "_:b0",
+    "http://xmlns.com/foaf/0.1/name": [
+      { "@value": "Dave Longley" }
+    ]
+  },
+  {
+    "@id": "http://me.markus-lanthaler.com/",
+    "http://xmlns.com/foaf/0.1/name": [
+      { "@value": "Markus Lanthaler" }
+    ],
+    "http://xmlns.com/foaf/0.1/knows": [
+      { "@id": "_:b0" }
+    ]
+  }
+]

--- a/examples/example-011-Flattened-and-compacted-sample-document.jsonld
+++ b/examples/example-011-Flattened-and-compacted-sample-document.jsonld
@@ -1,0 +1,16 @@
+{
+  "@context": {
+    "name": "http://xmlns.com/foaf/0.1/name",
+    "knows": "http://xmlns.com/foaf/0.1/knows"
+  },
+  "@graph": [
+    {
+      "@id": "_:b0",
+      "name": "Dave Longley"
+    }, {
+      "@id": "http://me.markus-lanthaler.com/",
+      "name": "Markus Lanthaler",
+      "knows": { "@id": "_:b0" }
+    }
+  ]
+}

--- a/examples/example-012-Sample-Turtle-document.ttl
+++ b/examples/example-012-Sample-Turtle-document.ttl
@@ -1,0 +1,2 @@
+<http://me.markus-lanthaler.com/> <http://xmlns.com/foaf/0.1/name> "Markus Lanthaler" .
+<http://me.markus-lanthaler.com/> <http://xmlns.com/foaf/0.1/homepage> <http://www.markus-lanthaler.com/> .

--- a/examples/example-013-Sample-Turtle-document-converted-to-JSON-LD.jsonld
+++ b/examples/example-013-Sample-Turtle-document-converted-to-JSON-LD.jsonld
@@ -1,0 +1,11 @@
+[
+  {
+    "@id": "http://me.markus-lanthaler.com/",
+    "http://xmlns.com/foaf/0.1/name": [
+      { "@value": "Markus Lanthaler" }
+    ],
+    "http://xmlns.com/foaf/0.1/homepage": [
+      { "@id": "http://www.markus-lanthaler.com/" }
+    ]
+  }
+]

--- a/examples/example-014-Term-definition-with-language-map.jsonld
+++ b/examples/example-014-Term-definition-with-language-map.jsonld
@@ -1,0 +1,3 @@
+{
+  "@context": {"t": {"@id": "http://example.org/t", "@container": "@language"}}
+}

--- a/examples/example-016-Term-definition-with-datatype.jsonld
+++ b/examples/example-016-Term-definition-with-datatype.jsonld
@@ -1,0 +1,3 @@
+{
+  "@context": {"t": {"@id": "http://example.org/t", "@type": "http:/example.org/type"}}
+}

--- a/index.html
+++ b/index.html
@@ -371,7 +371,9 @@
     -->
     </pre>
 
-    <script type="application/ld+json" data-api="expand">
+    <script class="example" 
+            data-result-for="JSON-LD documenet using only terms"
+            title="JSON-LD document using only terms (expanded)">
       [
         {
           "@id": "http://me.markus-lanthaler.com/",
@@ -426,6 +428,7 @@
       operation) against the above examples results in the following output:</p>
 
     <pre class="example nohighlight" data-transform="updateExample"
+         data-result-for="Sample JSON-LD document using an IRI instead of a term to express a property"
          title="Expanded JSON-LD document using an IRI">
     <!--
     [
@@ -479,6 +482,7 @@
     <p>For example, assume the following expanded JSON-LD input document:</p>
 
     <pre class="example nohighlight" data-transform="updateExample"
+         data-result-for="Sample JSON-LD document using an IRI instead of a term to express a property"
          title="Expanded sample document">
     <!--
     [
@@ -499,6 +503,7 @@
       <a>context</a>:</p>
 
     <pre class="example nohighlight" data-transform="updateExample"
+         data-context-for="Expanded sample document"
          title="JSON-LD context">
     <!--
     {
@@ -519,6 +524,9 @@
       document provided above would result in the following output:</p>
 
     <pre class="example nohighlight" data-transform="updateExample"
+         data-result-for="Expanded sample document"
+         data-context="JSON-LD context"
+         data-compact
          title="Compacted sample document">
     <!--
     {
@@ -590,11 +598,13 @@
       returns the following document:</p>
 
     <pre class="example nohighlight" data-transform="updateExample"
+         data-result-for="JSON-LD document in compact form"
+         data-flatten
          title="Flattened sample document in expanded form">
     <!--
     [
       {
-        "@id": "_:t0",
+        "@id": "_:b0",
         "http://xmlns.com/foaf/0.1/name": [
           { "@value": "Dave Longley" }
         ]
@@ -605,7 +615,7 @@
           { "@value": "Markus Lanthaler" }
         ],
         "http://xmlns.com/foaf/0.1/knows": [
-          { "@id": "_:t0" }
+          { "@id": "_:b0" }
         ]
       }
     ]
@@ -619,7 +629,7 @@
     <p>Note how in the output above all properties of a <a>node</a> are collected in a
       single <a class="changed">dictionary</a> and how the <a>blank node</a> representing
       &quot;Dave Longley&quot; has been assigned the <a>blank node identifier</a>
-      <code>_:t0</code>.</p>
+      <code>_:b0</code>.</p>
 
     <p>To make it easier for humans to read or for certain applications to
       process it, a flattened document can be compacted by passing a context. Using
@@ -627,6 +637,9 @@
       looks as follows:</p>
 
     <pre class="example nohighlight" data-transform="updateExample"
+         data-result-for="JSON-LD document in compact form"
+         data-flatten
+         data-context="JSON-LD document in compact form"
          title="Flattened and compacted sample document">
     <!--
     {
@@ -636,12 +649,12 @@
       },
       "@graph": [
         {
-          "@id": "_:t0",
+          "@id": "_:b0",
           "name": "Dave Longley"
         }, {
           "@id": "http://me.markus-lanthaler.com/",
           "name": "Markus Lanthaler",
-          "knows": { "@id": "_:t0" }
+          "knows": { "@id": "_:b0" }
         }
       ]
     }
@@ -666,6 +679,7 @@
 
     <pre class="example nohighlight" data-transform="updateExample"
          data-content-type="text/turtle"
+         data-from-rdf
          title="Sample Turtle document">
     <!--
     <http://me.markus-lanthaler.com/> <http://xmlns.com/foaf/0.1/name> "Markus Lanthaler" .
@@ -677,6 +691,8 @@
       a developer could transform this document into expanded JSON-LD:</p>
 
     <pre class="example nohighlight" data-transform="updateExample"
+         data-result-for="Sample Turtle document"
+         data-from-rdf
          title="Sample Turtle document converted to JSON-LD">
     <!--
     [
@@ -740,6 +756,24 @@
     suite [[JSON-LD-TESTS]]. Note, however, that passing all the tests in the test
     suite does not imply complete conformance to this specification. It only implies
     that the implementation conforms to aspects tested by the test suite.</p>
+
+  <p>This specification makes use of the following namespace prefixes:</p>
+  <table class="simple">
+    <thead><tr>
+      <th>Prefix</th>
+      <th>IRI</th>
+    </tr></thead>
+    <tbody>
+      <tr>
+        <td>rdf</td>
+        <td>http://www.w3.org/1999/02/22-rdf-syntax-ns#</td>
+      </tr>
+      <tr>
+        <td>xsd</td>
+        <td>http://www.w3.org/2001/XMLSchema#</td>
+      </tr>
+    </tbody>
+  </table>
 </section> <!-- end of Conformance section -->
 
 <section>
@@ -3134,22 +3168,22 @@
           <a>value object</a> having no <code>@type</code>.</p>
         <pre class="example" title="Term definition with language map">
           {
-            "@context": {"t": {"@id": "http://example/t", "@container": "@language"}}
+            "@context": {"t": {"@id": "http://example.org/t", "@container": "@language"}}
           }
         </pre>
         <p>The inverse context will contain the following:</p>
         <pre>
-{
-  "@language": {
-    "@language": {"@none": "t"},
-    "@type": {"@none": "t"},
-    "@any": {"@none": "t"}
-  }
-}
+        {
+          "@language": {
+            "@language": {"@none": "t"},
+            "@type": {"@none": "t"},
+            "@any": {"@none": "t"}
+          }
+        }
         </pre>
 
         <aside class="example" data-ignore title="Language map term with language value">
-          <p>Given the member <code>{"http://example/t": {"@value": "foo", "@type": "http:/example/type"}}</code>,
+          <p>Given the member <code>{"http://example.org/t": {"@value": "foo", "@type": "http:/example.org/type"}}</code>,
             The algorithm will be invoked as follows:</p>
           <dl>
             <dt><var>containers</var></dt>
@@ -3169,24 +3203,24 @@
         <h4>Datatyped Term</h4>
         <p>If the term definition has a datatype, it will only match a
           <a>value object</a> having a matching datatype.</p>
-        <pre class="example" data-ignore title="Term definition with datatype">
+        <pre class="example" title="Term definition with datatype">
           {
-            "@context": {"t": {"@id": "http://example/t", "@type": "http:/example/type"}}
+            "@context": {"t": {"@id": "http://example.org/t", "@type": "http:/example.org/type"}}
           }
         </pre>
         <p>The inverse context will contain the following:</p>
         <pre>
-{
-  "@none": {
-    "@language": {},
-    "@type": {"http:/example/type": "t"},
-    "@any": {"@none": "t"}
-  }
-}
+          {
+            "@none": {
+              "@language": {},
+              "@type": {"http:/example.org/type": "t"},
+              "@any": {"@none": "t"}
+            }
+          }
         </pre>
 
         <aside class="example" data-ignore title="Datatyped term with datatyped value">
-          <p>Given the member <code>{"http://example/t": {"@value": "foo", "@type": "http:/example/type"}}</code>,
+          <p>Given the member <code>{"http://example.org/t": {"@value": "foo", "@type": "http:/example.org/type"}}</code>,
             The algorithm will be invoked as follows:</p>
           <dl>
             <dt><var>containers</var></dt>
@@ -3194,15 +3228,15 @@
             <dt><var>type/language</var></dt>
             <dd><code>@type</code></dd>
             <dt><var>preferred values</var></dt>
-            <dd><code>["http:/example/type", "@none"]</code></dd>
+            <dd><code>["http:/example.org/type", "@none"]</code></dd>
           </dl>
-          <p>The <var>value map</var> will be set to <code>{"http:/example/type": "t"}</code>,
-            as <var>preferred values</var> contains <code>"http:/example/type"</code>,
+          <p>The <var>value map</var> will be set to <code>{"http:/example.org/type": "t"}</code>,
+            as <var>preferred values</var> contains <code>"http:/example.org/type"</code>,
             the algorithm returns <code>"t"</code> as the term to use for compaction.</p>
         </aside>
 
         <aside class="example" data-ignore title="Datatyped term with simple value">
-          <p>Given the member <code>{"http://example/t": {"@value": "foo"}}</code>,
+          <p>Given the member <code>{"http://example.org/t": {"@value": "foo"}}</code>,
             The algorithm will be invoked as follows:</p>
           <dl>
             <dt><var>containers</var></dt>
@@ -3218,7 +3252,7 @@
         </aside>
 
         <aside class="example" data-ignore title="Datatyped term with object value">
-          <p>Given the member <code>{"http://example/t": {"@id": "http://example/id"}}</code>,
+          <p>Given the member <code>{"http://example.org/t": {"@id": "http://example.org/id"}}</code>,
             The algorithm will be invoked as follows:</p>
           <dl>
             <dt><var>containers</var></dt>
@@ -3228,7 +3262,7 @@
             <dt><var>preferred values</var></dt>
             <dd><code>["@id", "@vocab", "@none"]</code></dd>
           </dl>
-          <p>The <var>value map</var> will be set to <code>{"http:/example/type": "t"}</code>,
+          <p>The <var>value map</var> will be set to <code>{"http:/example.org/type": "t"}</code>,
             as no key in <var>preferred values</var> matches a key in <var>value map</var>,
             the algorithm returns <code>null</code> and no term is found.</p>
         </aside>
@@ -3703,31 +3737,6 @@
   <p>This section describes algorithms to deserialize a JSON-LD document to an
     <a>RDF dataset</a> and vice versa. The algorithms are designed for in-memory
     implementations with random access to <a class="changed">dictionary</a> elements.</p>
-
-  <p>Throughout this section, the following vocabulary
-    <a>prefixes</a> are used in
-    <a>compact IRIs</a>:</p>
-
-  <table class="simple">
-    <thead><tr>
-      <th>Prefix</th>
-      <th>IRI</th>
-    </tr></thead>
-    <tbody>
-      <tr>
-        <td>rdf</td>
-        <td>http://www.w3.org/1999/02/22-rdf-syntax-ns#</td>
-      </tr>
-      <tr>
-        <td>rdfs</td>
-        <td> http://www.w3.org/2000/01/rdf-schema#</td>
-      </tr>
-      <tr>
-        <td>xsd</td>
-        <td>http://www.w3.org/2001/XMLSchema#</td>
-      </tr>
-    </tbody>
-  </table>
 
   <section>
     <h2>Deserialize JSON-LD to RDF algorithm</h2>

--- a/trig/example-002-Sample-JSON-LD-document.trig
+++ b/trig/example-002-Sample-JSON-LD-document.trig
@@ -1,0 +1,5 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://me.markus-lanthaler.com/> foaf:knows [ foaf:name "Dave Longley"];
+   foaf:name "Markus Lanthaler" .

--- a/trig/example-003-JSON-LD-documenet-using-only-terms.trig
+++ b/trig/example-003-JSON-LD-documenet-using-only-terms.trig
@@ -1,0 +1,5 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://me.markus-lanthaler.com/> foaf:homepage <http://www.markus-lanthaler.com/>;
+   foaf:name "Markus Lanthaler" .

--- a/trig/example-003-JSON-LD-document-using-only-terms-expanded-.trig
+++ b/trig/example-003-JSON-LD-document-using-only-terms-expanded-.trig
@@ -1,0 +1,5 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://me.markus-lanthaler.com/> foaf:homepage <http://www.markus-lanthaler.com/>;
+   foaf:name "Markus Lanthaler" .

--- a/trig/example-004-Sample-JSON-LD-document-using-an-IRI-instead-of-a-term-to-express-a-property.trig
+++ b/trig/example-004-Sample-JSON-LD-document-using-an-IRI-instead-of-a-term-to-express-a-property.trig
@@ -1,0 +1,5 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://me.markus-lanthaler.com/> foaf:homepage <http://www.markus-lanthaler.com/>;
+   foaf:name "Markus Lanthaler" .

--- a/trig/example-005-Expanded-JSON-LD-document-using-an-IRI.trig
+++ b/trig/example-005-Expanded-JSON-LD-document-using-an-IRI.trig
@@ -1,0 +1,5 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://me.markus-lanthaler.com/> foaf:homepage <http://www.markus-lanthaler.com/>;
+   foaf:name "Markus Lanthaler" .

--- a/trig/example-006-Expanded-sample-document.trig
+++ b/trig/example-006-Expanded-sample-document.trig
@@ -1,0 +1,5 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://me.markus-lanthaler.com/> foaf:homepage <http://www.markus-lanthaler.com/>;
+   foaf:name "Markus Lanthaler" .

--- a/trig/example-007-JSON-LD-context.trig
+++ b/trig/example-007-JSON-LD-context.trig
@@ -1,0 +1,5 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://me.markus-lanthaler.com/> foaf:homepage <http://www.markus-lanthaler.com/>;
+   foaf:name "Markus Lanthaler" .

--- a/trig/example-008-Compacted-sample-document.trig
+++ b/trig/example-008-Compacted-sample-document.trig
@@ -1,0 +1,5 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://me.markus-lanthaler.com/> foaf:homepage <http://www.markus-lanthaler.com/>;
+   foaf:name "Markus Lanthaler" .

--- a/trig/example-009-JSON-LD-document-in-compact-form.trig
+++ b/trig/example-009-JSON-LD-document-in-compact-form.trig
@@ -1,0 +1,5 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://me.markus-lanthaler.com/> foaf:knows [ foaf:name "Dave Longley"];
+   foaf:name "Markus Lanthaler" .

--- a/trig/example-010-Flattened-sample-document-in-expanded-form.trig
+++ b/trig/example-010-Flattened-sample-document-in-expanded-form.trig
@@ -1,0 +1,5 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://me.markus-lanthaler.com/> foaf:knows [ foaf:name "Dave Longley"];
+   foaf:name "Markus Lanthaler" .

--- a/trig/example-011-Flattened-and-compacted-sample-document.trig
+++ b/trig/example-011-Flattened-and-compacted-sample-document.trig
@@ -1,0 +1,5 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://me.markus-lanthaler.com/> foaf:knows [ foaf:name "Dave Longley"];
+   foaf:name "Markus Lanthaler" .

--- a/trig/example-013-Sample-Turtle-document-converted-to-JSON-LD.trig
+++ b/trig/example-013-Sample-Turtle-document-converted-to-JSON-LD.trig
@@ -1,0 +1,5 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://me.markus-lanthaler.com/> foaf:homepage <http://www.markus-lanthaler.com/>;
+   foaf:name "Markus Lanthaler" .

--- a/yaml/example-002-Sample-JSON-LD-document.yml
+++ b/yaml/example-002-Sample-JSON-LD-document.yml
@@ -1,0 +1,9 @@
+Example 002: Sample JSON-LD document
+---
+"@context":
+  name: http://xmlns.com/foaf/0.1/name
+  knows: http://xmlns.com/foaf/0.1/knows
+"@id": http://me.markus-lanthaler.com/
+name: Markus Lanthaler
+knows:
+- name: Dave Longley

--- a/yaml/example-003-JSON-LD-documenet-using-only-terms.yml
+++ b/yaml/example-003-JSON-LD-documenet-using-only-terms.yml
@@ -1,0 +1,10 @@
+Example 003: JSON-LD documenet using only terms
+---
+"@context":
+  name: http://xmlns.com/foaf/0.1/name
+  homepage:
+    "@id": http://xmlns.com/foaf/0.1/homepage
+    "@type": "@id"
+"@id": http://me.markus-lanthaler.com/
+name: Markus Lanthaler
+homepage: http://www.markus-lanthaler.com/

--- a/yaml/example-003-JSON-LD-document-using-only-terms-expanded-.yml
+++ b/yaml/example-003-JSON-LD-document-using-only-terms-expanded-.yml
@@ -1,0 +1,7 @@
+Example 003: JSON-LD document using only terms (expanded)
+---
+- "@id": http://me.markus-lanthaler.com/
+  http://xmlns.com/foaf/0.1/homepage:
+  - "@id": http://www.markus-lanthaler.com/
+  http://xmlns.com/foaf/0.1/name:
+  - "@value": Markus Lanthaler

--- a/yaml/example-004-Sample-JSON-LD-document-using-an-IRI-instead-of-a-term-to-express-a-property.yml
+++ b/yaml/example-004-Sample-JSON-LD-document-using-an-IRI-instead-of-a-term-to-express-a-property.yml
@@ -1,0 +1,8 @@
+Example 004: Sample JSON-LD document using an IRI instead of a term to express a property
+---
+"@context":
+  website: http://xmlns.com/foaf/0.1/homepage
+"@id": http://me.markus-lanthaler.com/
+http://xmlns.com/foaf/0.1/name: Markus Lanthaler
+website:
+  "@id": http://www.markus-lanthaler.com/

--- a/yaml/example-005-Expanded-JSON-LD-document-using-an-IRI.yml
+++ b/yaml/example-005-Expanded-JSON-LD-document-using-an-IRI.yml
@@ -1,0 +1,7 @@
+Example 005: Expanded JSON-LD document using an IRI
+---
+- "@id": http://me.markus-lanthaler.com/
+  http://xmlns.com/foaf/0.1/name:
+  - "@value": Markus Lanthaler
+  http://xmlns.com/foaf/0.1/homepage:
+  - "@id": http://www.markus-lanthaler.com/

--- a/yaml/example-006-Expanded-sample-document.yml
+++ b/yaml/example-006-Expanded-sample-document.yml
@@ -1,0 +1,7 @@
+Example 006: Expanded sample document
+---
+- "@id": http://me.markus-lanthaler.com/
+  http://xmlns.com/foaf/0.1/name:
+  - "@value": Markus Lanthaler
+  http://xmlns.com/foaf/0.1/homepage:
+  - "@id": http://www.markus-lanthaler.com/

--- a/yaml/example-007-JSON-LD-context.yml
+++ b/yaml/example-007-JSON-LD-context.yml
@@ -1,0 +1,7 @@
+Example 007: JSON-LD context
+---
+"@context":
+  name: http://xmlns.com/foaf/0.1/name
+  homepage:
+    "@id": http://xmlns.com/foaf/0.1/homepage
+    "@type": "@id"

--- a/yaml/example-008-Compacted-sample-document.yml
+++ b/yaml/example-008-Compacted-sample-document.yml
@@ -1,0 +1,10 @@
+Example 008: Compacted sample document
+---
+"@context":
+  name: http://xmlns.com/foaf/0.1/name
+  homepage:
+    "@id": http://xmlns.com/foaf/0.1/homepage
+    "@type": "@id"
+"@id": http://me.markus-lanthaler.com/
+name: Markus Lanthaler
+homepage: http://www.markus-lanthaler.com/

--- a/yaml/example-009-JSON-LD-document-in-compact-form.yml
+++ b/yaml/example-009-JSON-LD-document-in-compact-form.yml
@@ -1,0 +1,9 @@
+Example 009: JSON-LD document in compact form
+---
+"@context":
+  name: http://xmlns.com/foaf/0.1/name
+  knows: http://xmlns.com/foaf/0.1/knows
+"@id": http://me.markus-lanthaler.com/
+name: Markus Lanthaler
+knows:
+- name: Dave Longley

--- a/yaml/example-010-Flattened-sample-document-in-expanded-form.yml
+++ b/yaml/example-010-Flattened-sample-document-in-expanded-form.yml
@@ -1,0 +1,10 @@
+Example 010: Flattened sample document in expanded form
+---
+- "@id": _:b0
+  http://xmlns.com/foaf/0.1/name:
+  - "@value": Dave Longley
+- "@id": http://me.markus-lanthaler.com/
+  http://xmlns.com/foaf/0.1/name:
+  - "@value": Markus Lanthaler
+  http://xmlns.com/foaf/0.1/knows:
+  - "@id": _:b0

--- a/yaml/example-011-Flattened-and-compacted-sample-document.yml
+++ b/yaml/example-011-Flattened-and-compacted-sample-document.yml
@@ -1,0 +1,12 @@
+Example 011: Flattened and compacted sample document
+---
+"@context":
+  name: http://xmlns.com/foaf/0.1/name
+  knows: http://xmlns.com/foaf/0.1/knows
+"@graph":
+- "@id": _:b0
+  name: Dave Longley
+- "@id": http://me.markus-lanthaler.com/
+  name: Markus Lanthaler
+  knows:
+    "@id": _:b0

--- a/yaml/example-013-Sample-Turtle-document-converted-to-JSON-LD.yml
+++ b/yaml/example-013-Sample-Turtle-document-converted-to-JSON-LD.yml
@@ -1,0 +1,7 @@
+Example 013: Sample Turtle document converted to JSON-LD
+---
+- "@id": http://me.markus-lanthaler.com/
+  http://xmlns.com/foaf/0.1/name:
+  - "@value": Markus Lanthaler
+  http://xmlns.com/foaf/0.1/homepage:
+  - "@id": http://www.markus-lanthaler.com/

--- a/yaml/example-014-Term-definition-with-language-map.yml
+++ b/yaml/example-014-Term-definition-with-language-map.yml
@@ -1,0 +1,6 @@
+Example 014: Term definition with language map
+---
+"@context":
+  t:
+    "@id": http://example.org/t
+    "@container": "@language"

--- a/yaml/example-016-Term-definition-with-datatype.yml
+++ b/yaml/example-016-Term-definition-with-datatype.yml
@@ -1,0 +1,6 @@
+Example 016: Term definition with datatype
+---
+"@context":
+  t:
+    "@id": http://example.org/t
+    "@type": http:/example.org/type


### PR DESCRIPTION
This update makes use of improved features in extract-examples.rb to process all files, rather than simply doing syntactic validation, and to compare with expected results. Expected results have `@data-result-for` referencing the title of the source example. Expected results can also be in `script` elements, which don't show up in the rendered documentation.

The extract-examples script was also updated to extract JSON, as well as generate Turtle/TriG and YAML for most examples; these are updated using `rake examples`.

Eventually, multiple formats will be associated with each example, so the identification mechanism may change.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/23.html" title="Last updated on Aug 19, 2018, 12:51 AM GMT (2adb98e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/23/e054cd4...2adb98e.html" title="Last updated on Aug 19, 2018, 12:51 AM GMT (2adb98e)">Diff</a>