### PR TITLE
Mark blank node property labels as obsolete

### DIFF
--- a/common/algorithm-terms.html
+++ b/common/algorithm-terms.html
@@ -1,21 +1,17 @@
 <dl class="termlist" data-sort>
   <dt><dfn>active graph</dfn></dt><dd>
-    The name of the currently active graph that the processor should use when
-    processing.</dd>
+    The name of the currently active graph that the processor should use when processing.</dd>
   <dt><dfn>active object</dfn></dt><dd>
-    The currently active object that the processor should use when
-    processing.</dd>
+    The currently active object that the processor should use when processing.</dd>
   <dt><dfn>active property</dfn></dt><dd>
-    The currently active <a>property</a> or <a>keyword</a> that the processor
-    should use when processing. The <a>active property</a> is represented in
-    the original lexical form, which is used for finding coercion mappings in
-    the <a>active context</a>.</dd>
+    The currently active <a>property</a> or <a>keyword</a> that the processor should use when processing.
+    The <a>active property</a> is represented in the original lexical form,
+    which is used for finding coercion mappings in the <a>active context</a>.</dd>
   <dt><dfn>active subject</dfn></dt><dd>
-    The currently active subject that the processor should use when
-    processing.</dd>
+    The currently active subject that the processor should use when processing.</dd>
   <dt><dfn>explicit inclusion flag</dfn></dt><dd>
-    A flag specifying that for <a>properties</a> to be included in the output, they
-    MUST be explicitly declared in the matching <a>frame</a>.</dd>
+    A flag specifying that for <a>properties</a> to be included in the output,
+    they MUST be explicitly declared in the matching <a>frame</a>.</dd>
   <dt><dfn>framing state</dfn></dt><dd>
     A <a>dictionary</a> containing values for the
     <a>object embed flag</a>, the
@@ -35,24 +31,23 @@
     A flag specifying that <a>node objects</a> should be directly embedded in the output,
     instead of being referred to by their <a>IRI</a>.</dd>
   <dt><dfn>omit default flag</dfn></dt><dd>
-    A flag specifying that properties that are missing from the
-    <a>JSON-LD input</a>, but present in the <a>input frame</a>
+    A flag specifying that properties that are missing from the <a>JSON-LD input</a>,
+    but present in the <a>input frame</a>,
     should be omitted from the output.</dd>
   <dt class="changed"><dfn>omit graph flag</dfn></dt><dd class="changed">
-    A flag that determines if framing output is always contained within a
-    <code>@graph</code> member, or only if required to represent multiple <a>node objects</a>.</dd>
+    A flag that determines if framing output is always contained within a <code>@graph</code> member,
+    or only if required to represent multiple <a>node objects</a>.</dd>
   <dt><dfn>processor state</dfn></dt><dd>
-    The <a>processor state</a>, which includes the <a>active
-    context</a>, <a>active subject</a>, and
-    <a>active property</a>. The <a>processor state</a> is managed
-    as a stack with elements from the previous <a>processor state</a>
-    copied into a new <a>processor state</a> when entering a new
-    <a>JSON object</a>.</dd>
+    The <a>processor state</a>,
+    which includes the <a>active context</a>, <a>active subject</a>, and <a>active property</a>.
+    The <a>processor state</a> is managed as a stack with elements from the previous <a>processor state</a>
+    copied into a new <a>processor state</a> when entering a new <a>JSON object</a>.</dd>
   <dt><dfn>promise</dfn></dt><dd>
     A <a data-cite="ECMASCRIPT#sec-promise-objects" class="externalDFN">promise</a> is an object that represents the eventual result of a single asynchronous operation.
     Promises are defined in [[ECMASCRIPT]].</dd>
   <dt><dfn>require all flag</dfn></dt><dd>
     A flag specifying that all properties present in the <a>input frame</a>
-    MUST either have a default value or be present in the <a>JSON-LD
-    input</a> for the frame to match.</dd>
+    MUST either have a default value
+    or be present in the <a>JSON-LD input</a>
+    for the frame to match.</dd>
 </dl>

--- a/common/terms.html
+++ b/common/terms.html
@@ -1,142 +1,160 @@
 <dl class="termlist" data-sort>
   <dt><dfn>array</dfn></dt><dd>
-    In the JSON serialization, an array structure is represented as square brackets surrounding zero
-    or more values. Values are separated by commas.
-    In the <a>internal representation</a>, an array is an <em>ordered</em> collection of zero or more values.
+    In the JSON serialization,
+    an array structure is represented as square brackets surrounding zero or more values.
+    Values are separated by commas.
+    In the <a>internal representation</a>,
+    an array is an <em>ordered</em> collection of zero or more values.
     While JSON-LD uses the same array representation as JSON,
-    the collection is <em>unordered</em> by default. While order is
-    preserved in regular JSON arrays, it is not in regular JSON-LD arrays
-    unless specifically defined (see
-    <a data-cite="JSON-LD11#sets-and-lists" class="externalDFN">Sets and Lists</a> in
-    the JSON-LD Syntax specification [[JSON-LD11]]).</dd>
+    the collection is <em>unordered</em> by default.
+    While order is preserved in regular JSON arrays,
+    it is not in regular JSON-LD arrays unless specifically defined
+    (see <a data-cite="JSON-LD11#sets-and-lists" class="externalDFN">Sets and Lists</a>
+    in the JSON-LD Syntax specification [[JSON-LD11]]).</dd>
   <dt><dfn>JSON object</dfn></dt><dd>
-    In the JSON serialization, an <a data-cite="RFC8259#section-4" class="externalDFN">object</a> structure is represented as a pair of curly brackets surrounding zero or
-    more members composed of name-value pairs. A name is a <a>string</a>. A single colon comes after
-    each name, separating the name from the value. A single comma separates a value
-    from a following name. In JSON-LD the names in an object MUST be unique.
+    In the JSON serialization,
+    an <a data-cite="RFC8259#section-4" class="externalDFN">object</a> structure
+    is represented as a pair of curly brackets surrounding zero or more members
+    composed of name-value pairs.
+    A name is a <a>string</a>.
+    A single colon comes after each name,
+    separating the name from the value.
+    A single comma separates a value from a following name.
+    In JSON-LD the names in an object MUST be unique.
     In the <a>internal representation</a> a <a>JSON object</a> is equivalent to a
     <dfn data-cite="WEBIDL#dfn-dictionary" class="preserve">dictionary</dfn> (see [[WEBIDL]]),
     composed of <dfn data-cite="WEBIDL#dfn-dictionary-member" data-lt="dictionary member|member" class="preserve">dictionary members</dfn> with key-value pairs.</dd>
-  <dt class="changed"><dfn data-lt="internal representation">JSON-LD internal representation</dfn></dt><dd class="changed">The JSON-LD
-    internal representation is the result of transforming a JSON syntactic structure
+  <dt class="changed"><dfn data-lt="internal representation">JSON-LD internal representation</dfn></dt><dd class="changed">
+    The JSON-LD internal representation
+    is the result of transforming a JSON syntactic structure
     into the core data structures suitable for direct processing:
-    <a>arrays</a>, <a>dictionaries</a>,
-    <a>strings</a>, <a>numbers</a>, <a>booleans</a>, and <a>null</a>.</dd>
+    <a>arrays</a>, <a>dictionaries</a>, <a>strings</a>, <a>numbers</a>, <a>booleans</a>, and <a>null</a>.</dd>
   <dt><dfn>null</dfn></dt><dd>
