### PR TITLE
Fix duplicate name in `tests/expand-manifest.jsonld`

### DIFF
--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -289,7 +289,6 @@
     }, {
       "@id": "#t0041",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "@language: null",
       "name": "@language: null resets the default language",
       "input": "expand/0041-in.jsonld",
       "expect": "expand/0041-out.jsonld"


### PR DESCRIPTION
The expand fixtures otherwise appear clean, but haven't tested the other test categories yet. This sort of thing currently fails in certain JSON parsers (serde in my case).