### PR TITLE
Don't do HTML html decoding, and update expand/h010 to reflect this.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: git://github.com/ruby-rdf/json-ld.git
-  revision: 488d5e7737d401bb83a246248ad2f921c56938c4
+  revision: a26c3205d006550f85162848a4a2bc3366b39970
   branch: develop
   specs:
     json-ld (3.0.2)
-      multi_json (~> 1.12)
-      rdf (>= 2.2.8, < 4.0)
+      multi_json (~> 1.13)
+      rdf (~> 3.0, >= 3.0.4)
 
 GEM
   remote: https://rubygems.org/
@@ -16,7 +16,7 @@ GEM
       i18n
     builder (3.2.3)
     colorize (0.8.1)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.3)
     connection_pool (2.2.2)
     ebnf (1.1.3)
       rdf (~> 3.0)
@@ -29,9 +29,9 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     htmlentities (4.3.4)
-    i18n (1.1.0)
+    i18n (1.1.1)
       concurrent-ruby (~> 1.0)
-    json-ld-preloaded (3.0.1)
+    json-ld-preloaded (3.0.2)
       json-ld (~> 3.0)
       multi_json (~> 1.12)
       rdf (~> 3.0)
@@ -76,8 +76,8 @@ GEM
     nokogumbo (1.5.0)
       nokogiri
     public_suffix (3.0.3)
-    rake (12.3.1)
-    rdf (3.0.4)
+    rake (12.3.2)
+    rdf (3.0.7)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
     rdf-aggregate-repo (2.2.1)
@@ -126,7 +126,7 @@ GEM
     rdf-turtle (3.0.3)
       ebnf (~> 1.1)
       rdf (~> 3.0)
-    rdf-vocab (3.0.3)
+    rdf-vocab (3.0.4)
       rdf (~> 3.0)
     rdf-xsd (3.0.1)
       rdf (~> 3.0)
@@ -146,13 +146,13 @@ GEM
       rdf-xsd (~> 3.0)
       sparql-client (~> 3.0)
       sxp (~> 1.0)
-    sparql-client (3.0.0)
+    sparql-client (3.0.1)
       net-http-persistent (>= 2.9, < 4)
       rdf (~> 3.0)
     sxp (1.0.1)
       rdf (>= 2.2, < 4.0)
     temple (0.8.0)
-    tilt (2.0.8)
+    tilt (2.0.9)
 
 PLATFORMS
   ruby
@@ -166,4 +166,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.16.4
+   1.17.1

--- a/common/extract-examples.rb
+++ b/common/extract-examples.rb
@@ -303,7 +303,6 @@ ARGV.each do |input|
     # Perform example syntactic validation based on extension
     case ex[:ext]
     when 'json', 'jsonld', 'jsonldf'
-      content = CGI.unescapeHTML(content)
       begin
         ::JSON.parse(content)
       rescue JSON::ParserError => exception
@@ -327,9 +326,7 @@ ARGV.each do |input|
         ex[:base] = html_base.to_s if html_base
 
         script_content = doc.at_xpath(xpath)
-        
-        # Remove (faked) XML comments and unescape sequences
-        content = CGI.unescapeHTML(script_content.inner_html) if script_content          
+        content = script_content.inner_html if script_content          
       rescue Nokogiri::XML::SyntaxError => exception
         errors << "Example #{ex[:number]} at line #{ex[:line]} parse error: #{exception.message}"
         $stdout.write "F".colorize(:red)
@@ -451,7 +448,7 @@ ARGV.each do |input|
           $stdout.write "F".colorize(:red)
           next
         end
-        StringIO.new(CGI.unescapeHTML(script_content.inner_html))
+        StringIO.new(script_content.inner_html)
       elsif examples[ex[:result_for]][:ext] == 'html' && ex[:target]
         # Only use the targeted script
         doc = Nokogiri::HTML.parse(examples[ex[:result_for]][:content])
@@ -461,9 +458,7 @@ ARGV.each do |input|
           $stdout.write "F".colorize(:red)
           next
         end
-        StringIO.new(script_content
-          .to_html
-          .gsub(/&lt;/, '<'))
+        StringIO.new(script_content.to_html)
       else
         StringIO.new(examples[ex[:result_for]][:content])
       end