-    The use of the <a data-cite="RFC8259#section-3" class="externalDFN">null</a> value within JSON-LD is used to
-    ignore or reset values. A <a>dictionary member</a> in the <code>@context</code> where
-    the value, or the <code>@id</code> of the value, is <code>null</code>
-    explicitly decouples a term's association with an IRI. A <a>dictionary member</a> in
-    the body of a <a>JSON-LD document</a> whose value is <code>null</code> has the
-    same meaning as if the <a>dictionary member</a> was not defined. If
-    <code>@value</code>, <code>@list</code>, or <code>@set</code> is set to
-    <code>null</code> in expanded form, then the entire <a>JSON
-    object</a> is ignored.</dd>
+    The use of the <a data-cite="RFC8259#section-3" class="externalDFN">null</a> value within JSON-LD
+    is used to ignore or reset values.
+    A <a>dictionary member</a> in the <code>@context</code> where the value,
+    or the <code>@id</code> of the value, is <code>null</code>,
+    explicitly decouples a term's association with an IRI.
+    A <a>dictionary member</a> in the body of a <a>JSON-LD document</a>
+    whose value is <code>null</code>
+    has the same meaning as if the <a>dictionary member</a> was not defined.
+    If <code>@value</code>, <code>@list</code>, or <code>@set</code> is set to <code>null</code> in expanded form,
+    then the entire <a>JSON object</a> is ignored.</dd>
   <dt><dfn data-lt="number|JSON number">number</dfn></dt><dd>
-    In the JSON serialization, a <a data-cite="RFC8259#section-6" class="externalDFN">number</a> is similar to that used in most programming languages, except
-    that the octal and hexadecimal formats are not used and that leading
-    zeros are not allowed.
-    In the <a>internal representation</a>, a <a>number</a> is equivalent to either
-    a <dfn data-cite="WEBIDL#idl-long" class="preserve">long</dfn>
-    or <dfn data-cite="WEBIDL#idl-double" class="preserve">double</dfn>, depending
-    on if the number has a non-zero fractional part (see [[WEBIDL]]).</dd>
+    In the JSON serialization, a <a data-cite="RFC8259#section-6" class="externalDFN">number</a>
+    is similar to that used in most programming languages,
+    except that the octal and hexadecimal formats are not used and that leading zeros are not allowed.
+    In the <a>internal representation</a>,
+    a <a>number</a> is equivalent to either a <dfn data-cite="WEBIDL#idl-long" class="preserve">long</dfn>
+    or <dfn data-cite="WEBIDL#idl-double" class="preserve">double</dfn>,
+    depending on if the number has a non-zero fractional part (see [[WEBIDL]]).</dd>
   <dt><dfn>scalar</dfn></dt><dd>
-    A scalar is either a JSON <a>string</a>, <a>number</a>, <a>true</a>,
-    or <a>false</a>.</dd>
+    A scalar is either a JSON <a>string</a>, <a>number</a>, <a>true</a>, or <a>false</a>.</dd>
   <dt><dfn>string</dfn></dt><dd>
-    A <a data-cite="RFC8259#section-7" class="externalDFN">string</a> is a sequence of zero or more Unicode (UTF-8) characters,
-    wrapped in double quotes, using backslash escapes (if necessary). A
-    character is represented as a single character string.</dd>
+    A <a data-cite="RFC8259#section-7" class="externalDFN">string</a>
+    is a sequence of zero or more Unicode (UTF-8) characters,
+    wrapped in double quotes, using backslash escapes (if necessary).
+    A character is represented as a single character string.</dd>
   <dt><dfn>true</dfn> and <dfn>false</dfn></dt><dd>
-    <a data-cite="RFC8259#section-3" class="externalDFN">Values</a> that are used to express one of two possible
-    <dfn data-cite="WEBIDL#idl-boolean" class="preserve">boolean</dfn> states.</dd>
+    <a data-cite="RFC8259#section-3" class="externalDFN">Values</a> that are used
+    to express one of two possible <dfn data-cite="WEBIDL#idl-boolean" class="preserve">boolean</dfn> states.</dd>
 </dl>
 
 <p>Furthermore, the following terminology is used throughout this document:</p>
 
 <dl class="termlist" data-sort>
   <dt><dfn>absolute IRI</dfn></dt><dd>
-    An <a data-cite="RFC3987#section-1.3" class="externalDFN">absolute IRI</a> is defined in [[RFC3987]] containing a <em>scheme</em> along with a <em>path</em> and
-    optional <em>query</em> and fragment segments.</dd>
+    An <a data-cite="RFC3987#section-1.3" class="externalDFN">absolute IRI</a>
+    is defined in [[RFC3987]] containing a <em>scheme</em> along with a <em>path</em>
+    and optional <em>query</em> and fragment segments.</dd>
   <dt><dfn>active context</dfn></dt><dd>
-    A <a>context</a> that is used to resolve <a>terms</a> while the processing
-    algorithm is running.</dd>
+    A <a>context</a> that is used to resolve <a>terms</a>
+    while the processing algorithm is running.</dd>
   <dt><dfn>base IRI</dfn></dt><dd>
     The <a>base IRI</a> is an <a>absolute IRI</a> established in the <a>context</a>,
-    or is based on the <a>JSON-LD document</a> location. The <a>base IRI</a> is used to turn
-    <a>relative IRIs</a> into <a>absolute IRIs</a>.</dd>
+    or is based on the <a>JSON-LD document</a> location.
+    The <a>base IRI</a> is used to turn <a>relative IRIs</a> into <a>absolute IRIs</a>.</dd>
   <dt><dfn>blank node</dfn></dt><dd>
-    A <a>node</a> in a <a>graph</a> that is neither an
-    <a>IRI</a>, nor a <a>JSON-LD value</a>, nor a <a>list</a>.
-    A <a data-cite="RDF11-CONCEPTS#dfn-blank-node" class="externalDFN">blank node</a> does not contain a de-referenceable
-    identifier because it is either ephemeral in nature or does not contain information that needs to be
-    linked to from outside of the <a>linked data graph</a>. A blank node is assigned an identifier starting with
-    the prefix <code>_:</code>.</dd>
+    A <a>node</a> in a <a>graph</a> that is neither an <a>IRI</a>,
+    nor a <a>JSON-LD value</a>, nor a <a>list</a>.
+    A <a data-cite="RDF11-CONCEPTS#dfn-blank-node" class="externalDFN">blank node</a> does not contain
+    a de-referenceable identifier because it is either ephemeral in nature
+    or does not contain information that needs to be linked to from outside of the <a>linked data graph</a>.
+    A blank node is assigned an identifier starting with the prefix <code>_:</code>.</dd>
   <dt><dfn>blank node identifier</dfn></dt><dd>
-    A <a data-cite="RDF11-CONCEPTS#dfn-blank-node-identifier" class="externalDFN">blank node identifier</a> is a string that can be used as an identifier for a
-    <a>blank node</a> within the scope of a JSON-LD document. Blank node identifiers
-    begin with <code>_:</code>.</dd>
+    A <a data-cite="RDF11-CONCEPTS#dfn-blank-node-identifier" class="externalDFN">blank node identifier</a>
+    is a string that can be used as an identifier for a <a>blank node</a> within the scope of a JSON-LD document.
+    Blank node identifiers begin with <code>_:</code>.</dd>
   <dt><dfn>compact IRI</dfn></dt><dd>
