### PR TITLE
Relative vocab

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 dist: trusty
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 jobs:
   include:
     - stage: common

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,13 @@
 GIT
   remote: git://github.com/ruby-rdf/json-ld.git
-  revision: a26c3205d006550f85162848a4a2bc3366b39970
+  revision: afe7b3b10547b552676d1379a2be4bc34cf83d02
   branch: develop
   specs:
     json-ld (3.0.2)
+      link_header (~> 0.0, >= 0.0.8)
       multi_json (~> 1.13)
-      rdf (~> 3.0, >= 3.0.4)
+      rack (>= 1.6, < 3.0)
+      rdf (~> 3.0, >= 3.0.8)
 
 GEM
   remote: https://rubygems.org/
@@ -16,7 +18,7 @@ GEM
       i18n
     builder (3.2.3)
     colorize (0.8.1)
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.1.4)
     connection_pool (2.2.2)
     ebnf (1.1.3)
       rdf (~> 3.0)
@@ -29,7 +31,7 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     htmlentities (4.3.4)
-    i18n (1.1.1)
+    i18n (1.5.1)
       concurrent-ruby (~> 1.0)
     json-ld-preloaded (3.0.2)
       json-ld (~> 3.0)
@@ -67,17 +69,18 @@ GEM
       shex (~> 0.5, >= 0.5.2)
       sparql (~> 3.0)
       sparql-client (~> 3.0)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     multi_json (1.13.1)
     net-http-persistent (3.0.0)
       connection_pool (~> 2.2)
-    nokogiri (1.8.5)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.10.0)
+      mini_portile2 (~> 2.4.0)
     nokogumbo (1.5.0)
       nokogiri
     public_suffix (3.0.3)
+    rack (2.0.6)
     rake (12.3.2)
-    rdf (3.0.7)
+    rdf (3.0.9)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
     rdf-aggregate-repo (2.2.1)
@@ -166,4 +169,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/common/terms.html
+++ b/common/terms.html
@@ -335,5 +335,5 @@
     A <a>value object</a> is a <a>dictionary</a> that has an <code>@value</code> <a>member</a>.</dd>
   <dt><dfn>vocabulary mapping</dfn></dt><dd>
     The vocabulary mapping is set in the <a>context</a> using the <code>@vocab</code> key
-    whose value MUST be an <a>absolute IRI</a> or <code>null</code>.</dd>
+    whose value MUST be an <a>IRI</a> or <code>null</code>.</dd>
 </dl>

--- a/index.html
+++ b/index.html
@@ -1092,14 +1092,12 @@
                   <code>@vocab</code> <a>member</a>.</li>
                 <li>If <var>value</var> is <a>null</a>, remove
                   any <a>vocabulary mapping</a> from <var>result</var>.</li>
-                <li class="changed">Otherwise, if <var>value</var>
-                  the empty string (<code>&quot;&quot;</code>),
-                  the effective value is the current <a>base IRI</a>.</li>
                 <li>Otherwise, if <var>value</var> is
-                  an <a>absolute IRI</a>
+                  an <a>IRI</a>
                   or <a>blank node identifier</a>, the <a>vocabulary mapping</a>
-                  of <var>result</var> is set to <var>value</var>. If it is not
-                  an <a>absolute IRI</a>, or a <a>blank node identifier</a>, an
+                  of <var>result</var> is set to <var>value</var>,
+                  <span class="changed">expanding relative to the <a>base IRI</a>, if it is a <a>relative IRI</a></span>.
+                  If it is not an <a>IRI</a>, or a <a>blank node identifier</a>, an
                   <a data-link-for="JsonLdErrorCode">invalid vocab mapping</a>
                   error has been detected and processing is aborted.
                   <div class="issue atrisk">The use of <a>blank node identifiers</a> to value for <code>@vocab</code> is obsolete,
@@ -5520,7 +5518,7 @@
           i.e., it is neither a <a>scalar</a> nor <code>null</code>.</dd>
         <dt><dfn>invalid vocab mapping</dfn></dt>
         <dd>An invalid <a>vocabulary mapping</a> has been detected,
-          i.e., it is neither an <a>absolute IRI</a> nor <code>null</code>.</dd>
+          i.e., it is neither an <a>IRI</a> nor <code>null</code>.</dd>
         <dt><dfn>keyword redefinition</dfn></dt>
         <dd>A <a>keyword</a> redefinition has been detected.</dd>
         <dt><dfn>loading document failed</dfn></dt>

