### PR TITLE
Issue 14 circular imports

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/ruby-rdf/json-ld.git
-  revision: afe7b3b10547b552676d1379a2be4bc34cf83d02
+  revision: 6bb0c2d269e8cf80152d519ee5fd16696812b1f2
   branch: develop
   specs:
     json-ld (3.0.2)
@@ -12,7 +12,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     bcp47 (0.3.3)
       i18n
@@ -31,7 +31,7 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     htmlentities (4.3.4)
-    i18n (1.5.1)
+    i18n (1.5.3)
       concurrent-ruby (~> 1.0)
     json-ld-preloaded (3.0.2)
       json-ld (~> 3.0)
@@ -73,14 +73,14 @@ GEM
     multi_json (1.13.1)
     net-http-persistent (3.0.0)
       connection_pool (~> 2.2)
-    nokogiri (1.10.0)
+    nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
     nokogumbo (1.5.0)
       nokogiri
     public_suffix (3.0.3)
     rack (2.0.6)
     rake (12.3.2)
-    rdf (3.0.9)
+    rdf (3.0.10)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
     rdf-aggregate-repo (2.2.1)
@@ -126,7 +126,7 @@ GEM
       rdf-turtle (~> 3.0, >= 3.0.3)
     rdf-trix (2.2.1)
       rdf (>= 2.2, < 4.0)
-    rdf-turtle (3.0.3)
+    rdf-turtle (3.0.5)
       ebnf (~> 1.1)
       rdf (~> 3.0)
     rdf-vocab (3.0.4)

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+require 'bundler/setup'
 task default: :test
 
 desc "Test examples in spec files"

--- a/common/terms.html
+++ b/common/terms.html
@@ -112,6 +112,16 @@
     Whenever possible, an <a>edge</a> should be labeled with an <a>IRI</a>.
     <div class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
       and may be removed in a future version of JSON-LD.</div></dd>
+  <dt><dfn>embedded context</dfn></dt><dd>
+    An embedded <a>context</a> is a <a>dictionary</a> composed of a combintation of
+    <a>term definitions</a>, a <a>vocabulary mapping</a>, a <a>base IRI</a> and <a>default language</a>.
+    An <a>embedded context</a> may appear as part of a <a>node object</a> or <a>value object</a> using the
+    <code>@context</code> <a>member</a>.
+  </dd>
+  <dt><dfn>scoped context</dfn></dt><dd>
+    A <a>scoped context</a> is part of an <a>expanded term definition</a> using the
+    <code>@context</code> <a>member</a>. It has the same form as an <a>embedded context</a>.
+  </dd>
   <dt><dfn>expanded term definition</dfn></dt><dd>
     An expanded term definition is a <a>term definition</a>
     where the value is a <a>dictionary</a>
@@ -150,7 +160,8 @@
     is a <a>graph object</a> which does not have an <code>@id</code> <a>member</a>.
     Note that <a>node objects</a> may have a <code>@graph</code> member,
     but are not considered <a>graph objects</a> if they include any other <a>members</a>.
-    A top-level object consisting of <code>@graph</code> is also not a <a>graph object</a>.</dd>
+    A top-level object consisting of <code>@graph</code> is also not a <a>graph object</a>.
+    Note that a <a>node object</a> may also represent a <a>named graph</a> it it includes other properties.</dd>
   <dt><dfn>index map</dfn></dt><dd>
     An <a>index map</a> is a <a>dictionary</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@index</code>,
@@ -212,7 +223,8 @@
     A <a>list</a> is an ordered sequence of <a>IRIs</a>, <a>blank nodes</a>, and <a>JSON-LD values</a>.
     See <dfn data-cite="RDF-SCHEMA#ch_collectionvocab" data-lt="collection" class="preserve">RDF collection</dfn> in [[RDF-SCHEMA]].</dd>
   <dt><dfn>list object</dfn></dt><dd>
-    A <a>list object</a> is a <a>dictionary</a> that has a <code>@list</code> key.</dd>
+    A <a>list object</a> is a <a>dictionary</a> that has a <code>@list</code> key.
+    It may also have an <code>@index</code> key, but no other members.</dd>
   <dt><dfn>literal</dfn></dt><dd>
     An <a>object</a> expressed as a value such as a string, number or in expanded form.</dd>
   <dt><dfn>local context</dfn></dt><dd>