-    A compact IRI is has the form of <a>prefix</a>:<em>suffix</em> and is used as a way
-    of expressing an <a>IRI</a> without needing to define separate <a>term</a> definitions for
-    each IRI contained within a common vocabulary identified by <a>prefix</a>.</dd>
+    A compact IRI is has the form of <a>prefix</a>:<em>suffix</em>
+    and is used as a way of expressing an <a>IRI</a> without needing to define separate <a>term</a> definitions
+    for each IRI contained within a common vocabulary identified by <a>prefix</a>.</dd>
   <dt><dfn>context</dfn></dt><dd>
-    A set of rules for interpreting a <a>JSON-LD document</a> as specified in
-    <a data-cite="JSON-LD11#the-context">The Context</a> of the JSON-LD Syntax specification [[JSON-LD11]].</dd>
+    A set of rules for interpreting a <a>JSON-LD document</a>
+    as specified in <a data-cite="JSON-LD11#the-context">The Context</a> of the JSON-LD Syntax specification [[JSON-LD11]].</dd>
   <dt><dfn>datatype IRI</dfn></dt><dd>
     A <a data-cite="RDF11-CONCEPTS#dfn-datatype-iri" class="externalDFN">datatype IRI</a>
     as specified by [[RDF11-CONCEPTS]].</dd>
   <dt><dfn>default graph</dfn></dt><dd>
-    The <a data-cite="RDF11-CONCEPTS#dfn-default-graph" class="externalDFN">default graph</a> is the only graph in a JSON-LD document which has no <a>graph name</a>.
-    When executing an algorithm, the graph where data should be placed
-    if a <a>named graph</a> is not specified.</dd>
+    The <a data-cite="RDF11-CONCEPTS#dfn-default-graph" class="externalDFN">default graph</a>
+    is the only graph in a JSON-LD document which has no <a>graph name</a>.
+    When executing an algorithm,
+    the graph where data should be placed if a <a>named graph</a> is not specified.</dd>
   <dt><dfn>default language</dfn></dt><dd>
-    The default language is set in the <a>context</a> using the <code>@language</code> key whose
-    value MUST be a <a>string</a> representing a [[BCP47]] language code or <code>null</code>.</dd>
+    The default language is set in the <a>context</a> using the <code>@language</code> key
+    whose value MUST be a <a>string</a> representing a [[BCP47]] language code or <code>null</code>.</dd>
   <dt><dfn>default object</dfn></dt><dd>
     A <a>default object</a> is a <a>dictionary</a> that has a <code>@default</code> key.</dd>
   <dt><dfn>edge</dfn></dt><dd>
-    Every <a>edge</a> has a direction associated with it and is labeled with
-    an <a>IRI</a> or a <a>blank node identifier</a>. Within the JSON-LD syntax
-    these edge labels are called <a>properties</a>. Whenever possible, an
-    <a>edge</a> should be labeled with an <a>IRI</a>.</dd>
+    Every <a>edge</a> has a direction associated with it
+    and is labeled with an <a>IRI</a> or a <a>blank node identifier</a>.
+    Within the JSON-LD syntax these edge labels are called <a>properties</a>.
+    Whenever possible, an <a>edge</a> should be labeled with an <a>IRI</a>.
+    <div class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
+      and may be removed in a future version of JSON-LD.</div></dd>
   <dt><dfn>expanded term definition</dfn></dt><dd>
-    An expanded term definition, is a <a>term definition</a> where the value is a <a>dictionary</a>
+    An expanded term definition is a <a>term definition</a>
+    where the value is a <a>dictionary</a>
     containing one or more <a>keyword</a> keys to define the associated <a>absolute IRI</a>,
-    if this is a reverse property, the type associated with string values, and a container mapping.</dd>
+    if this is a reverse property,
+    the type associated with string values, and a container mapping.</dd>
   <dt><dfn data-lt="frame|JSON-LD frame">frame</dfn></dt><dd>
-    A <a>JSON-LD document</a>, which describes the form for transforming
-    another <a>JSON-LD document</a> using matching and embedding rules.
+    A <a>JSON-LD document</a>,
+    which describes the form for transforming another <a>JSON-LD document</a>
+    using matching and embedding rules.
     A frame document allows additional keywords and certain <a>dictionary members</a>
     to describe the matching and transforming process.</dd>
   <dt><dfn data-lt="json-ld processor|Processors">JSON-LD Processor</dfn></dt><dd>
     A <a>JSON-LD Processor</a> is a system which can perform the algorithms defined in [[JSON-LD11-API]].</dd>
   <dt><dfn>frame object</dfn></dt><dd>
     A frame object is a <a>dictionary</a> element within a <a>frame</a>
-    which represents a specific portion of the <a>frame</a> matching either a
-    <a>node object</a> or a <a>value object</a> in the input.</dd>
+    which represents a specific portion of the <a>frame</a> matching either
+    a <a>node object</a> or a <a>value object</a>
+    in the input.</dd>
   <dt><dfn>graph name</dfn></dt><dd>
     The <a>IRI</a> identifying a <a data-cite="RDF11-CONCEPTS#dfn-graph-name" class="externalDFN">named graph</a>.</dd>
   <dt class="changed"><dfn>id map</dfn></dt><dd class="changed">
-    An <a>id map</a> is a <a>dictionary</a> value of a <a>term</a> defined with
-    <code>@container</code> set to <code>@id</code>, whose keys are
-    interpreted as <a>IRIs</a> representing the <code>@id</code>
-    of the associated <a>node object</a>; value MUST be a <a>node object</a>.
-    If the value contains a key expanding to <code>@id</code>, it's value MUST
-    be equivalent to the referencing key.</dd>
+    An <a>id map</a> is a <a>dictionary</a> value of a <a>term</a>
+    defined with <code>@container</code> set to <code>@id</code>,
+    whose keys are interpreted as <a>IRIs</a> representing
+    the <code>@id</code> of the associated <a>node object</a>;
+    value MUST be a <a>node object</a>.
+    If the value contains a key expanding to <code>@id</code>,
+    it's value MUST be equivalent to the referencing key.</dd>
   <dt class="changed"><dfn>graph object</dfn></dt><dd class="changed">
-    A <a>graph object</a> represents a <a>named graph</a> represented as the
-    value of a <a>dictionary member</a> within a <a>node object</a>. When expanded, a
-    graph object MUST have an <code>@graph</code> <a>member</a>, and may also have
-    <code>@id</code>, and <code>@index</code> <a>members</a>.
-    A <dfn class="preserve">simple graph object</dfn> is a
-    <a>graph object</a> which does not have an <code>@id</code> <a>member</a>. Note
-    that <a>node objects</a> may have a <code>@graph</code> member, but are
-    not considered <a>graph objects</a> if they include any other <a>members</a>.
+    A <a>graph object</a> represents a <a>named graph</a>
+    represented as the value of a <a>dictionary member</a> within a <a>node object</a>.
+    When expanded, a graph object MUST have an <code>@graph</code> <a>member</a>,
+    and MAY also have <code>@id</code>, and <code>@index</code> <a>members</a>.
+    A <dfn class="preserve">simple graph object</dfn>
+    is a <a>graph object</a> which does not have an <code>@id</code> <a>member</a>.
+    Note that <a>node objects</a> may have a <code>@graph</code> member,
+    but are not considered <a>graph objects</a> if they include any other <a>members</a>.
     A top-level object consisting of <code>@graph</code> is also not a <a>graph object</a>.</dd>