--- a/index.html
+++ b/index.html
@@ -1095,8 +1095,14 @@
                 <li>Otherwise, if <var>value</var> is
                   an <a>IRI</a>
                   or <a>blank node identifier</a>, the <a>vocabulary mapping</a>
-                  of <var>result</var> is set to <var>value</var>,
-                  <span class="changed">expanding relative to the <a>base IRI</a>, if it is a <a>relative IRI</a></span>.
+                  of <var>result</var> is set to
+                  <span class="changed">the result of using the 
+                    <a href="#iri-expansion">IRI Expansion algorithm</a>,
+                    passing <var>result</var> as the <a>active context</a>,
+                    <var>value</var>,
+                    <code>true</code> for <var>vocab</var>, and
+                    <code>true</code> for <var>document relative</var>.
+                  </span>.
                   If it is not an <a>IRI</a>, or a <a>blank node identifier</a>, an
                   <a data-link-for="JsonLdErrorCode">invalid vocab mapping</a>
                   error has been detected and processing is aborted.

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -897,6 +897,14 @@
       "expect": "compact/0106-out.jsonld",
       "option": {"processingMode": "json-ld-1.0", "specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#t0107",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Relative propererty IRIs with @vocab: ''",
+      "purpose": "Complex use cases for relative IRI compaction or properties",
+      "input": "compact/0107-in.jsonld",
+      "context": "compact/0107-context.jsonld",
+      "expect": "compact/0107-out.jsonld"
+    }, {
       "@id": "#tc001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "adding new term",

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -616,7 +616,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Compact using relative fragment identifier",
       "purpose": "Compacting a relative round-trips",
-      "option": {"base": "http://example.org/"},
+      "option": {"processingMode": "json-ld-1.0", "base": "http://example.org/"},
       "input": "compact/0075-in.jsonld",
       "context": "compact/0075-context.jsonld",
       "expect": "compact/0075-out.jsonld"

--- a/tests/compact/0107-context.jsonld
+++ b/tests/compact/0107-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@base": "http://example.com/some/",
+    "@vocab": "other/"
+  }
+}

--- a/tests/compact/0107-in.jsonld
+++ b/tests/compact/0107-in.jsonld
@@ -1,0 +1,13 @@
+[
+  {
+    "@id": "http://example.com/some/deep/directory/and/relativePropertyIris",
+    "http://example.com/absolute": [{"@value": "/absolute"}],
+    "http://example.com/some/other/deep/directory/": [{"@value": "deep/directory"}],
+    "http://example.com/some/other/deep/directory/and/": [{"@value": "deep/directory/and/"}],
+    "http://example.com/some/other/#fragment-works": [{"@value": "#fragment-works"}],
+    "http://example.com/some/other/?query=works": [{"@value": "?query=works"}],
+    "http://example.com/some/other/link": [{"@value": "link"}],
+    "http://example.com/some/other/../parent": [{"@value": "../parent"}],
+    "http://example.com/too-many-dots": [{"@value": "too-many-dots"}]
+  }
+]

