### PR TITLE
Update IRI Expansion to not return values including a : that are not absolute IRIs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1514,7 +1514,8 @@
               for <var>prefix</var>, return the result of concatenating
               the <a>IRI mapping</a> associated with <var>prefix</var> and
               <var>suffix</var>.</li>
-            <li>Return <var>value</var> as it is already an <a>absolute IRI</a>.</li>
+            <li><span class="changed">If <var>value</var> as the form of an <a>absolute IRI</a></span>,
+              return <var>value</var>.</li>
           </ol>
         </li>
         <li>If <var>vocab</var> is <code>true</code>, and
@@ -5510,6 +5511,11 @@
       to ensure that <code>@type</code> members are always represented as an array. This
       also allows a term to be defined for <code>@type</code>, where the value MUST be a <a>dictionary</a>
       with <code>@container</code> set to <code>@set</code>.</li>
+    <li>Updated the <a href="#iri-expansion">IRI Expansion algorithm</a> so that
+      if <var>value</var> contains a colon (<code>:</code>), but
+      <var>prefix</var> is not a <a>term</a>, to only return <var>value</var>
+      if it has the form of an <a>absolute IRI</a>, otherwise fall through to
+      the rest of the algorithm.</li>
   </ul>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -1514,7 +1514,7 @@
               for <var>prefix</var>, return the result of concatenating
               the <a>IRI mapping</a> associated with <var>prefix</var> and
               <var>suffix</var>.</li>
-            <li><span class="changed">If <var>value</var> as the form of an <a>absolute IRI</a></span>,
+            <li><span class="changed">If <var>value</var> has the form of an <a>absolute IRI</a></span>,
               return <var>value</var>.</li>
           </ol>
         </li>

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -803,6 +803,13 @@
       "expect": "expand/0108-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#t0109",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "IRI expansion of fragments including ':'",
+      "purpose": "Do not treat as absolute IRIs values that look like compact IRIs if they're not absolute",
+      "input": "expand/0109-in.jsonld",
+      "expect": "expand/0109-out.jsonld"
+    }, {
       "@id": "#tc001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "adding new term",

--- a/tests/expand/0109-in.jsonld
+++ b/tests/expand/0109-in.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@base": "https://ex.org/",
+    "u": {"@id": "urn:u:", "@type": "@id"}
+  },
+  "u": ["#Test", "#Test:2"]
+}

--- a/tests/expand/0109-out.jsonld
+++ b/tests/expand/0109-out.jsonld
@@ -1,0 +1,6 @@
+[{
+  "urn:u:": [
+    {"@id": "https://ex.org/#Test"},
+    {"@id": "https://ex.org/#Test:2"}
+  ]
+}]


### PR DESCRIPTION
but continue processing.

Fixes w3c/json-ld-syntax#66.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/42.html" title="Last updated on Oct 4, 2018, 8:05 PM GMT (2eb2a7f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/42/3ce32cb...2eb2a7f.html" title="Last updated on Oct 4, 2018, 8:05 PM GMT (2eb2a7f)">Diff</a>