- <dt><dfn>index map</dfn></dt><dd>
-  An <a>index map</a> is a <a>dictionary</a> value of a <a>term</a> defined with
-  <code>@container</code> set to <code>@index</code>, whose values MUST be any of the following types:
+  <dt><dfn>index map</dfn></dt><dd>
+    An <a>index map</a> is a <a>dictionary</a> value of a <a>term</a>
+    defined with <code>@container</code> set to <code>@index</code>,
+    whose values MUST be any of the following types:
     <a>string</a>,
     <a>number</a>,
     <a>true</a>,
@@ -149,149 +167,173 @@
     an <a>array</a> of zero or more of the above possibilities.
   </dd>
   <dt><dfn data-lt="IRI|Internationalized Resource Identifier"><abbr title="Internationalized Resource Identifier">IRI</abbr></dfn></dt><dd>
-    An <a data-cite="RFC3987#section-1.3" class="externalDFN">Internationalized Resource Identifier</a> as described in [[RFC3987]].</dd>
+    An <a data-cite="RFC3987#section-1.3" class="externalDFN">Internationalized Resource Identifier</a>
+    as described in [[RFC3987]].</dd>
   <dt><dfn>JSON-LD document</dfn></dt><dd>
-    A <a>JSON-LD document</a> is a serialization of a collection of
-    <a>graphs</a> and comprises exactly one
-    <a>default graph</a> and zero or more <a>named graphs</a>.</dd>
+    A <a>JSON-LD document</a> is a serialization of
+    a collection of <a>graphs</a>
+    and comprises exactly one <a>default graph</a> and zero or more <a>named graphs</a>.</dd>
   <dt><dfn>JSON-LD value</dfn></dt><dd>
-    A <a>JSON-LD value</a> is a <a>string</a>, a <a>number</a>,
-    <a>true</a> or <a>false</a>, a <a>typed value</a>, or a
-    <a>language-tagged string</a>.</dd>
+    A <a>JSON-LD value</a> is a <a>string</a>,
+    a <a>number</a>,
+    <a>true</a> or <a>false</a>,
+    a <a>typed value</a>,
+    or a <a>language-tagged string</a>.
+  </dd>
   <dt><dfn>keyword</dfn></dt><dd>
-    A <a>string</a> that is specific to JSON-LD, specified in the JSON-LD Syntax specification [[JSON-LD11]]
+    A <a>string</a> that is specific to JSON-LD,
+    specified in the JSON-LD Syntax specification [[JSON-LD11]]
     in the section titled <a data-cite="JSON-LD11#syntax-tokens-and-keywords">Syntax Tokens and Keywords</a>.</dd>
   <dt><dfn>language map</dfn></dt><dd>
-    An <a>language map</a> is a <a>dictionary</a> value of a <a>term</a> defined with
-    <code>@container</code> set to <code>@language</code>, whose keys MUST be <a>strings</a> representing
-    [[BCP47]] language codes and the values MUST be any of the following types:
-      <a>null</a>,
-      <a>string</a>, or
-      an <a>array</a> of zero or more of the above possibilities.
-    </dd>
+    An <a>language map</a> is a <a>dictionary</a> value of a <a>term</a>
+    defined with <code>@container</code> set to <code>@language</code>,
+    whose keys MUST be <a>strings</a> representing [[BCP47]] language codes
+    and the values MUST be any of the following types:
+    <a>null</a>,
+    <a>string</a>, or
+    an <a>array</a> of zero or more of the above possibilities.
+  </dd>
   <dt><dfn>language-tagged string</dfn></dt><dd>
-    A <a data-cite="RDF11-CONCEPTS#dfn-language-tagged-string" class="externalDFN">language-tagged string</a> consists of a string and a non-empty language
-    tag as defined by [[BCP47]]. The <dfn>language tag</dfn> MUST be well-formed according to
-    <a data-cite="BCP47#section-2.2.9">section 2.2.9 Classes of Conformance</a>
-    of [[BCP47]], and is normalized to lowercase.</dd>
+    A <a data-cite="RDF11-CONCEPTS#dfn-language-tagged-string" class="externalDFN">language-tagged string</a>
+    consists of a string and a non-empty language tag
+    as defined by [[BCP47]].
+    The <dfn>language tag</dfn> MUST be well-formed
+    according to <a data-cite="BCP47#section-2.2.9">section 2.2.9 Classes of Conformance</a> of [[BCP47]],
+    and is normalized to lowercase.</dd>
   <dt><dfn>Linked Data</dfn></dt><dd>
     A set of documents, each containing a representation of a <a>linked data graph</a>.</dd>
   <dt><dfn data-lt="graph">linked data graph</dfn></dt><dd>
-    A labeled directed <a data-cite="RDF11-CONCEPTS#dfn-rdf-graph" class="externalDFN">graph</a>, i.e., a set of <a>nodes</a>
-    connected by <a>edges</a>,
-    as specified in the <a data-cite="JSON-LD11#data-model">Data Model</a>
-    section of the JSON-LD specification [[JSON-LD11]].
-    A <a>linked data graph</a> is a generalized representation of an
-    <dfn class="preserve" data-cite="RDF11-CONCEPTS#dfn-rdf-graph">RDF graph</dfn>
+    A labeled directed <a data-cite="RDF11-CONCEPTS#dfn-rdf-graph" class="externalDFN">graph</a>,
+    i.e., a set of <a>nodes</a> connected by <a>edges</a>,
+    as specified in the <a data-cite="JSON-LD11#data-model">Data Model</a> section of the JSON-LD specification [[JSON-LD11]].
+    A <a>linked data graph</a> is a generalized representation of an <dfn class="preserve" data-cite="RDF11-CONCEPTS#dfn-rdf-graph">RDF graph</dfn>
     as defined in [[RDF11-CONCEPTS]].</dd>
   <dt><dfn>list</dfn></dt><dd>
-    A <a>list</a> is an ordered sequence of <a>IRIs</a>,
-    <a>blank nodes</a>, and <a>JSON-LD values</a>.
-    See <dfn data-cite="RDF-SCHEMA#ch_collectionvocab" data-lt="collection" class="preserve">RDF collection</dfn>
-    in [[RDF-SCHEMA]].</dd>
+    A <a>list</a> is an ordered sequence of <a>IRIs</a>, <a>blank nodes</a>, and <a>JSON-LD values</a>.
+    See <dfn data-cite="RDF-SCHEMA#ch_collectionvocab" data-lt="collection" class="preserve">RDF collection</dfn> in [[RDF-SCHEMA]].</dd>
   <dt><dfn>list object</dfn></dt><dd>
-    A <a>list object</a> is a <a>dictionary</a> that has a <code>@list</code>
-    key.</dd>
+    A <a>list object</a> is a <a>dictionary</a> that has a <code>@list</code> key.</dd>
   <dt><dfn>literal</dfn></dt><dd>
     An <a>object</a> expressed as a value such as a string, number or in expanded form.</dd>
   <dt><dfn>local context</dfn></dt><dd>
     A <a>context</a> that is specified with a <a>dictionary</a>,
     specified via the <code>@context</code> <a>keyword</a>.</dd>
   <dt><dfn>named graph</dfn></dt><dd>
-    A <a data-cite="RDF11-CONCEPTS#dfn-named-graph" class="externalDFN">named graph</a> is a <a>linked data graph</a> that is identified by an <a>IRI</a> or <a>blank node</a>.</dd>
+    A <a data-cite="RDF11-CONCEPTS#dfn-named-graph" class="externalDFN">named graph</a>
+    is a <a>linked data graph</a> that is identified by an <a>IRI</a> or <a>blank node</a>.</dd>
   <dt><dfn>implicitly named graph</dfn></dt><dd>
