### PR TITLE
Simplify check when expanding array

### DIFF
--- a/index.html
+++ b/index.html
@@ -1655,9 +1655,9 @@
                   <var>active property</var>, <var>item</var> as <var>element</var>,
                   <span class="changed">the <a data-link-for="JsonLdOptions">frameExpansion</a>
                     and <a data-link-for="JsonLdOptions">ordered</a></span> flags.</li>
-                <li class="changed">If <var>active property</var>
-                  is <code>@list</code>, or its <a>container mapping</a> is set
-                  to <code>@list</code>, and <var>expanded item</var> is an
+                <li class="changed">If the <a>container mapping</a>
+                  of <var>active property</var> includes <code>@list</code>,
+                  and <var>expanded item</var> is an
                   <a>array</a>, set <var>expanded item</var> to a new
                   <a>dictionary</a> containing the <a>member</a>
                   <code>@list</code> where the value is the original


### PR DESCRIPTION
as _active property_ will never be `@list`, but it's _container mapping_ may include `@list`.

Fixes #47.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/48.html" title="Last updated on Oct 15, 2018, 6:24 PM GMT (08d5708)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/48/2e8b486...08d5708.html" title="Last updated on Oct 15, 2018, 6:24 PM GMT (08d5708)">Diff</a>