### PR TITLE
Fix remote-doc-manifest context.

### DIFF
--- a/tests/remote-doc-manifest.jsonld
+++ b/tests/remote-doc-manifest.jsonld
@@ -1,5 +1,5 @@
 {
-  "@context": "https://w3c.github.io/json-ld-api/context.jsonld",
+  "@context": "https://w3c.github.io/json-ld-api/tests/context.jsonld",
   "@id": "",
   "@type": "mf:Manifest",
   "name": "Remote document",


### PR DESCRIPTION
Looks like this context should point at a valid URL.