-    A <a>named graph</a> created from the value of a <a>dictionary member</a> having an
-    <a>expanded term definition</a> where <code>@container</code> is set to  <code>@graph</code>.</dd>
+    A <a>named graph</a> created from the value of a <a>dictionary member</a>
+    having an <a>expanded term definition</a>
+    where <code>@container</code> is set to  <code>@graph</code>.</dd>
   <dt><dfn>nested property</dfn></dt><dd>
-    A <a>nested property</a> is a key in a <a>node object</a> whose value is a
-    <a>dictionary</a> containing <a>members</a> which are treated as if they were values of the <a>node object</a>.
-    The <a>nested property</a> itself is semantically meaningless used only to create a sub-structure within
-    a <a>node object</a>.
+    A <a>nested property</a> is a key in a <a>node object</a>
+    whose value is a <a>dictionary</a> containing <a>members</a> which are treated as if they were values of the <a>node object</a>.
+    The <a>nested property</a> itself is semantically meaningless used only to create a sub-structure within a <a>node object</a>.
   </dd>
   <dt><dfn>node</dfn></dt><dd>
-    Every <a data-cite="RDF11-CONCEPTS#dfn-node" class="externalDFN">node</a> is an <a>IRI</a>, a <a>blank node</a>,
-    a <a>JSON-LD value</a>, or a <a>list</a>.
+    Every <a data-cite="RDF11-CONCEPTS#dfn-node" class="externalDFN">node</a> is an <a>IRI</a>,
+    a <a>blank node</a>,
+    a <a>JSON-LD value</a>,
+    or a <a>list</a>.
     A piece of information that is represented in a <a>linked data graph</a>.</dd>
   <dt><dfn>node object</dfn></dt><dd>
-    A <a>node object</a> represents zero or more <a>properties</a> of a
-    <a>node</a> in the <a>graph</a> serialized by the
-    <a>JSON-LD document</a>. A <a>dictionary</a> is a <a>node object</a>
+    A <a>node object</a> represents zero or more <a>properties</a> of a <a>node</a> in the <a>graph</a>
+    serialized by the <a>JSON-LD document</a>.
+    A <a>dictionary</a> is a <a>node object</a>
     if it exists outside of the JSON-LD <a>context</a> and:
     <ul>
-      <li>it does not contain the <code>@value</code>, <code>@list</code>,
-        or <code>@set</code> keywords, or</li>
-      <li>it is not the top-most <a>dictionary</a> in the JSON-LD document consisting
-        of no other <a>members</a> than <code>@graph</code> and <code>@context</code>.</li>
+      <li>it does not contain the <code>@value</code>, <code>@list</code>, or <code>@set</code> keywords, or</li>
+      <li>it is not the top-most <a>dictionary</a> in the JSON-LD document
+        consisting of no other <a>members</a> than <code>@graph</code> and <code>@context</code>.</li>
     </ul>
     The <a>members</a> of a <a>node object</a> whose keys are not keywords are also called <a>properties</a> of the <a>node object</a>.
   </dd>
   <dt><dfn>node reference</dfn></dt><dd>
-    A <a>node object</a> used to reference a node having only the
-    <code>@id</code> key.</dd>
+    A <a>node object</a> used to reference a node having only the <code>@id</code> key.</dd>
   <dt><dfn>object</dfn></dt><dd>
-    An <a data-cite="RDF11-CONCEPTS#dfn-object" class="externalDFN">object</a> is a <a>node</a> in a <a>linked data graph</a> with at least one incoming edge.
+    An <a data-cite="RDF11-CONCEPTS#dfn-object" class="externalDFN">object</a> is a <a>node</a> in a <a>linked data graph</a>
+    with at least one incoming edge.
     See <dfn data-cite="RDF11-CONCEPTS#dfn-object" class="preserve">RDF object</dfn> in [[RDF11-CONCEPTS]].</dd>
   <dt><dfn>prefix</dfn></dt><dd>
-    A <a>prefix</a> is the first component of a <a>compact IRI</a> which comes from a
-    <a>term</a> that maps to a string that, when prepended to the suffix of the <a>compact IRI</a>
+    A <a>prefix</a> is the first component of a <a>compact IRI</a>
+    which comes from a <a>term</a> that maps to a string that,
+    when prepended to the suffix of the <a>compact IRI</a>,
     results in an <a>absolute IRI</a>.</dd>
   <dt><dfn>processing mode</dfn></dt><dd>
     The processing mode defines how a JSON-LD document is processed.
-    By default, all documents are assumed to be conformant with
-    <a data-cite="JSON-LD">JSON-LD 1.0</a> [[JSON-LD]]. By defining
-    a different version using the <code>@version</code> <a>member</a> in a
-    <a>context</a>, or via explicit API option, other processing modes
-    can be accessed. This specification defines extensions for the
-    <code>json-ld-1.1</code> <a>processing mode</a>.</dd>
+    By default, all documents are assumed to be conformant with <a data-cite="JSON-LD">JSON-LD 1.0</a> [[JSON-LD]].
+    By defining a different version using the <code>@version</code> <a>member</a> in a <a>context</a>,
+    or via explicit API option,
+    other processing modes can be accessed.
+    This specification defines extensions for the <code>json-ld-1.1</code> <a>processing mode</a>.</dd>
   <dt><dfn>property</dfn></dt><dd>
     The <a>IRI</a> label of an edge in a <a>linked data graph</a>.
     See <dfn data-cite="RDF11-CONCEPTS#dfn-predicate" data-lt="predicate" class="preserve">RDF predicate</dfn> in [[RDF11-CONCEPTS]].</dd>
-    <dt><dfn>quad</dfn></dt><dd>
-    A piece of information that contains four items; a <a>subject</a>, a <a>property</a>,
-    an <a>object</a>, and a <a>graph name</a>.</dd>
+  <dt><dfn>quad</dfn></dt><dd>
+    A piece of information that contains four items;
+    a <a>subject</a>,
+    a <a>property</a>,
+    an <a>object</a>,
+    and a <a>graph name</a>.</dd>
   <dt><dfn data-lt="dataset">RDF dataset</dfn></dt><dd>
-    A <a data-cite="RDF11-CONCEPTS#dfn-rdf-dataset" class="externalDFN">dataset</a> as specified by [[RDF11-CONCEPTS]] representing a collection of
-    <a data-cite="RDF11-CONCEPTS#dfn-rdf-graph">RDF graphs</a>.</dd>
+    A <a data-cite="RDF11-CONCEPTS#dfn-rdf-dataset" class="externalDFN">dataset</a>
+    as specified by [[RDF11-CONCEPTS]]
+    representing a collection of <a data-cite="RDF11-CONCEPTS#dfn-rdf-graph">RDF graphs</a>.</dd>
   <dt><dfn data-lt="resource">RDF resource</dfn></dt><dd>
-    A <a data-cite="RDF11-CONCEPTS#dfn-resource" class="externalDFN">resource</a> as specified by [[RDF11-CONCEPTS]].</dd>
+    A <a data-cite="RDF11-CONCEPTS#dfn-resource" class="externalDFN">resource</a>
+    as specified by [[RDF11-CONCEPTS]].</dd>
   <dt><dfn data-lt="triple">RDF triple</dfn></dt><dd>
-    A <a data-cite="RDF11-CONCEPTS#dfn-rdf-triple" class="externalDFN">triple</a> as specified by [[RDF11-CONCEPTS]].</dd>
+    A <a data-cite="RDF11-CONCEPTS#dfn-rdf-triple" class="externalDFN">triple</a>
+    as specified by [[RDF11-CONCEPTS]].</dd>
   <dt><dfn>relative IRI</dfn></dt><dd>
     A relative IRI is an <a>IRI</a> that is relative to some other <a>absolute IRI</a>,
