### PR TITLE
Use test-vocabulary in this repo, rather than json-ld.org.

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -5,6 +5,8 @@ be used to verify JSON-LD Processor conformance to the set of specifications
 that constitute JSON-LD. The goal of the suite is to provide an easy and
 comprehensive JSON-LD testing solution for developers creating JSON-LD Processors.
 
+More information and an RDFS definition of the test vocabulary can be found at [vocab](https://w3c.github.io/json-ld-api/tests/vocab).
+
 # Design
 
 Tests are defined into _compact_, _expand_, _flatten_, _remote-doc_, _fromRdf_, and _toRdf_ sections:
@@ -35,6 +37,18 @@ Tests are defined into _compact_, _expand_, _flatten_, _remote-doc_, _fromRdf_, 
   The _expected_ results  can be compared using [JSON-LD object comparison](#json-ld-object-comparison) with the processor output.
 * _toRdf_ tests have _input_ and _expected_ documents.
   The _expected_ results can be compared using [RDF Dataset Isomorphism](https://www.w3.org/TR/rdf11-concepts/#dfn-dataset-isomorphism).
+* _http_ tests have _input_ and _expected_ documents and an optional _context_ document.
+  These tests describe the behavior of an HTTP server performing content-negotiation using the ACCEPT header, specified using the _accept_ option to generate the _expected_ result document.
+  The _expected_ results can be compared using [JSON-LD object comparison](#json-ld-object-comparison) with the processor output
+  after potentially remapping blank node identifiers (see below).
+  Additionally, if the result is compacted and the `ordered` option is not set, result should be expanded and compared with the expanded _expected_ document also using [JSON-LD object comparison](#json-ld-object-comparison).
+
+  If the result is to be compacted, and no explicit context URL is provided, test subjects should use http/default-context.jsonld
+
+  If the profile parameter includes http://example.com/do-not-use, test subjects should reject the URL and not accept the media type. Otherwise, for any other URL, applications should apply the specified URL for the context or frame, as appropriate.
+
+  For *NegativeEvaluationTests*, the result is the expected HTTP status. Options may be present to describe the intended HTTP behavior:
+  * _accept_: The HTTP _Accept_ header value.
 
 Unless `processingMode` is set explicitly in a test entry, `processingMode` is compatible with both `json-ld-1.0` and `json-ld-1.1`.
 

--- a/tests/context.jsonld
+++ b/tests/context.jsonld
@@ -1,8 +1,8 @@
 {
   "@context": {
-    "@vocab":   "https://json-ld.org/test-suite/vocab#",
+    "@vocab":   "https://w3c.github.io/json-ld-api/tests/vocab#",
     "dc":       "http://purl.org/dc/terms/",
-    "jld":      "https://w3c.github.io/json-ld-api/vocab#",
+    "jld":      "https://w3c.github.io/json-ld-api/tests/vocab#",
     "mf":       "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
     "rdfs":     "http://www.w3.org/2000/01/rdf-schema#",
     "xsd":      "http://www.w3.org/2001/XMLSchema#",
@@ -21,10 +21,10 @@
     "base":                 { "@type": "@id" },
     "compactArrays":        { "@type": "xsd:boolean" },
     "compactToRelative":    { "@type": "xsd:boolean" },
-    "documentLoader":       { "@type": "xsd:string" },
+    "contentType":          { "@type": "xsd:boolean" },
     "expandContext":        { "@type": "xsd:string" },
-    "httpStatus":           { "@type": "xsd:integer" },
     "httpLink":             { "@type": "xsd:string", "@container": "@set" },
+    "httpStatus":           { "@type": "xsd:integer" },
     "processingMode":       { "@type": "xsd:string" },
     "produceGeneralizedRdf":{ "@type": "xsd:boolean" },
     "specVersion":          { "@type": "xsd:string" },

--- a/tests/mk_vocab.rb
+++ b/tests/mk_vocab.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+# Generate vocab.jsonld and vocab.html from vocab.ttl and vocab_template.
+#
+# Generating vocab.jsonld is equivalent to running the following:
+#
+#    jsonld --compact --context vocab_context.jsonld --input-format ttl vocab.ttl  -o vocab.jsonld
+require 'linkeddata'
+require 'haml'
+
+File.open("vocab.jsonld", "w") do |f|
+  r = RDF::Repository.load("vocab.ttl")
+  JSON::LD::API.fromRDF(r, :useNativeTypes => true) do |expanded|
+    # Remove leading/trailing and multiple whitespace from rdf:comments
+    expanded.each do |o|
+      c = o[RDF::RDFS.comment.to_s].first['@value']
+      o[RDF::RDFS.comment.to_s].first['@value'] = c.strip.gsub(/\s+/m, ' ')
+    end
+    JSON::LD::API.compact(expanded, File.open("vocab_context.jsonld")) do |compacted|
+      # Create vocab.jsonld
+      f.write(compacted.to_json(JSON::LD::JSON_STATE))
+
+      # Create vocab.html using vocab_template.haml and compacted vocabulary
+      template = File.read("vocab_template.haml")
+      
+      html = Haml::Engine.new(template, format: :html5).render(self,
+        ontology: compacted['@graph'].detect {|o| o['@id'] == "https://json-ld.org/test-suite/vocab#"},
+        classes: compacted['@graph'].select {|o| o['@type'] == "rdfs:Class"}.sort_by {|o| o['rdfs:label']},
+        properties: compacted['@graph'].select {|o| o['@type'] == "rdf:Property"}.sort_by {|o| o['rdfs:label']},
+        source: compacted.to_json(JSON::LD::JSON_STATE)
+      )
+      File.open("vocab.html", "w") {|fh| fh.write html}
+    end
+  end
+end

--- a/tests/vocab.html
+++ b/tests/vocab.html
@@ -1,0 +1,400 @@
+<html lang='en'>
+<head>
+<meta charset='utf-8'>
+<title>Test case manifest vocabulary extensions</title>
+<link href='http://www.w3.org/StyleSheets/2016/base.css' rel='stylesheet'>
+<script type='application/ld+json'>
+{
+  "@context": {
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "mf": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "jld": "https://json-ld.org/test-suite/vocab#",
+    "jld:Test": {
+      "@type": "@id"
+    },
+    "dc:identifier": {
+      "@type": "@id"
+    },
+    "rdfs:subClassOf": {
+      "@type": "@id"
+    },
+    "rdfs:domain": {
+      "@type": "@id"
+    },
+    "rdfs:range": {
+      "@type": "@id"
+    }
+  },
+  "@graph": [
+    {
+      "@id": "jld:FromRDFTest",
+      "@type": "rdfs:Class",
+      "rdfs:label": "From RDF Evaluation Test",
+      "rdfs:subClassOf": "jld:Test",
+      "rdfs:comment": "A `FromRDFTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`."
+    },
+    {
+      "@id": "jld:Test",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Superclass of all JSON-LD tests",
+      "rdfs:comment": "All JSON-LD tests have an input file referenced using `mf:action` (aliased as \"input\" in test manifest). Positive and Negative Evaluation Tests also have a result file referenced using `mf:result` (aliased as \"expect\" in test manifest). Other tests may take different inputs and options as defined for each test class. Tests should be run with the processingMode option set to \"json-ld-1.1\", unless specified explicitly as a test option."
+    },
+    {
+      "@id": "jld:processingMode",
+      "@type": "rdf:Property",
+      "rdfs:label": "processing mode",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "If set to \"json-ld-1.1\", the JSON-LD processor must produce exactly the same results as the algorithms defined in this specification. If set to another value, the JSON-LD processor is allowed to extend or modify the algorithms defined in this specification to enable application-specific optimizations. The definition of such optimizations is beyond the scope of this specification and thus not defined. Consequently, different implementations may implement different optimizations. Developers must not define modes beginning with json-ld as they are reserved for future versions of this specification.",
+      "rdfs:range": "xsd:string"
+    },
+    {
+      "@id": "jld:Option",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Processor Options",
+      "rdfs:comment": "Options passed to the test runner to affect invocation of the appropriate API method."
+    },
+    {
+      "@id": "jld:frame",
+      "@type": "rdf:Property",
+      "rdfs:subPropertyOf": {
+        "@id": "jld:input"
+      },
+      "rdfs:domain": "jld:Test",
+      "rdfs:comment": "A frame that is used for transforming the input document.",
+      "rdfs:range": "rdfs:Resource",
+      "rdfs:label": "input"
+    },
+    {
+      "@id": "jld:input",
+      "@type": "rdf:Property",
+      "rdfs:label": "input",
+      "rdfs:domain": "jld:Test",
+      "rdfs:comment": "Secondary input file",
+      "rdfs:range": "rdfs:Resource"
+    },
+    {
+      "@id": "jld:option",
+      "@type": "rdf:Property",
+      "rdfs:label": "option",
+      "rdfs:domain": "jld:Test",
+      "rdfs:comment": "Options affecting processing",
+      "rdfs:range": "jld:Option"
+    },
+    {
+      "@id": "jld:FlattenTest",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Flatten Evaluation Test",
+      "rdfs:subClassOf": "jld:Test",
+      "rdfs:comment": "A `FlattenTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`."
+    },
+    {
+      "@id": "jld:PositiveEvaluationTest",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Positive Evaluation Test",
+      "rdfs:subClassOf": "jld:Test",
+      "rdfs:comment": "A Positive Evaluation test is successful when the result of processing the input file specified as `mf:action` (aliased as \"input\" in test manifest) exactly matches the output file specified as `mf:result` (aliased as \"expect\" in test manifest) using the comparison defined in another class. The specifics of invoking test, including the interpretation of options (`:option`) and other input files are specified through another class."
+    },
+    {
+      "@id": "jld:NegativeSyntaxTest",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Negative Syntax Test",
+      "rdfs:subClassOf": "jld:Test",
+      "rdfs:comment": "A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action. Negative syntax tests are tests of which the result should be a parser error."
+    },
+    {
+      "@id": "https://json-ld.org/test-suite/vocab#",
+      "dc:date": "2013-09-23",
+      "dc:identifier": "https://json-ld.org/test-suite/vocab#",
+      "dc:creator": "Gregg Kellogg",
+      "dc:publisher": "W3C Linked JSON Community Group",
+      "dc:description": "Test case manifest vocabulary extensions",
+      "rdfs:comment": "Manifest vocabulary for JSON-LD test cases",
+      "dc:title": "Test case manifest vocabulary extensions"
+    },
+    {
+      "@id": "jld:compactArrays",
+      "@type": "rdf:Property",
+      "rdfs:label": "compact arrays",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "If set to `true`, the JSON-LD processor replaces arrays with just one element with that element during compaction. If set to false, all arrays will remain arrays even if they have just one element.",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "jld:FrameTest",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Frame Evaluation Test",
+      "rdfs:subClassOf": "jld:Test",
+      "rdfs:comment": "A `FrameTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`."
+    },
+    {
+      "@id": "jld:useRdfType",
+      "@type": "rdf:Property",
+      "rdfs:label": "use RDF types",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "If the _use rdf type_ flag is set to `true`, statements with an `rdf:type` predicate will not use `@type`, but will be transformed as a normal property.",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "jld:httpLink",
+      "@type": "rdf:Property",
+      "rdfs:label": "HTTP link",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "An HTTP Link header to be added to the result of requesting the input file.",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "jld:HttpTest",
+      "@type": "rdfs:Class",
+      "rdfs:label": "HTTP Evaluation Test",
+      "rdfs:subClassOf": "jld:Test",
+      "rdfs:comment": "An `HttpTest` modifies either a `PositiveEvaluationTest` or `NegativeEvaluationTest`."
+    },
+    {
+      "@id": "jld:expandContext",
+      "@type": "rdf:Property",
+      "rdfs:label": "expand context",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "A context that is used to initialize the active context when expanding a document.",
+      "rdfs:range": "rdfs:Resource"
+    },
+    {
+      "@id": "jld:NegativeEvaluationTest",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Positive Evaluation Test",
+      "rdfs:subClassOf": "jld:Test",
+      "rdfs:comment": "A Negative Evaluation test is successful when the result of processing the input file specified as `mf:action` (aliased as \"input\" in test manifest) results in the error identified by the literal value of `mf:result` (aliased as \"expect\" in test manifest). The specifics of invoking test, including the interpretation of options (`:option`) and other input files are specified through another class. See the [README](https://w3c.github.io/json-ld-api/tests/) for more details on running tests."
+    },
+    {
+      "@id": "jld:context",
+      "@type": "rdf:Property",
+      "rdfs:subPropertyOf": {
+        "@id": "jld:input"
+      },
+      "rdfs:domain": "jld:Test",
+      "rdfs:comment": "A context that is used for transforming the input document.",
+      "rdfs:range": "rdfs:Resource",
+      "rdfs:label": "input"
+    },
+    {
+      "@id": "jld:PositiveSyntaxTest",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Positive Syntax Test",
+      "rdfs:subClassOf": "jld:Test",
+      "rdfs:comment": "A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action."
+    },
+    {
+      "@id": "jld:base",
+      "@type": "rdf:Property",
+      "rdfs:label": "base",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "The base IRI to use when expanding or compacting the document. If set, this overrides the input document's IRI.",
+      "rdfs:range": "rdfs:Resource"
+    },
+    {
+      "@id": "jld:contentType",
+      "@type": "rdf:Property",
+      "rdfs:label": "content type",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "The HTTP Content-Type used for the input file, in case it is a non-registered type.",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "jld:useNativeTypes",
+      "@type": "rdf:Property",
+      "rdfs:label": "use native types",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "If the _use native types_ flag is set to `true`, RDF literals with a datatype IRI that equal `xsd:integer` or `xsd:double` are converted to a JSON numbers and RDF literals with a datatype IRI that equals `xsd:boolean` are converted to `true` or `false` based on their lexical form.",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "jld:httpAccept",
+      "@type": "rdf:Property",
+      "rdfs:label": "HTTP Accept",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "An HTTP Accept header.",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "jld:ExpandTest",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Expand Evaluation Test",
+      "rdfs:subClassOf": "jld:Test",
+      "rdfs:comment": "A `ExpandTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`."
+    },
+    {
+      "@id": "jld:redirectTo",
+      "@type": "rdf:Property",
+      "rdfs:label": "redirect to",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "The location of a URL for redirection. A request made of the input file must be redirected to the designated URL.",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "jld:ToRDFTest",
+      "@type": "rdfs:Class",
+      "rdfs:label": "To RDF Evaluation Test",
+      "rdfs:subClassOf": "jld:Test",
+      "rdfs:comment": "A `ToRDFTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`."
+    },
+    {
+      "@id": "jld:compactToRelative",
+      "@type": "rdf:Property",
+      "rdfs:label": "compact to relative",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "If set to `false`, the JSON-LD processor will not attempt to compact using document-relative IRIs.",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "jld:httpStatus",
+      "@type": "rdf:Property",
+      "rdfs:label": "HTTP status",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "The HTTP status code that must be returned when the input file is requested. This is typically used along with the `redirectTo` property.",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "jld:CompactTest",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Compact Evaluation Test",
+      "rdfs:subClassOf": "jld:Test",
+      "rdfs:comment": "A `CompactTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`."
+    },
+    {
+      "@id": "jld:produceGeneralizedRdf",
+      "@type": "rdf:Property",
+      "rdfs:label": "produce generalized RDF",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "Unless the produce generalized RDF flag is set to true, RDF triples containing a blank node predicate are excluded from output.",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "jld:specVersion",
+      "@type": "rdf:Property",
+      "rdfs:label": "spec version",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "Indicates the JSON-LD version to which the test applies, rather than the specific processing mode. Values are \"json-ld-1.0\", and \"json-ld-1.1\". If not set, the test is presumed to be valid for all versions of JSON-LD. In cases where results differ between spec versions for the same test, the test will have both a \"1.0\" and \"1.1\" version, for example.",
+      "rdfs:range": "xsd:string"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+<h1>Test case manifest vocabulary extensions</h1>
+<p><a href='http://www.w3.org/'><img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'></a></p>
+<p>
+Alternate versions of the test vocabulary definition exist in
+<a href='vocab.ttl' rel='alternate'>Turtle</a>
+and <a href='vocab.jsonld' rel='alternate'>JSON-LD</a>.
+</p>
+<section>
+<h2>Test Case Classes</h2>
+<dl>
+<dt><strong>Compact Evaluation Test</strong></dt>
+<dd><p>A <code>CompactTest</code> modifies either a <code>PositiveEvaluationTest</code>, <code>NegativeEvaluationTest</code>, <code>PositiveSyntaxTest</code> or <code>NegativeSyntaxTest</code>.</p>
+</dd>
+<dt><strong>Expand Evaluation Test</strong></dt>
+<dd><p>A <code>ExpandTest</code> modifies either a <code>PositiveEvaluationTest</code>, <code>NegativeEvaluationTest</code>, <code>PositiveSyntaxTest</code> or <code>NegativeSyntaxTest</code>.</p>
+</dd>
+<dt><strong>Flatten Evaluation Test</strong></dt>
+<dd><p>A <code>FlattenTest</code> modifies either a <code>PositiveEvaluationTest</code>, <code>NegativeEvaluationTest</code>, <code>PositiveSyntaxTest</code> or <code>NegativeSyntaxTest</code>.</p>
+</dd>
+<dt><strong>Frame Evaluation Test</strong></dt>
+<dd><p>A <code>FrameTest</code> modifies either a <code>PositiveEvaluationTest</code>, <code>NegativeEvaluationTest</code>, <code>PositiveSyntaxTest</code> or <code>NegativeSyntaxTest</code>.</p>
+</dd>
+<dt><strong>From RDF Evaluation Test</strong></dt>
+<dd><p>A <code>FromRDFTest</code> modifies either a <code>PositiveEvaluationTest</code>, <code>NegativeEvaluationTest</code>, <code>PositiveSyntaxTest</code> or <code>NegativeSyntaxTest</code>.</p>
+</dd>
+<dt><strong>HTTP Evaluation Test</strong></dt>
+<dd><p>An <code>HttpTest</code> modifies either a <code>PositiveEvaluationTest</code> or <code>NegativeEvaluationTest</code>.</p>
+</dd>
+<dt><strong>Negative Syntax Test</strong></dt>
+<dd><p>A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action. Negative syntax tests are tests of which the result should be a parser error.</p>
+</dd>
+<dt><strong>Positive Evaluation Test</strong></dt>
+<dd><p>A Positive Evaluation test is successful when the result of processing the input file specified as <code>mf:action</code> (aliased as &quot;input&quot; in test manifest) exactly matches the output file specified as <code>mf:result</code> (aliased as &quot;expect&quot; in test manifest) using the comparison defined in another class. The specifics of invoking test, including the interpretation of options (<code>:option</code>) and other input files are specified through another class.</p>
+</dd>
+<dt><strong>Positive Evaluation Test</strong></dt>
+<dd><p>A Negative Evaluation test is successful when the result of processing the input file specified as <code>mf:action</code> (aliased as &quot;input&quot; in test manifest) results in the error identified by the literal value of <code>mf:result</code> (aliased as &quot;expect&quot; in test manifest). The specifics of invoking test, including the interpretation of options (<code>:option</code>) and other input files are specified through another class. See the <a href="https://w3c.github.io/json-ld-api/tests/">README</a> for more details on running tests.</p>
+</dd>
+<dt><strong>Positive Syntax Test</strong></dt>
+<dd><p>A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action.</p>
+</dd>
+<dt><strong>Processor Options</strong></dt>
+<dd><p>Options passed to the test runner to affect invocation of the appropriate API method.</p>
+</dd>
+<dt><strong>Superclass of all JSON-LD tests</strong></dt>
+<dd><p>All JSON-LD tests have an input file referenced using <code>mf:action</code> (aliased as &quot;input&quot; in test manifest). Positive and Negative Evaluation Tests also have a result file referenced using <code>mf:result</code> (aliased as &quot;expect&quot; in test manifest). Other tests may take different inputs and options as defined for each test class. Tests should be run with the processingMode option set to &quot;json-ld-1.1&quot;, unless specified explicitly as a test option.</p>
+</dd>
+<dt><strong>To RDF Evaluation Test</strong></dt>
+<dd><p>A <code>ToRDFTest</code> modifies either a <code>PositiveEvaluationTest</code>, <code>NegativeEvaluationTest</code>, <code>PositiveSyntaxTest</code> or <code>NegativeSyntaxTest</code>.</p>
+</dd>
+</dl>
+</section>
+<section>
+<h2>Test Case Properties</h2>
+<dl>
+<dt><strong>HTTP Accept</strong></dt>
+<dd><p>An HTTP Accept header.</p>
+</dd>
+<dt><strong>HTTP link</strong></dt>
+<dd><p>An HTTP Link header to be added to the result of requesting the input file.</p>
+</dd>
+<dt><strong>HTTP status</strong></dt>
+<dd><p>The HTTP status code that must be returned when the input file is requested. This is typically used along with the <code>redirectTo</code> property.</p>
+</dd>
+<dt><strong>base</strong></dt>
+<dd><p>The base IRI to use when expanding or compacting the document. If set, this overrides the input document&#39;s IRI.</p>
+</dd>
+<dt><strong>compact arrays</strong></dt>
+<dd><p>If set to <code>true</code>, the JSON-LD processor replaces arrays with just one element with that element during compaction. If set to false, all arrays will remain arrays even if they have just one element.</p>
+</dd>
+<dt><strong>compact to relative</strong></dt>
+<dd><p>If set to <code>false</code>, the JSON-LD processor will not attempt to compact using document-relative IRIs.</p>
+</dd>
+<dt><strong>content type</strong></dt>
+<dd><p>The HTTP Content-Type used for the input file, in case it is a non-registered type.</p>
+</dd>
+<dt><strong>expand context</strong></dt>
+<dd><p>A context that is used to initialize the active context when expanding a document.</p>
+</dd>
+<dt><strong>input</strong></dt>
+<dd><p>A context that is used for transforming the input document.</p>
+</dd>
+<dt><strong>input</strong></dt>
+<dd><p>Secondary input file</p>
+</dd>
+<dt><strong>input</strong></dt>
+<dd><p>A frame that is used for transforming the input document.</p>
+</dd>
+<dt><strong>option</strong></dt>
+<dd><p>Options affecting processing</p>
+</dd>
+<dt><strong>processing mode</strong></dt>
+<dd><p>If set to &quot;json-ld-1.1&quot;, the JSON-LD processor must produce exactly the same results as the algorithms defined in this specification. If set to another value, the JSON-LD processor is allowed to extend or modify the algorithms defined in this specification to enable application-specific optimizations. The definition of such optimizations is beyond the scope of this specification and thus not defined. Consequently, different implementations may implement different optimizations. Developers must not define modes beginning with json-ld as they are reserved for future versions of this specification.</p>
+</dd>
+<dt><strong>produce generalized RDF</strong></dt>
+<dd><p>Unless the produce generalized RDF flag is set to true, RDF triples containing a blank node predicate are excluded from output.</p>
+</dd>
+<dt><strong>redirect to</strong></dt>
+<dd><p>The location of a URL for redirection. A request made of the input file must be redirected to the designated URL.</p>
+</dd>
+<dt><strong>spec version</strong></dt>
+<dd><p>Indicates the JSON-LD version to which the test applies, rather than the specific processing mode. Values are &quot;json-ld-1.0&quot;, and &quot;json-ld-1.1&quot;. If not set, the test is presumed to be valid for all versions of JSON-LD. In cases where results differ between spec versions for the same test, the test will have both a &quot;1.0&quot; and &quot;1.1&quot; version, for example.</p>
+</dd>
+<dt><strong>use RDF types</strong></dt>
+<dd><p>If the <em>use rdf type</em> flag is set to <code>true</code>, statements with an <code>rdf:type</code> predicate will not use <code>@type</code>, but will be transformed as a normal property.</p>
+</dd>
+<dt><strong>use native types</strong></dt>
+<dd><p>If the <em>use native types</em> flag is set to <code>true</code>, RDF literals with a datatype IRI that equal <code>xsd:integer</code> or <code>xsd:double</code> are converted to a JSON numbers and RDF literals with a datatype IRI that equals <code>xsd:boolean</code> are converted to <code>true</code> or <code>false</code> based on their lexical form.</p>
+</dd>
+</dl>
+</section>
+<footer>
+<span>W3C Linked JSON Community Group</span>
+</footer>
+</body>
+</html>

--- a/tests/vocab.jsonld
+++ b/tests/vocab.jsonld
@@ -1,0 +1,276 @@
+{
+  "@context": {
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "mf": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "jld": "https://json-ld.org/test-suite/vocab#",
+    "jld:Test": {
+      "@type": "@id"
+    },
+    "dc:identifier": {
+      "@type": "@id"
+    },
+    "rdfs:subClassOf": {
+      "@type": "@id"
+    },
+    "rdfs:domain": {
+      "@type": "@id"
+    },
+    "rdfs:range": {
+      "@type": "@id"
+    }
+  },
+  "@graph": [
+    {
+      "@id": "jld:FromRDFTest",
+      "@type": "rdfs:Class",
+      "rdfs:label": "From RDF Evaluation Test",
+      "rdfs:subClassOf": "jld:Test",
+      "rdfs:comment": "A `FromRDFTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`."
+    },
+    {
+      "@id": "jld:Test",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Superclass of all JSON-LD tests",
+      "rdfs:comment": "All JSON-LD tests have an input file referenced using `mf:action` (aliased as \"input\" in test manifest). Positive and Negative Evaluation Tests also have a result file referenced using `mf:result` (aliased as \"expect\" in test manifest). Other tests may take different inputs and options as defined for each test class. Tests should be run with the processingMode option set to \"json-ld-1.1\", unless specified explicitly as a test option."
+    },
+    {
+      "@id": "jld:processingMode",
+      "@type": "rdf:Property",
+      "rdfs:label": "processing mode",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "If set to \"json-ld-1.1\", the JSON-LD processor must produce exactly the same results as the algorithms defined in this specification. If set to another value, the JSON-LD processor is allowed to extend or modify the algorithms defined in this specification to enable application-specific optimizations. The definition of such optimizations is beyond the scope of this specification and thus not defined. Consequently, different implementations may implement different optimizations. Developers must not define modes beginning with json-ld as they are reserved for future versions of this specification.",
+      "rdfs:range": "xsd:string"
+    },
+    {
+      "@id": "jld:Option",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Processor Options",
+      "rdfs:comment": "Options passed to the test runner to affect invocation of the appropriate API method."
+    },
+    {
+      "@id": "jld:frame",
+      "@type": "rdf:Property",
+      "rdfs:subPropertyOf": {
+        "@id": "jld:input"
+      },
+      "rdfs:domain": "jld:Test",
+      "rdfs:comment": "A frame that is used for transforming the input document.",
+      "rdfs:range": "rdfs:Resource",
+      "rdfs:label": "input"
+    },
+    {
+      "@id": "jld:input",
+      "@type": "rdf:Property",
+      "rdfs:label": "input",
+      "rdfs:domain": "jld:Test",
+      "rdfs:comment": "Secondary input file",
+      "rdfs:range": "rdfs:Resource"
+    },
+    {
+      "@id": "jld:option",
+      "@type": "rdf:Property",
+      "rdfs:label": "option",
+      "rdfs:domain": "jld:Test",
+      "rdfs:comment": "Options affecting processing",
+      "rdfs:range": "jld:Option"
+    },
+    {
+      "@id": "jld:FlattenTest",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Flatten Evaluation Test",
+      "rdfs:subClassOf": "jld:Test",
+      "rdfs:comment": "A `FlattenTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`."
+    },
+    {
+      "@id": "jld:PositiveEvaluationTest",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Positive Evaluation Test",
+      "rdfs:subClassOf": "jld:Test",
+      "rdfs:comment": "A Positive Evaluation test is successful when the result of processing the input file specified as `mf:action` (aliased as \"input\" in test manifest) exactly matches the output file specified as `mf:result` (aliased as \"expect\" in test manifest) using the comparison defined in another class. The specifics of invoking test, including the interpretation of options (`:option`) and other input files are specified through another class."
+    },
+    {
+      "@id": "jld:NegativeSyntaxTest",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Negative Syntax Test",
+      "rdfs:subClassOf": "jld:Test",
+      "rdfs:comment": "A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action. Negative syntax tests are tests of which the result should be a parser error."
+    },
+    {
+      "@id": "https://json-ld.org/test-suite/vocab#",
+      "dc:date": "2013-09-23",
+      "dc:identifier": "https://json-ld.org/test-suite/vocab#",
+      "dc:creator": "Gregg Kellogg",
+      "dc:publisher": "W3C Linked JSON Community Group",
+      "dc:description": "Test case manifest vocabulary extensions",
+      "rdfs:comment": "Manifest vocabulary for JSON-LD test cases",
+      "dc:title": "Test case manifest vocabulary extensions"
+    },
+    {
+      "@id": "jld:compactArrays",
+      "@type": "rdf:Property",
+      "rdfs:label": "compact arrays",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "If set to `true`, the JSON-LD processor replaces arrays with just one element with that element during compaction. If set to false, all arrays will remain arrays even if they have just one element.",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "jld:FrameTest",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Frame Evaluation Test",
+      "rdfs:subClassOf": "jld:Test",
+      "rdfs:comment": "A `FrameTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`."
+    },
+    {
+      "@id": "jld:useRdfType",
+      "@type": "rdf:Property",
+      "rdfs:label": "use RDF types",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "If the _use rdf type_ flag is set to `true`, statements with an `rdf:type` predicate will not use `@type`, but will be transformed as a normal property.",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "jld:httpLink",
+      "@type": "rdf:Property",
+      "rdfs:label": "HTTP link",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "An HTTP Link header to be added to the result of requesting the input file.",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "jld:HttpTest",
+      "@type": "rdfs:Class",
+      "rdfs:label": "HTTP Evaluation Test",
+      "rdfs:subClassOf": "jld:Test",
+      "rdfs:comment": "An `HttpTest` modifies either a `PositiveEvaluationTest` or `NegativeEvaluationTest`."
+    },
+    {
+      "@id": "jld:expandContext",
+      "@type": "rdf:Property",
+      "rdfs:label": "expand context",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "A context that is used to initialize the active context when expanding a document.",
+      "rdfs:range": "rdfs:Resource"
+    },
+    {
+      "@id": "jld:NegativeEvaluationTest",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Positive Evaluation Test",
+      "rdfs:subClassOf": "jld:Test",
+      "rdfs:comment": "A Negative Evaluation test is successful when the result of processing the input file specified as `mf:action` (aliased as \"input\" in test manifest) results in the error identified by the literal value of `mf:result` (aliased as \"expect\" in test manifest). The specifics of invoking test, including the interpretation of options (`:option`) and other input files are specified through another class. See the [README](https://w3c.github.io/json-ld-api/tests/) for more details on running tests."
+    },
+    {
+      "@id": "jld:context",
+      "@type": "rdf:Property",
+      "rdfs:subPropertyOf": {
+        "@id": "jld:input"
+      },
+      "rdfs:domain": "jld:Test",
+      "rdfs:comment": "A context that is used for transforming the input document.",
+      "rdfs:range": "rdfs:Resource",
+      "rdfs:label": "input"
+    },
+    {
+      "@id": "jld:PositiveSyntaxTest",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Positive Syntax Test",
+      "rdfs:subClassOf": "jld:Test",
+      "rdfs:comment": "A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action."
+    },
+    {
+      "@id": "jld:base",
+      "@type": "rdf:Property",
+      "rdfs:label": "base",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "The base IRI to use when expanding or compacting the document. If set, this overrides the input document's IRI.",
+      "rdfs:range": "rdfs:Resource"
+    },
+    {
+      "@id": "jld:contentType",
+      "@type": "rdf:Property",
+      "rdfs:label": "content type",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "The HTTP Content-Type used for the input file, in case it is a non-registered type.",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "jld:useNativeTypes",
+      "@type": "rdf:Property",
+      "rdfs:label": "use native types",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "If the _use native types_ flag is set to `true`, RDF literals with a datatype IRI that equal `xsd:integer` or `xsd:double` are converted to a JSON numbers and RDF literals with a datatype IRI that equals `xsd:boolean` are converted to `true` or `false` based on their lexical form.",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "jld:httpAccept",
+      "@type": "rdf:Property",
+      "rdfs:label": "HTTP Accept",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "An HTTP Accept header.",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "jld:ExpandTest",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Expand Evaluation Test",
+      "rdfs:subClassOf": "jld:Test",
+      "rdfs:comment": "A `ExpandTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`."
+    },
+    {
+      "@id": "jld:redirectTo",
+      "@type": "rdf:Property",
+      "rdfs:label": "redirect to",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "The location of a URL for redirection. A request made of the input file must be redirected to the designated URL.",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "jld:ToRDFTest",
+      "@type": "rdfs:Class",
+      "rdfs:label": "To RDF Evaluation Test",
+      "rdfs:subClassOf": "jld:Test",
+      "rdfs:comment": "A `ToRDFTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`."
+    },
+    {
+      "@id": "jld:compactToRelative",
+      "@type": "rdf:Property",
+      "rdfs:label": "compact to relative",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "If set to `false`, the JSON-LD processor will not attempt to compact using document-relative IRIs.",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "jld:httpStatus",
+      "@type": "rdf:Property",
+      "rdfs:label": "HTTP status",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "The HTTP status code that must be returned when the input file is requested. This is typically used along with the `redirectTo` property.",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "jld:CompactTest",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Compact Evaluation Test",
+      "rdfs:subClassOf": "jld:Test",
+      "rdfs:comment": "A `CompactTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`."
+    },
+    {
+      "@id": "jld:produceGeneralizedRdf",
+      "@type": "rdf:Property",
+      "rdfs:label": "produce generalized RDF",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "Unless the produce generalized RDF flag is set to true, RDF triples containing a blank node predicate are excluded from output.",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "jld:specVersion",
+      "@type": "rdf:Property",
+      "rdfs:label": "spec version",
+      "rdfs:domain": "jld:Option",
+      "rdfs:comment": "Indicates the JSON-LD version to which the test applies, rather than the specific processing mode. Values are \"json-ld-1.0\", and \"json-ld-1.1\". If not set, the test is presumed to be valid for all versions of JSON-LD. In cases where results differ between spec versions for the same test, the test will have both a \"1.0\" and \"1.1\" version, for example.",
+      "rdfs:range": "xsd:string"
+    }
+  ]
+}

--- a/tests/vocab.ttl
+++ b/tests/vocab.ttl
@@ -1,0 +1,287 @@
+# Test vocabulary for the JSON-LD test suite.
+# This vocabulary defines classes an properties which extend
+# the test-manifest vocabulary at <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest>.
+
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix dc:     <http://purl.org/dc/elements/1.1/> .
+@prefix mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
+@prefix :       <https://json-ld.org/test-suite/vocab#> .
+
+: rdfs:comment     "Manifest vocabulary for JSON-LD test cases" ;
+  dc:creator       "Gregg Kellogg" ;
+  dc:publisher     "W3C Linked JSON Community Group" ;
+  dc:title         "Test case manifest vocabulary extensions" ;
+  dc:description   "Test case manifest vocabulary extensions" ;
+  dc:date          "2013-09-23" ;
+  dc:identifier    : .
+
+## ---- Test Case Classes ---
+
+:Test a rdfs:Class ;
+  rdfs:label "Superclass of all JSON-LD tests" ;
+  rdfs:comment """
+    All JSON-LD tests have an input file referenced using
+    `mf:action` (aliased as "input" in test manifest).
+    Positive and Negative Evaluation Tests also have a result file
+    referenced using `mf:result` (aliased as "expect" in test manifest).
+    Other tests may take different inputs and options as defined for each test class.
+    Tests should be run with the processingMode option set to "json-ld-1.1",
+    unless specified explicitly as a test option.
+  """ .
+
+:PositiveEvaluationTest a rdfs:Class ;
+  rdfs:label "Positive Evaluation Test" ;
+  rdfs:subClassOf :Test ;
+  rdfs:comment """
+    A Positive Evaluation test is successful when the result of processing
+    the input file specified as `mf:action` (aliased as "input" in test manifest)
+    exactly matches the output file specified as
+    `mf:result` (aliased as "expect" in test manifest) using the comparison defined in
+    another class. The specifics of invoking test, including the interpretation of options
+    (`:option`) and other input files are specified through another class.
+  """ .
+
+:NegativeEvaluationTest a rdfs:Class ;
+  rdfs:label "Positive Evaluation Test" ;
+  rdfs:subClassOf :Test ;
+  rdfs:comment """
+    A Negative Evaluation test is successful when the result of processing
+    the input file specified as `mf:action` (aliased as "input" in test manifest)
+    results in the error identified by the literal value of
+    `mf:result` (aliased as "expect" in test manifest).
+    The specifics of invoking test, including
+    the interpretation of options (`:option`) and other input files are
+    specified through another class.
+    See the [README](https://w3c.github.io/json-ld-api/tests/) for more details on running tests.
+  """ .
+
+:PositiveSyntaxTest a rdfs:Class ;
+  rdfs:subClassOf :Test ;
+  rdfs:label "Positive Syntax Test" ;
+  rdfs:comment """
+    A type of test specifically for syntax testing.
+    Syntax tests are not required to have an associated result, only an action.
+  """ .
+
+:NegativeSyntaxTest a rdfs:Class ;
+  rdfs:subClassOf :Test ;
+  rdfs:label "Negative Syntax Test" ;
+  rdfs:comment """
+    A type of test specifically for syntax testing.
+    Syntax tests are not required to have an associated result, only an action.
+    Negative syntax tests are tests of which the result should be a parser error.
+  """ .
+
+:CompactTest a rdfs:Class ;
+  rdfs:subClassOf :Test ;
+  rdfs:label "Compact Evaluation Test" ;
+  rdfs:comment """
+    A `CompactTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`,
+    `PositiveSyntaxTest` or `NegativeSyntaxTest`.
+  """ .
+
+:ExpandTest a rdfs:Class ;
+  rdfs:subClassOf :Test ;
+  rdfs:label "Expand Evaluation Test" ;
+  rdfs:comment """
+    A `ExpandTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`,
+    `PositiveSyntaxTest` or `NegativeSyntaxTest`.
+  """ .
+
+:FlattenTest a rdfs:Class ;
+  rdfs:subClassOf :Test ;
+  rdfs:label "Flatten Evaluation Test" ;
+  rdfs:comment """
+    A `FlattenTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`,
+    `PositiveSyntaxTest` or `NegativeSyntaxTest`.
+  """ .
+
+:FrameTest a rdfs:Class ;
+  rdfs:subClassOf :Test ;
+  rdfs:label "Frame Evaluation Test" ;
+  rdfs:comment """
+    A `FrameTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`,
+    `PositiveSyntaxTest` or `NegativeSyntaxTest`.
+  """ .
+
+:FromRDFTest a rdfs:Class ;
+  rdfs:subClassOf :Test ;
+  rdfs:label "From RDF Evaluation Test" ;
+  rdfs:comment """
+    A `FromRDFTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`,
+    `PositiveSyntaxTest` or `NegativeSyntaxTest`.
+  """ .
+
+:HttpTest a rdfs:Class ;
+  rdfs:subClassOf :Test ;
+  rdfs:label "HTTP Evaluation Test" ;
+  rdfs:comment """
+    An `HttpTest` modifies either a `PositiveEvaluationTest` or `NegativeEvaluationTest`.
+  """ .
+
+:ToRDFTest a rdfs:Class ;
+  rdfs:subClassOf :Test ;
+  rdfs:label "To RDF Evaluation Test" ;
+  rdfs:comment """
+    A `ToRDFTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`,
+    `PositiveSyntaxTest` or `NegativeSyntaxTest`.
+  """ .
+
+:Option a rdfs:Class ;
+  rdfs:label "Processor Options" ;
+  rdfs:comment "Options passed to the test runner to affect invocation of the appropriate API method." .
+
+## ---- Property declarations for each test ----
+
+:input a rdf:Property ;
+  rdfs:label "input";
+  rdfs:comment "Secondary input file" ;
+  rdfs:domain	 :Test ;
+  rdfs:range   rdfs:Resource .
+
+:context a rdf:Property ;
+  rdfs:label "context";
+  rdfs:comment "A context that is used for transforming the input document." ;
+  rdfs:domain	 :Test ;
+  rdfs:range   rdfs:Resource .
+
+:frame a rdf:Property ;
+  rdfs:label "input";
+  rdfs:comment "A frame that is used for transforming the input document." ;
+  rdfs:domain	 :Test ;
+  rdfs:range   rdfs:Resource .
+
+:option a rdf:Property ;
+  rdfs:label "option";
+  rdfs:comment "Options affecting processing" ;
+  rdfs:domain	 :Test ;
+  rdfs:range   :Option .
+
+:base a rdf:Property ;
+  rdfs:label "base";
+  rdfs:comment """
+    The base IRI to use when expanding or compacting the document.
+    If set, this overrides the input document's IRI.
+  """ ;
+  rdfs:domain	 :Option ;
+  rdfs:range   rdfs:Resource .
+
+:compactArrays a rdf:Property ;
+  rdfs:label "compact arrays";
+  rdfs:comment """
+    If set to `true`, the JSON-LD processor replaces arrays with just one element
+    with that element during compaction.
+    If set to false, all arrays will remain arrays even if they have just one element.
+  """ ;
+  rdfs:domain	 :Option ;
+  rdfs:range   xsd:boolean .
+
+:compactToRelative a rdf:Property ;
+  rdfs:label "compact to relative";
+  rdfs:comment """
+    If set to `false`, the JSON-LD processor will not attempt to compact using document-relative IRIs.
+  """ ;
+  rdfs:domain	 :Option ;
+  rdfs:range   xsd:boolean .
+
+:expandContext a rdf:Property ;
+  rdfs:label "expand context";
+  rdfs:comment "A context that is used to initialize the active context when expanding a document." ;
+  rdfs:domain	 :Option ;
+  rdfs:range   rdfs:Resource .
+
+:processingMode a rdf:Property ;
+  rdfs:label "processing mode";
+  rdfs:comment """
+    If set to "json-ld-1.1", the JSON-LD processor must produce exactly the same results as
+    the algorithms defined in this specification.
+    If set to another value, the JSON-LD processor is allowed to extend or modify
+    the algorithms defined in this specification to enable application-specific optimizations.
+    The definition of such optimizations is beyond the scope of this specification and thus not defined.
+    Consequently, different implementations may implement different optimizations.
+    Developers must not define modes beginning with json-ld as they are reserved for future versions of this specification.
+  """ ;
+  rdfs:domain	 :Option ;
+  rdfs:range   xsd:string .
+
+:produceGeneralizedRdf a rdf:Property ;
+  rdfs:label "produce generalized RDF";
+  rdfs:comment "Unless the produce generalized RDF flag is set to true, RDF triples containing a blank node predicate are excluded from output." ;
+  rdfs:domain	 :Option ;
+  rdfs:range   xsd:boolean .
+
+:useNativeTypes a rdf:Property ;
+  rdfs:label "use native types";
+  rdfs:comment """
+    If the _use native types_ flag is set to `true`, RDF literals with a datatype IRI that
+    equal `xsd:integer` or `xsd:double` are converted to a JSON numbers and RDF literals
+    with a datatype IRI that equals `xsd:boolean` are converted to `true` or `false` based
+    on their lexical form.
+    """ ;
+  rdfs:domain	 :Option ;
+  rdfs:range   xsd:boolean .
+
+:useRdfType a rdf:Property ;
+  rdfs:label "use RDF types";
+  rdfs:comment """
+    If the _use rdf type_ flag is set to `true`, statements with an `rdf:type` predicate
+    will not use `@type`, but will be transformed as a normal property.
+    """ ;
+  rdfs:domain	 :Option ;
+  rdfs:range   xsd:boolean .
+
+:contentType a rdf:Property ;
+  rdfs:label "content type";
+  rdfs:comment """
+    The HTTP Content-Type used for the input file, in case it is a non-registered type.
+    """ ;
+  rdfs:domain	 :Option ;
+  rdfs:range   xsd:boolean .
+
+:redirectTo a rdf:Property ;
+  rdfs:label "redirect to";
+  rdfs:comment """
+    The location of a URL for redirection. A request made of the input file must be redirected
+    to the designated URL.
+    """ ;
+  rdfs:domain	 :Option ;
+  rdfs:range   xsd:boolean .
+
+:httpAccept a rdf:Property ;
+  rdfs:label "HTTP Accept";
+  rdfs:comment """
+    An HTTP Accept header.
+    """ ;
+  rdfs:domain	 :Option ;
+  rdfs:range   xsd:boolean .
+
+:httpLink a rdf:Property ;
+  rdfs:label "HTTP link";
+  rdfs:comment """
+    An HTTP Link header to be added to the result of requesting the input file.
+    """ ;
+  rdfs:domain	 :Option ;
+  rdfs:range   xsd:boolean .
+
+:httpStatus a rdf:Property ;
+  rdfs:label "HTTP status";
+  rdfs:comment """
+    The HTTP status code that must be returned when the input file is requested. This
+    is typically used along with the `redirectTo` property.
+    """ ;
+  rdfs:domain	 :Option ;
+  rdfs:range   xsd:boolean .
+
+:specVersion a rdf:Property ;
+  rdfs:label "spec version";
+  rdfs:comment """
+    Indicates the JSON-LD version to which the test applies, rather than the
+    specific processing mode. Values are "json-ld-1.0", and "json-ld-1.1". If not set, the
+    test is presumed to be valid for all versions of JSON-LD. In cases where
+    results differ between spec versions for the same test, the test will have
+    both a "1.0" and "1.1" version, for example.
+  """ ;
+  rdfs:domain	 :Option ;
+  rdfs:range   xsd:string .

--- a/tests/vocab_context.jsonld
+++ b/tests/vocab_context.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "mf": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "jld": "https://json-ld.org/test-suite/vocab#",
+    "jld:Test": {"@type": "@id"},
+    "dc:identifier": {"@type": "@id"},
+    "rdfs:subClassOf": {"@type": "@id"},
+    "rdfs:domain": {"@type": "@id"},
+    "rdfs:range": {"@type": "@id"}
+  }
+}

--- a/tests/vocab_template.haml
+++ b/tests/vocab_template.haml
@@ -1,0 +1,39 @@
+%html{lang: :en}
+  %head
+    %meta{charset: 'utf-8'}
+    %title<= ontology['dc:title']
+    %link{href: "http://www.w3.org/StyleSheets/2016/base.css", rel: :stylesheet}
+    %script{type: 'application/ld+json'}
+      = source
+  %body
+    %h1<=ontology['dc:title']
+    %p<
+      %a{href: 'http://www.w3.org/'}<
+        %img(src="http://www.w3.org/Icons/w3c_home" alt="W3C" height="48" width="72")
+    %p
+      Alternate versions of the test vocabulary definition exist in
+      %a(rel="alternate" href="vocab.ttl")<="Turtle"
+      and
+      = " "
+      %a(rel="alternate" href="vocab.jsonld")<>="JSON-LD"
+      = "."
+    %section
+      %h2<="Test Case Classes"
+      %dl
+        - classes.each do |cls|
+          %dt<
+            %strong<~cls["rdfs:label"]
+          %dd<
+            :markdown
+              #{cls["rdfs:comment"].to_s.gsub(/^\s+/, '')}
+    %section
+      %h2<="Test Case Properties"
+      %dl
+        - properties.each do |prop|
+          %dt<
+            %strong<~prop["rdfs:label"]
+          %dd<
+            :markdown
+              #{prop["rdfs:comment"].to_s.gsub(/^\s+/, '')}
+    %footer
+      %span<= ontology["dc:publisher"]


### PR DESCRIPTION
This allows for changing the vocabulary for WG purposes rather than depending on the CG version.

Change is localized to the `@context` used in the main test manifest; no change for test runners using the JSON representation of the manifests.