--- a/index.html
+++ b/index.html
@@ -4851,7 +4851,8 @@
                 If no element is found
                 or the located element is not a <a data-cite="HTML52/semantics-scripting.html#the-script-element">script element</a> with <code>type</code> <code>application/ld+json</code>,
                 reject <var>promise</var> passing an <a data-link-for="JsonLdErrorCode">invalid script element</a> error.
-                Set <var>original input</var> to <var>source</var>.</li>
+                Set <var>original input</var> to the result of the <a href="#extract-script-content">Extract Script Content algorithm</a>,
+                using <var>source</var>.</li>
               <li>Otherwise, if the <a data-link-for="JsonldOptions">extractAllScripts</a> option is not present, or <code>false</code>,
                 locate the first <a>JSON-LD script element</a> in <var>input</var>,
                 and set <var>source</var> to its <a data-cite="DOM#dom-node-textcontent">textContent</a>, if found.

--- a/index.html
+++ b/index.html
@@ -4673,25 +4673,14 @@
       within an HTML [[HTML52]] document with the with the <code>type</code> attribute set to
       <code>application/ld+json</code>.</p>
 
-    <section class="informative">
-      <h4>Overview</h4>
-      <p>The algorithm reverses <a data-cite="HTML5/syntax.html#character-references">HTML Character references</a>.
-    </section>
+    <p>The algorithm takes a single required input variable: <var>source</var>,
+      the <a data-cite="DOM#dom-node-textcontent">textContent</a> of an HTML <a data-cite="HTML52/semantics-scripting.html#the-script-element">script element</a>.</p>
 
-    <section>
-      <h4>Algorithm</h4>
-      <p>The algorithm takes a single required input variable: <var>source</var>,
-        the <a data-cite="DOM#dom-node-textcontent">textContent</a> of an HTML <a data-cite="HTML52/semantics-scripting.html#the-script-element">script element</a>.</p>
-
-      <ol>
-      <li>For all occurances of a <a data-cite="HTML5/syntax.html#character-references">HTML Character reference</a> in <var>source</var>,
-        replace the sequence with the equivalent Unicode character as defined
-        in <a data-cite="HTML52/syntax.html#named-character-references">Named character references</a> in [[HTML52]].</li>
-      <li>If <var>source</var> is not a valid JSON document,
-        an <a data-link-for="JsonLdErrorCode">invalid script element</a> has been detected, and processing is aborted.</li>
-      <li>Return the result of transforming <var>source</var> into the <a>internal representation</a>.</li>
-      </ol>
-    </section>
+    <ol>
+    <li>If <var>source</var> is not a valid JSON document,
+      an <a data-link-for="JsonLdErrorCode">invalid script element</a> has been detected, and processing is aborted.</li>
+    <li>Return the result of transforming <var>source</var> into the <a>internal representation</a>.</li>
+    </ol>
   </section>
 </section>
 
@@ -4862,8 +4851,7 @@
                 If no element is found
                 or the located element is not a <a data-cite="HTML52/semantics-scripting.html#the-script-element">script element</a> with <code>type</code> <code>application/ld+json</code>,
                 reject <var>promise</var> passing an <a data-link-for="JsonLdErrorCode">invalid script element</a> error.
-                Set <var>original input</var> to the result of the <a href="#extract-script-content">Extract Script Content algorithm</a>,
-                using <var>source</var>.</li>
+                Set <var>original input</var> to <var>source</var>.</li>
               <li>Otherwise, if the <a data-link-for="JsonldOptions">extractAllScripts</a> option is not present, or <code>false</code>,
                 locate the first <a>JSON-LD script element</a> in <var>input</var>,
                 and set <var>source</var> to its <a data-cite="DOM#dom-node-textcontent">textContent</a>, if found.

--- a/tests/expand/h010-out.jsonld
+++ b/tests/expand/h010-out.jsonld
@@ -1,3 +1,3 @@
 [{
-  "http://example/foo": [{"@value": "<&>"}]
+  "http://example/foo": [{"@value": "&lt;&amp;&gt;"}]
 }]


### PR DESCRIPTION
For w3c/json-ld-syntax#100.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/54.html" title="Last updated on Dec 8, 2018, 9:30 PM GMT (f9236d8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/54/e2ba014...f9236d8.html" title="Last updated on Dec 8, 2018, 9:30 PM GMT (f9236d8)">Diff</a>