-    typically the <a>base IRI</a> of the document. Note that
-    <a>properties</a>, values of <code>@type</code>, and values of <a>terms</a> defined to be <em>vocabulary relative</em>
-    are resolved relative to the <a>vocabulary mapping</a>, not the <a>base IRI</a>.</dd>
+    typically the <a>base IRI</a> of the document.
+    Note that <a>properties</a>,
+    values of <code>@type</code>,
+    and values of <a>terms</a> defined to be <em>vocabulary relative</em>
+    are resolved relative to the <a>vocabulary mapping</a>,
+    not the <a>base IRI</a>.</dd>
   <dt><dfn>set object</dfn></dt><dd>
     A <a>set object</a> is a <a>dictionary</a> that has an <code>@set</code> <a>member</a>.</dd>
   <dt><dfn>subject</dfn></dt><dd>
-    A <a data-cite="RDF11-CONCEPTS#dfn-subject" class="externalDFN">subject</a> is a<a>node</a> in a <a>linked data graph</a> with at least one outgoing edge, related to an <a>object</a> node through a <a>property</a>.
+    A <a data-cite="RDF11-CONCEPTS#dfn-subject" class="externalDFN">subject</a>
+    is a <a>node</a> in a <a>linked data graph</a>
+    with at least one outgoing edge,
+    related to an <a>object</a> node through a <a>property</a>.
     See <dfn data-cite="RDF11-CONCEPTS#dfn-subject" class="preserve">RDF subject</dfn> in [[RDF11-CONCEPTS]].</dd>
-    <dt><dfn>term</dfn></dt><dd>
-    A <a>term</a> is a short word defined in a <a>context</a> that MAY be expanded to an <a>IRI</a>
+  <dt><dfn>term</dfn></dt><dd>
+    A <a>term</a> is a short word defined in a <a>context</a>
+    that MAY be expanded to an <a>IRI</a>.
   </dd>
   <dt><dfn>term definition</dfn></dt><dd>
-    A term definition is an entry in a <a>context</a>, where the key defines a <a>term</a> which may be used within
-    a <a>dictionary</a> as a key, type, or elsewhere that a string is interpreted as a vocabulary item.
-    Its value is either a string (<dfn data-lt="simple term">simple term definition</dfn>), expanding to an absolute IRI, or an <a>expanded term definition</a>.
+    A term definition is an entry in a <a>context</a>,
+    where the key defines a <a>term</a>
+    which may be used within a <a>dictionary</a>
+    as a key, type, or elsewhere that a string is interpreted as a vocabulary item.
+    Its value is either a string (<dfn data-lt="simple term">simple term definition</dfn>),
+    expanding to an absolute IRI,
+    or an <a>expanded term definition</a>.
   </dd>
   <dt class="changed"><dfn>type map</dfn></dt><dd class="changed">
-    An <a>type map</a> is a <a>dictionary</a> value of a <a>term</a> defined with
-    <code>@container</code> set to <code>@type</code>, whose keys are
-    interpreted as <a>IRIs</a> representing the <code>@type</code>
-    of the associated <a>node object</a>;
-    value MUST be a <a>node object</a>, or <a>array</a> of node objects.
-    If the value contains a <a>term</a> expanding to <code>@type</code>, it's values
-    are merged with the map value when expanding.</dd>
+    An <a>type map</a> is a <a>dictionary</a> value of a <a>term</a>
+    defined with <code>@container</code> set to <code>@type</code>,
+    whose keys are interpreted as <a>IRIs</a>
+    representing the <code>@type</code> of the associated <a>node object</a>;
+    the value MUST be a <a>node object</a>, or <a>array</a> of node objects.
+    If the value contains a <a>term</a> expanding to <code>@type</code>,
+    it's values are merged with the map value when expanding.</dd>
   <dt><dfn>typed literal</dfn></dt><dd>
     A <a>typed literal</a> is a <a>literal</a> with an associated <a>IRI</a>
     which indicates the literal's datatype.
     See <dfn data-cite="RDF11-CONCEPTS#dfn-literal" class="preserve">RDF literal</dfn> in [[RDF11-CONCEPTS]].</dd>
   <dt><dfn>typed value</dfn></dt><dd>
-    A <a>typed value</a> consists of a value, which is a <a>string</a>, and a type,
+    A <a>typed value</a> consists of a value,
+    which is a <a>string</a>,
+    and a type,
     which is an <a>IRI</a>.</dd>
   <dt><dfn>value object</dfn></dt><dd>
     A <a>value object</a> is a <a>dictionary</a> that has an <code>@value</code> <a>member</a>.</dd>
   <dt><dfn>vocabulary mapping</dfn></dt><dd>
-    The vocabulary mapping is set in the <a>context</a> using the <code>@vocab</code> key whose
-    value MUST be an <a>absolute IRI</a> or <code>null</code>.</dd>
+    The vocabulary mapping is set in the <a>context</a> using the <code>@vocab</code> key
+    whose value MUST be an <a>absolute IRI</a> or <code>null</code>.</dd>
 </dl>

--- a/common/typographical-conventions.html
+++ b/common/typographical-conventions.html
@@ -1,35 +1,49 @@
 <p>The following typographic conventions are used in this specification:</p>
 
 <dl class="typography">
-  <dt><code>markup</code></dt>
-  <dd>Markup (elements, attributes, properties), machine processable values (string, characters, media types), property name, or a file name is in red-orange monospace font.</dd>
-  <dt><var>variable</var></dt>
-  <dd>A variable in pseudo-code or in an algorithm description is in italics.</dd>
-  <dt><dfn>definition</dfn></dt>
-  <dd>A definition of a term, to be used elsewhere in this or other specifications, is in bold and italics.</dd>
-  <dt><a data-lt="definition">definition reference</a></dt>
-  <dd>A reference to a definition <em>in this document</em> is underlined and is also an active link to the definition itself. </dd>
-  <dt><a data-lt="definition"><code>markup definition reference</code></a></dt>
-  <dd>A references to a definition <em>in this document</em>, when the reference itself is also a markup, is underlined, red-orange monospace font, and is also an active link to the definition itself.</dd>
-  <dt><a class="externalDFN">external definition reference</a></dt>
-  <dd>A reference to a definition <em>in another document</em> is underlined, in italics, and is also an active link to the definition itself.</dd>
-  <dt><a class="externalDFN"><code> markup external definition reference</code></a></dt>
-  <dd>A reference to a definition <em>in another document</em>, when the reference itself is also a markup, is underlined, in italics red-orange monospace font, and is also an active link to the definition itself.</dd>
-  <dt><a href="">hyperlink</a></dt>
-  <dd>A hyperlink is underlined and in blue.</dd>
-  <dt>[<a href="">reference</a>]</dt>
-  <dd>A document reference (normative or informative) is enclosed in square brackets and links to the references section.</dd>
-  <dt class="changed">Changes from Recommendation</dt>
-  <dd>Sections or phrases changed from the previous Recommendation are <span class="changed">highlighted</span>.</dd>
+  <dt><code>markup</code></dt><dd>
+    Markup (elements, attributes, properties),
+    machine processable values (string, characters, media types),
+    property name,
+    or a file name is in red-orange monospace font.</dd>
+  <dt><var>variable</var></dt><dd>
+    A variable in pseudo-code or in an algorithm description is in italics.</dd>
+  <dt><dfn>definition</dfn></dt><dd>
+    A definition of a term, to be used elsewhere in this or other specifications,
+    is in bold and italics.</dd>
+  <dt><a data-lt="definition">definition reference</a></dt><dd>
+    A reference to a definition <em>in this document</em>
+    is underlined and is also an active link to the definition itself. </dd>
+  <dt><a data-lt="definition"><code>markup definition reference</code></a></dt><dd>
+    A references to a definition <em>in this document</em>,
+    when the reference itself is also a markup, is underlined,
+    red-orange monospace font, and is also an active link to the definition itself.</dd>
+  <dt><a class="externalDFN">external definition reference</a></dt><dd>
+    A reference to a definition <em>in another document</em>
+    is underlined, in italics, and is also an active link to the definition itself.</dd>
+  <dt><a class="externalDFN"><code> markup external definition reference</code></a></dt><dd>
+    A reference to a definition <em>in another document</em>,
+    when the reference itself is also a markup,
+    is underlined, in italics red-orange monospace font,
+    and is also an active link to the definition itself.</dd>
+  <dt><a href="">hyperlink</a></dt><dd>
+    A hyperlink is underlined and in blue.</dd>
+  <dt>[<a href="">reference</a>]</dt><dd>
+    A document reference (normative or informative) is enclosed in square brackets
+    and links to the references section.</dd>
+  <dt class="changed">Changes from Recommendation</dt><dd>
+    Sections or phrases changed from the previous Recommendation
+    are <span class="changed">highlighted</span>.</dd>
 </dl>
 
