### PR TITLE
Add literal value tests.

### DIFF
--- a/tests/fromRdf-manifest.jsonld
+++ b/tests/fromRdf-manifest.jsonld
@@ -175,6 +175,20 @@
       "input": "fromRdf/0023-in.nq",
       "expect": "fromRdf/0023-out.jsonld"
     }, {
+      "@id": "#t0024",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
+      "name": "multiple languages for same subject+property+value",
+      "purpose": "Uniqness of triples should include the value language",
+      "input": "fromRdf/0024-in.nq",
+      "expect": "fromRdf/0024-out.jsonld"
+    }, {
+      "@id": "#t0025",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
+      "name": "multiple types for same subject+property+value",
+      "purpose": "Uniqness of triples should include the value type",
+      "input": "fromRdf/0025-in.nq",
+      "expect": "fromRdf/0025-out.jsonld"
+    }, {
       "@id": "#tli01",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
       "name": "@list containing empty @list",

--- a/tests/fromRdf/0024-in.nq
+++ b/tests/fromRdf/0024-in.nq
@@ -1,0 +1,2 @@
+<http://example.com> <http://example.com/label> "test"@en .
+<http://example.com> <http://example.com/label> "test"@fr .

--- a/tests/fromRdf/0024-out.jsonld
+++ b/tests/fromRdf/0024-out.jsonld
@@ -1,0 +1,15 @@
+[
+  {
+    "@id": "http://example.com",
+    "http://example.com/label": [
+      {
+        "@value": "test",
+        "@language": "en"
+      },
+      {
+        "@value": "test",
+        "@language": "fr"
+      }
+    ]
+  }
+]

--- a/tests/fromRdf/0025-in.nq
+++ b/tests/fromRdf/0025-in.nq
@@ -1,0 +1,2 @@
+<http://example.com> <http://example.com/label> "test"^^<http://example.com/t1> .
+<http://example.com> <http://example.com/label> "test"^^<http://example.com/t2> .

--- a/tests/fromRdf/0025-out.jsonld
+++ b/tests/fromRdf/0025-out.jsonld
@@ -1,0 +1,15 @@
+[
+  {
+    "@id": "http://example.com",
+    "http://example.com/label": [
+      {
+        "@value": "test",
+        "@type": "http://example.com/t1"
+      },
+      {
+        "@value": "test",
+        "@type": "http://example.com/t2"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
- Add tests for triples with same the subject, property and value but
  different languages or datatypes. Helps to expose possible N-Quads
  parsing bugs.
- Used to check and fix https://github.com/digitalbazaar/jsonld.js/issues/293.