--- a/tests/compact/0107-out.jsonld
+++ b/tests/compact/0107-out.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@base": "http://example.com/some/",
+    "@vocab": "other/"
+  },
+  "#fragment-works": "#fragment-works",
+  "../parent": "../parent",
+  "?query=works": "?query=works",
+  "@id": "deep/directory/and/relativePropertyIris",
+  "deep/directory/": "deep/directory",
+  "deep/directory/and/": "deep/directory/and/",
+  "http://example.com/absolute": "/absolute",
+  "http://example.com/too-many-dots": "too-many-dots",
+  "link": "link"
+}

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -811,6 +811,13 @@
       "input": "expand/0109-in.jsonld",
       "expect": "expand/0109-out.jsonld"
     }, {
+      "@id": "#t0110",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Various relative IRIs as properties with with relative @vocab",
+      "purpose": "Pathological relative property IRIs",
+      "input": "expand/0110-in.jsonld",
+      "expect": "expand/0110-out.jsonld"
+    }, {
       "@id": "#tc001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "adding new term",

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -270,6 +270,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "Expanding blank node labels",
       "purpose": "Blank nodes are not relabeled during expansion",
+      "option": {"processingMode": "json-ld-1.0"},
       "input": "expand/0038-in.jsonld",
       "expect": "expand/0038-out.jsonld"
     }, {
@@ -528,6 +529,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "@vocab as blank node identifier",
       "purpose": "Use @vocab to map all properties to blank node identifiers",
+      "option": {"processingMode": "json-ld-1.0"},
       "input": "expand/0075-in.jsonld",
       "expect": "expand/0075-out.jsonld"
     }, {

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -818,6 +818,20 @@
       "input": "expand/0110-in.jsonld",
       "expect": "expand/0110-out.jsonld"
     }, {
+      "@id": "#t0111",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Various relative IRIs as properties with with relative @vocab itself relative to an existing vocabulary base",
+      "purpose": "Pathological relative property IRIs",
+      "input": "expand/0111-in.jsonld",
+      "expect": "expand/0111-out.jsonld"
+    }, {
+      "@id": "#t0112",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Various relative IRIs as properties with with relative @vocab relative to another relative vocabulary base",
+      "purpose": "Pathological relative property IRIs",
+      "input": "expand/0112-in.jsonld",
+      "expect": "expand/0112-out.jsonld"
+    }, {
       "@id": "#tc001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "adding new term",

--- a/tests/expand/0110-in.jsonld
+++ b/tests/expand/0110-in.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@base": "http://example.com/some/deep/directory/and/file/",
+    "@vocab": "/relative"
+  },
+  "@id": "relativePropertyIris",
+  "link": "link",
+  "#fragment-works": "#fragment-works",
+  "?query=works": "?query=works",
+  "./": "./",
+  "../": "../",
+  "../parent": "../parent",
+  "../../parent-parent-eq-root": "../../parent-parent-eq-root",
+  "../../../../../still-root": "../../../../../still-root",
+  "../.././.././../../too-many-dots": "../.././.././../../too-many-dots",
+  "/absolute": "/absolute",
+  "//example.org/scheme-relative": "//example.org/scheme-relative"
+}

--- a/tests/expand/0110-out.jsonld
+++ b/tests/expand/0110-out.jsonld
@@ -1,0 +1,16 @@
+[
+  {
+    "@id": "http://example.com/some/deep/directory/and/file/relativePropertyIris",
+    "http://example.com/relative#fragment-works": [{"@value": "#fragment-works"}],
+    "http://example.com/relative../": [{"@value": "../"}],
+    "http://example.com/relative../../../../../still-root": [{"@value": "../../../../../still-root"}],
+    "http://example.com/relative../.././.././../../too-many-dots": [{"@value": "../.././.././../../too-many-dots"}],
+    "http://example.com/relative../../parent-parent-eq-root": [{"@value": "../../parent-parent-eq-root"}],
+    "http://example.com/relative../parent": [{"@value": "../parent"}],
+    "http://example.com/relative./": [{"@value": "./"}],
+    "http://example.com/relative//example.org/scheme-relative": [{"@value": "//example.org/scheme-relative"}],
+    "http://example.com/relative/absolute": [{"@value": "/absolute"}],
+    "http://example.com/relative?query=works": [{"@value": "?query=works"}],
+    "http://example.com/relativelink": [{"@value": "link"}]
+  }
+]

--- a/tests/expand/0111-in.jsonld
+++ b/tests/expand/0111-in.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": [{
+    "@base": "http://example.com/some/deep/directory/and/file/",
+    "@vocab": "http://example.com/vocabulary/"
+  }, {
+    "@vocab": "./rel2#"
+  }],
+  "@id": "relativePropertyIris",
+  "link": "link",
+  "#fragment-works": "#fragment-works",
+  "?query=works": "?query=works",
+  "./": "./",
+  "../": "../",
+  "../parent": "../parent",
+  "../../parent-parent-eq-root": "../../parent-parent-eq-root",
+  "../../../../../still-root": "../../../../../still-root",
+  "../.././.././../../too-many-dots": "../.././.././../../too-many-dots",
+  "/absolute": "/absolute",
+  "//example.org/scheme-relative": "//example.org/scheme-relative"
+}