-<p class="note">Notes are in light green boxes with a green left border and with a "Note" header in green. Notes are always informative.</p>
+<p class="note">Notes are in light green boxes with a green left border and with a "Note" header in green.
+  Notes are always informative.</p>
 
 <pre class="example">
-  Examples are in light khaki boxes, with khaki left border, and with a
-  numbered "Example" header in khaki. Examples are always informative.
-  The content of the example is in monospace font and may be syntax colored.
+  Examples are in light khaki boxes, with khaki left border,
+  and with a numbered "Example" header in khaki.
+  Examples are always informative. The content of the example is in monospace font and may be syntax colored.
 
-  Examples may have tabbed navigation buttons to show the results of transforming
-  an example into other representations.
+  Examples may have tabbed navigation buttons
+  to show the results of transforming an example into other representations.
 </pre>

--- a/index.html
+++ b/index.html
@@ -4029,7 +4029,7 @@
 
       <p class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
         and may be removed in a future version of JSON-LD,
-        as is the support for <a>generalized rdf datasets</a>
+        as is the support for <a>generalized RDF Datasets</a>
         and thus the <a data-link-for="JsonLdOptions">produceGeneralizedRdf</a> option may be also be removed.</p>
 
       <ol>
@@ -4070,7 +4070,7 @@
                       continue with the next <var>property</var>-<var>values</var> pair.
                       <div class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
                         and may be removed in a future version of JSON-LD,
-                        as is the support for <a>generalized rdf datasets</a>
+                        as is the support for <a>generalized RDF Datasets</a>
                         and thus the <a data-link-for="JsonLdOptions">produceGeneralizedRdf</a> option may be also be removed.</div>
                       </li>
                     <li>Otherwise, if <var>property</var> is
@@ -4910,7 +4910,7 @@
             <a data-lt="jsonldprocessor-fromRdf-options">options</a>.
             <div class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
               and may be removed in a future version of JSON-LD,
-              as is the support for <a>generalized rdf datasets</a>
+              as is the support for <a>generalized RDF Datasets</a>
               and thus the <a data-link-for="JsonLdOptions">produceGeneralizedRdf</a> option may be also be removed.</div>
             </li>
           <li>Fulfill the <var>promise</var> passing <var>dataset</var>.</li>
@@ -4949,7 +4949,7 @@
             <a data-link-for="JsonldOptions">produceGeneralizedRdf</a> flag in <a data-lt="jsonldprocessor-toRdf-options">options</a>.
             <div class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
               and may be removed in a future version of JSON-LD,
-              as is the support for <a>generalized rdf datasets</a>
+              as is the support for <a>generalized RDF Datasets</a>
               and thus the <a data-link-for="JsonLdOptions">produceGeneralizedRdf</a> option may be also be removed.</div>
             </li>
           <li>Fulfill the <var>promise</var> passing <var>dataset</var>.</li>
@@ -5074,7 +5074,7 @@
       <dd>An absolute <a>IRI</a> denoting the <a>predicate</a> of the <a>triple</a>.
         If used to represent a <a>Generalized RDF Dataset</a>, it may also be a <a>blank node identifier</a>.
         <div class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
-          and may be removed in a future version of JSON-LD, as is the support for <a>generalized rdf datasets</a>.</div>
+          and may be removed in a future version of JSON-LD, as is the support for <a>generalized RDF Datasets</a>.</div>
         </dd>
       <dt><dfn data-dfn-for="RdfTriple">object</dfn></dt>
       <dd>An absolute <a>IRI</a>, <a>blank node identifier</a> or <a>literal</a> denoting the <a>object</a> of the <a>triple</a>.</dd>
@@ -5147,7 +5147,7 @@
           are defined in [[RDF11-CONCEPTS]].
         <div class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
           and may be removed in a future version of JSON-LD,
-          as is the support for <a>generalized rdf datasets</a>
+          as is the support for <a>generalized RDF Datasets</a>
           and thus the <a data-link-for="JsonLdOptions">produceGeneralizedRdf</a> option may be also be removed.</div>
       </dd>
       <dt><dfn data-dfn-for="JsonLdOptions">processingMode</dfn></dt>
@@ -5559,7 +5559,7 @@
       the rest of the algorithm.</li>
     <li>The use of <a>blank node identifiers</a> to label properties is obsolete,
       and may be removed in a future version of JSON-LD,
-      as is the support for <a>generalized rdf datasets</a>
+      as is the support for <a>generalized RDF Datasets</a>
       and thus the <a data-link-for="JsonLdOptions">produceGeneralizedRdf</a> option may be also be removed.</li>
     
   </ul>

--- a/index.html
+++ b/index.html
@@ -1100,7 +1100,9 @@
                   of <var>result</var> is set to <var>value</var>. If it is not
                   an <a>absolute IRI</a>, or a <a>blank node identifier</a>, an
                   <a data-link-for="JsonLdErrorCode">invalid vocab mapping</a>
-                  error has been detected and processing is aborted.</li>
+                  error has been detected and processing is aborted.
+                  <div class="issue atrisk">The use of <a>blank node identifiers</a> to value for <code>@vocab</code> is obsolete,
+                    and may be removed in a future version of JSON-LD.</div></li>
               </ol>
             </li>
             <li>If <var>context</var> has an <code>@language</code> <a>member</a>:
@@ -3859,7 +3861,9 @@
               <ol>
                 <li>If <var>property</var> is a <a>blank node identifier</a>, replace it with a newly
                   <a href="#generate-blank-node-identifier">generated blank node identifier</a>
-                  passing <var>property</var> for <var>identifier</var>.</li>
+                  passing <var>property</var> for <var>identifier</var>.
+                  <div class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
+                    and may be removed in a future version of JSON-LD.</div></li>
                 <li>If <var>node</var> does not have a <var>property</var> <a>member</a>, create one and initialize
                   its value to an empty <a>array</a>.</li>
                 <li>Recursively invoke this algorithm passing <var>value</var> for <var>element</var>,