@@ -294,7 +306,8 @@
     are resolved relative to the <a>vocabulary mapping</a>,
     not the <a>base IRI</a>.</dd>
   <dt><dfn>set object</dfn></dt><dd>
-    A <a>set object</a> is a <a>dictionary</a> that has an <code>@set</code> <a>member</a>.</dd>
+    A <a>set object</a> is a <a>dictionary</a> that has an <code>@set</code> <a>member</a>.
+    It may also have an <code>@index</code> key, but no other members.</dd>
   <dt><dfn>subject</dfn></dt><dd>
     A <a data-cite="RDF11-CONCEPTS#dfn-subject" class="externalDFN">subject</a>
     is a <a>node</a> in a <a>linked data graph</a>

--- a/index.html
+++ b/index.html
@@ -1030,8 +1030,9 @@
                   characters are treated in URI references, per
                   <a data-cite="RFC3987#section-6.5">section 6.5</a>
                   of [[RFC3987]].</li>
-                <li>If <var>context</var> is in the <var>remote contexts</var> array, a
-                  <a data-link-for="JsonLdErrorCode">recursive context inclusion</a>
+                <li>If the number of entries in the <var>remote contexts</var> array
+                  exceeds a processor defined limit, a
+                  <a data-link-for="JsonLdErrorCode">context overflow</a>
                   error has been detected and processing is aborted;
                   otherwise, add <var>context</var> to <var>remote contexts</var>.</li>
                 <li class="changed">If <var>context</var> was previously dereferenced,
@@ -5437,7 +5438,7 @@
             "loading remote context failed",
             "multiple context link headers",
             "processing mode conflict",
-            "recursive context inclusion"
+            "context overflow"
         };
       --></pre>
 
@@ -5551,8 +5552,8 @@
         <dt><dfn>processing mode conflict</dfn></dt>
         <dd>An attempt was made to change the <a>processing mode</a>
           which is incompatible with the previous specified version.</dd>
-        <dt><dfn>recursive context inclusion</dfn></dt>
-        <dd>A cycle in remote context inclusions has been detected.</dd>
+        <dt><dfn>context overflow</dfn></dt>
+        <dd>maximum number of <code>@context</code> URLs exceeded.</dd>
       </dl>
     </section>
   </section> <!-- end of Error Handling -->
@@ -5680,6 +5681,8 @@
       or all <a>JSON-LD script elements</a>.</li>
     <li>Added <a data-link-for="RemoteDocument">contentType</a> field to <a>RemoteDocument</a>.</li>
     <li>Added support for sealed <a>contexts</a> and <a>term definitions</a>.</li>
+    <li>Because scoped contexts can lead to contexts being reloaded, replace the
+      <strong>recursive context inclusion</strong> error with a <a data-link-for="JsonLdErrorCode">context overflow</a> error.</li>
   </ul>
 </section>
 

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -932,14 +932,16 @@
       "name": "A context may not include itself recursively (direct)",
       "purpose": "Verifies that an exception is raised on expansion when processing a context referencing itself",
       "input": "expand/e002-in.jsonld",
-      "expect": "recursive context inclusion"
+      "expect": "recursive context inclusion",
+      "option": {"specVersion": "json-ld-1.0"}
     }, {
       "@id": "#te003",
       "@type": [ "jld:NegativeEvaluationTest", "jld:ExpandTest" ],
       "name": "A context may not include itself recursively (indirect)",
       "purpose": "Verifies that an exception is raised on expansion when processing a context referencing itself indirectly",
       "input": "expand/e003-in.jsonld",
-      "expect": "recursive context inclusion"
+      "expect": "recursive context inclusion",
+      "option": {"specVersion": "json-ld-1.0"}
     }, {
       "@id": "#te004",
       "@type": [ "jld:NegativeEvaluationTest", "jld:ExpandTest" ],


### PR DESCRIPTION
Note, as the text says that the depth of inclusion is processor defined, there are no new tests for this, and the old expansion tests that looked for recursive context inclusion are now 1.0 only.

For #14.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/62.html" title="Last updated on Feb 16, 2019, 8:49 PM UTC (0d72f9d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/62/a1e1e30...0d72f9d.html" title="Last updated on Feb 16, 2019, 8:49 PM UTC (0d72f9d)">Diff</a>