--- a/tests/expand/0111-out.jsonld
+++ b/tests/expand/0111-out.jsonld
@@ -1,0 +1,16 @@
+[
+  {
+    "@id": "http://example.com/some/deep/directory/and/file/relativePropertyIris",
+    "http://example.com/vocabulary/./rel2##fragment-works": [{"@value": "#fragment-works"}],
+    "http://example.com/vocabulary/./rel2#../": [{"@value": "../"}],
+    "http://example.com/vocabulary/./rel2#../../../../../still-root": [{"@value": "../../../../../still-root"}],
+    "http://example.com/vocabulary/./rel2#../.././.././../../too-many-dots": [{"@value": "../.././.././../../too-many-dots"}],
+    "http://example.com/vocabulary/./rel2#../../parent-parent-eq-root": [{"@value": "../../parent-parent-eq-root"}],
+    "http://example.com/vocabulary/./rel2#../parent": [{"@value": "../parent"}],
+    "http://example.com/vocabulary/./rel2#./": [{"@value": "./"}],
+    "http://example.com/vocabulary/./rel2#//example.org/scheme-relative": [{"@value": "//example.org/scheme-relative"}],
+    "http://example.com/vocabulary/./rel2#/absolute": [{"@value": "/absolute"}],
+    "http://example.com/vocabulary/./rel2#?query=works": [{"@value": "?query=works"}],
+    "http://example.com/vocabulary/./rel2#link": [{"@value": "link"}]
+  }
+]

--- a/tests/expand/0112-in.jsonld
+++ b/tests/expand/0112-in.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": [{
+    "@base": "http://example.com/some/deep/directory/and/file/",
+    "@vocab": "/rel1"
+  }, {
+    "@vocab": "./rel2#"
+  }],
+  "@id": "relativePropertyIris",
+  "link": "link",
+  "#fragment-works": "#fragment-works",
+  "?query=works": "?query=works",
+  "./": "./",
+  "../": "../",
+  "../parent": "../parent",
+  "../../parent-parent-eq-root": "../../parent-parent-eq-root",
+  "../../../../../still-root": "../../../../../still-root",
+  "../.././.././../../too-many-dots": "../.././.././../../too-many-dots",
+  "/absolute": "/absolute",
+  "//example.org/scheme-relative": "//example.org/scheme-relative"
+}

--- a/tests/expand/0112-out.jsonld
+++ b/tests/expand/0112-out.jsonld
@@ -1,0 +1,16 @@
+[
+  {
+    "@id": "http://example.com/some/deep/directory/and/file/relativePropertyIris",
+    "http://example.com/rel1./rel2##fragment-works": [{"@value": "#fragment-works"}],
+    "http://example.com/rel1./rel2#../": [{"@value": "../"}],
+    "http://example.com/rel1./rel2#../../../../../still-root": [{"@value": "../../../../../still-root"}],
+    "http://example.com/rel1./rel2#../.././.././../../too-many-dots": [{"@value": "../.././.././../../too-many-dots"}],
+    "http://example.com/rel1./rel2#../../parent-parent-eq-root": [{"@value": "../../parent-parent-eq-root"}],
+    "http://example.com/rel1./rel2#../parent": [{"@value": "../parent"}],
+    "http://example.com/rel1./rel2#./": [{"@value": "./"}],
+    "http://example.com/rel1./rel2#//example.org/scheme-relative": [{"@value": "//example.org/scheme-relative"}],
+    "http://example.com/rel1./rel2#/absolute": [{"@value": "/absolute"}],
+    "http://example.com/rel1./rel2#?query=works": [{"@value": "?query=works"}],
+    "http://example.com/rel1./rel2#link": [{"@value": "link"}]
+  }
+]

--- a/tests/flatten-manifest.jsonld
+++ b/tests/flatten-manifest.jsonld
@@ -263,6 +263,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
       "name": "Flattening blank node labels",
       "purpose": "Blank nodes are not relabeled during expansion",
+      "option": {"processingMode": "json-ld-1.0"},
       "input": "flatten/0038-in.jsonld",
       "expect": "flatten/0038-out.jsonld"
     }, {

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -515,6 +515,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
       "name": "Drop blank node predicates by default",
       "purpose": "Triples with blank node predicates are dropped by default.",
+      "option": {"processingMode": "json-ld-1.0"},
       "input": "toRdf/0078-in.jsonld",
       "expect": "toRdf/0078-out.nq"
     }, {
@@ -796,6 +797,7 @@
       "name": "produce generalized RDF flag",
       "purpose": "Triples with blank node predicates are not dropped if the produce generalized RDF flag is true.",
       "option": {
+        "processingMode": "json-ld-1.0",
         "produceGeneralizedRdf": true
       },
       "input": "toRdf/0118-in.jsonld",


### PR DESCRIPTION
This update spec and tests to allow any relative IRI as the value of `@vocab`, not just the empty string.

For w3c/json-ld-syntax#72.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/58.html" title="Last updated on Jan 12, 2019, 10:23 PM UTC (460c0a9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/58/22aed10...460c0a9.html" title="Last updated on Jan 12, 2019, 10:23 PM UTC (460c0a9)">Diff</a>