@@ -3961,9 +3965,12 @@
 
     <p>This algorithm deserializes a JSON-LD document to an <a>RDF dataset</a>.
       Please note that RDF does not allow a <a>blank node</a> to be used
-      as a <a>property</a>, while JSON-LD does.  Therefore, by default
+      as a <a>property</a>, while JSON-LD does. Therefore, by default
       RDF triples that would have contained blank nodes as <a>properties</a> are
       discarded when interpreting JSON-LD as RDF.</p>
+
+    <p class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
+      and may be removed in a future version of JSON-LD.</p>
 
     <p class="changed">Implementations MUST generate only <dfn>well-formed</dfn>
       <a>RDF triples</a> and <a>graph names</a>:</p>
@@ -4020,6 +4027,11 @@
         containing a <a>blank node</a> <a>predicate</a>
         are excluded from output.</p>
 
+      <p class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
+        and may be removed in a future version of JSON-LD,
+        as is the support for <a>generalized rdf datasets</a>
+        and thus the <a data-link-for="JsonLdOptions">produceGeneralizedRdf</a> option may be also be removed.</p>
+
       <ol>
         <li>For each <var>graph name</var> and <var>graph</var> in <var>node map</var>
           ordered by <var>graph name</var>:
@@ -4055,7 +4067,12 @@
                       continue with the next <var>property</var>-<var>values</var> pair.</li>
                     <li>Otherwise, if <var>property</var> is a <a>blank node identifier</a> and
                       the <a data-link-for="JsonLdOptions">produceGeneralizedRdf</a> option is not <code>true</code>,
-                      continue with the next <var>property</var>-<var>values</var> pair.</li>
+                      continue with the next <var>property</var>-<var>values</var> pair.
+                      <div class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
+                        and may be removed in a future version of JSON-LD,
+                        as is the support for <a>generalized rdf datasets</a>
+                        and thus the <a data-link-for="JsonLdOptions">produceGeneralizedRdf</a> option may be also be removed.</div>
+                      </li>
                     <li>Otherwise, if <var>property</var> is
                       <span class="changed">not <a>well-formed</a></span>,
                       continue with the next <var>property</var>-<var>values</var> pair.</li>
@@ -4454,7 +4471,7 @@
     <h2>RDF to Object Conversion</h2>
 
     <p>This algorithm transforms an RDF literal to a JSON-LD <a>value object</a>
-      and a RDF blank node or IRI to an JSON-LD <a>node object</a>.</p>
+      and a RDF <a>blank node</a> or <a>IRI</a> to an JSON-LD <a>node object</a>.</p>
 
     <section class="informative">
       <h3>Overview</h3>
@@ -4890,7 +4907,12 @@
             <a href="#deserialize-json-ld-to-rdf-algorithm">Deserialize JSON-LD to RDF Algorithm</a>
             passing <var>node map</var>, <var>dataset</var>, and if passed, the
             <a data-link-for="JsonldOptions">produceGeneralizedRdf</a> flag in <a data-lt="jsonldprocessor-fromRdf-options">options</a>
-            <a data-lt="jsonldprocessor-fromRdf-options">options</a>.</li>
+            <a data-lt="jsonldprocessor-fromRdf-options">options</a>.
+            <div class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
+              and may be removed in a future version of JSON-LD,
+              as is the support for <a>generalized rdf datasets</a>
+              and thus the <a data-link-for="JsonLdOptions">produceGeneralizedRdf</a> option may be also be removed.</div>
+            </li>
           <li>Fulfill the <var>promise</var> passing <var>dataset</var>.</li>
         </ol>
 
@@ -4924,7 +4946,12 @@
           <li>Invoke the
             <a href="#deserialize-json-ld-to-rdf-algorithm">Deserialize JSON-LD to RDF Algorithm</a>
             passing <var>node map</var>, <var>dataset</var>, and if passed, the
-            <a data-link-for="JsonldOptions">produceGeneralizedRdf</a> flag in <a data-lt="jsonldprocessor-toRdf-options">options</a>.</li>
+            <a data-link-for="JsonldOptions">produceGeneralizedRdf</a> flag in <a data-lt="jsonldprocessor-toRdf-options">options</a>.
+            <div class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
+              and may be removed in a future version of JSON-LD,
+              as is the support for <a>generalized rdf datasets</a>
+              and thus the <a data-link-for="JsonLdOptions">produceGeneralizedRdf</a> option may be also be removed.</div>
+            </li>
           <li>Fulfill the <var>promise</var> passing <var>dataset</var>.</li>
         </ol>
 
@@ -5045,7 +5072,10 @@
       <dd>An absolute <a>IRI</a> or <a>blank node identifier</a> denoting the <a>subject</a> of the <a>triple</a>.</dd>
       <dt><dfn data-dfn-for="RdfTriple">predicate</dfn></dt>
       <dd>An absolute <a>IRI</a> denoting the <a>predicate</a> of the <a>triple</a>.
-        If used to represent a <a>Generalized RDF Dataset</a>, it may also be a <a>blank node identifier</a>.</dd>
+        If used to represent a <a>Generalized RDF Dataset</a>, it may also be a <a>blank node identifier</a>.
+        <div class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
+          and may be removed in a future version of JSON-LD, as is the support for <a>generalized rdf datasets</a>.</div>
+        </dd>
       <dt><dfn data-dfn-for="RdfTriple">object</dfn></dt>
       <dd>An absolute <a>IRI</a>, <a>blank node identifier</a> or <a>literal</a> denoting the <a>object</a> of the <a>triple</a>.</dd>
     </dl>
@@ -5113,8 +5143,13 @@
       <dt><dfn data-dfn-for="JsonLdOptions">produceGeneralizedRdf</dfn></dt>
       <dd>If set to <code>true</code>, the JSON-LD processor may emit blank nodes for
         <a>triple</a> <a>predicates</a>, otherwise they will be omitted.
-      <dfn data-cite="RDF11-CONCEPTS#dfn-generalized-rdf-dataset" data-lt="generalized rdf dataset">Generalized RDF Datasets</dfn>
-        are defined in [[RDF11-CONCEPTS]].</dd>
+        <dfn data-cite="RDF11-CONCEPTS#dfn-generalized-rdf-dataset" data-lt="generalized rdf dataset">Generalized RDF Datasets</dfn>
+          are defined in [[RDF11-CONCEPTS]].
+        <div class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
+          and may be removed in a future version of JSON-LD,
+          as is the support for <a>generalized rdf datasets</a>
+          and thus the <a data-link-for="JsonLdOptions">produceGeneralizedRdf</a> option may be also be removed.</div>
+      </dd>
       <dt><dfn data-dfn-for="JsonLdOptions">processingMode</dfn></dt>
       <dd>Sets the <a>processing mode</a>.
         If set to <code>json-ld-1.0</code> or <code>json-ld-1.1</code>, the
@@ -5522,6 +5557,11 @@
       <var>prefix</var> is not a <a>term</a>, to only return <var>value</var>
       if it has the form of an <a>absolute IRI</a>, otherwise fall through to
       the rest of the algorithm.</li>
+    <li>The use of <a>blank node identifiers</a> to label properties is obsolete,
+      and may be removed in a future version of JSON-LD,
+      as is the support for <a>generalized rdf datasets</a>
+      and thus the <a data-link-for="JsonLdOptions">produceGeneralizedRdf</a> option may be also be removed.</li>
+    
   </ul>
 </section>
 


### PR DESCRIPTION
… and generalized RDF datasets.

Fixes w3c/syntax#37.