### PR TITLE
Add JavaScript Object property name tests.

### DIFF
--- a/common/jsonld.js
+++ b/common/jsonld.js
@@ -15,6 +15,14 @@ const jsonld = {
       authors: ['Domenic Denicola'],
       status: 'unofficial',
       date: 'January 2014'
+    },
+    "JCS": {
+      title: "JSON Canonicalization Scheme (JCS)",
+      href: 'https://tools.ietf.org/html/draft-rundgren-json-canonicalization-scheme-05#page-6',
+      authors: ['A. Rundgren', 'B. Jordan', 'S. Erdtman'],
+      publisher: 'Network Working Group',
+      status: 'Internet-Draft',
+      date: 'February 16, 2019'
     }
   },
   conversions: {

--- a/common/terms.html
+++ b/common/terms.html
@@ -335,6 +335,12 @@
     the value MUST be a <a>node object</a>, or <a>array</a> of node objects.
     If the value contains a <a>term</a> expanding to <code>@type</code>,
     it's values are merged with the map value when expanding.</dd>
+  <dt><dfn>JSON literal</dfn></dt><dd>
+    A <a>JSON literal</a> is a <a>typed literal</a> where the associated <a>IRI</a> is <code>jsonld:JSON</code>.
+    In the <a>value object</a> representation, the value of <code>@type</code> is <code>@json</code>.
+    JSON literals represent values which are valid [[JSON]].
+    See <dfn data-cite="JSON-LD11#dfn-json-datatype" class="preserve">JSON datatype</dfn> in [[JSON-LD11]].
+  </dd>
   <dt><dfn>typed literal</dfn></dt><dd>
     A <a>typed literal</a> is a <a>literal</a> with an associated <a>IRI</a>
     which indicates the literal's datatype.

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -905,6 +905,16 @@
       "context": "compact/0107-context.jsonld",
       "expect": "compact/0107-out.jsonld"
     }, {
+      "@id": "#t0108",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Relative propererty IRIs with @vocab: ''",
+      "purpose": "Complex use cases for relative IRI compaction or properties",
+      "name": "context with JavaScript Object property names",
+      "purpose": "Compact with context including JavaScript Object property names",
+      "input": "compact/0108-in.jsonld",
+      "context": "compact/0108-context.jsonld",
+      "expect": "compact/0108-out.jsonld"
+    }, {
       "@id": "#tc001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "adding new term",

--- a/tests/compact/0108-context.jsonld
+++ b/tests/compact/0108-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "valueOf": "http://example.org/valueOf",
+    "toString": "http://example.org/toString"
+  }
+}

--- a/tests/compact/0108-in.jsonld
+++ b/tests/compact/0108-in.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "valueOf": "http://example.org/valueOf",
+    "toString": "http://example.org/toString"
+  },
+  "valueOf": "first",
+  "toString": "second"
+}

--- a/tests/compact/0108-out.jsonld
+++ b/tests/compact/0108-out.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "valueOf": "http://example.org/valueOf",
+    "toString": "http://example.org/toString"
+  },
+  "valueOf": "first",
+  "toString": "second"
+}

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -832,6 +832,13 @@
       "input": "expand/0112-in.jsonld",
       "expect": "expand/0112-out.jsonld"
     }, {
+      "@id": "#t0113",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "context with JavaScript Object property names",
+      "purpose": "Expand with context including JavaScript Object property names",
+      "input": "expand/0113-in.jsonld",
+      "expect": "expand/0113-out.jsonld"
+    }, {
       "@id": "#tc001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "adding new term",

--- a/tests/expand/0113-in.jsonld
+++ b/tests/expand/0113-in.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "valueOf": "http://example.org/valueOf",
+    "toString": "http://example.org/toString"
+  },
+  "valueOf": "first",
+  "toString": "second"
+}

--- a/tests/expand/0113-out.jsonld
+++ b/tests/expand/0113-out.jsonld
@@ -1,0 +1,14 @@
+[
+  {
+    "http://example.org/toString": [
+      {
+        "@value": "second"
+      }
+    ],
+    "http://example.org/valueOf": [
+      {
+        "@value": "first"
+      }
+    ]
+  }
+]

--- a/tests/flatten-manifest.jsonld
+++ b/tests/flatten-manifest.jsonld
@@ -342,6 +342,13 @@
       "input": "flatten/0048-in.jsonld",
       "expect": "flatten/0048-out.jsonld"
     }, {
+      "@id": "#t0049",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
+      "name": "context with JavaScript Object property names",
+      "purpose": "Flatten with context including JavaScript Object property names",
+      "input": "flatten/0049-in.jsonld",
+      "expect": "flatten/0049-out.jsonld"
+    }, {
       "@id": "#te001",
       "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
       "name": "Conflicting indexes",

--- a/tests/flatten/0049-in.jsonld
+++ b/tests/flatten/0049-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "valueOf": "http://example.org/valueOf",
+    "toString": "http://example.org/toString"
+  },
+  "@id": "ex:test",
+  "valueOf": "first",
+  "toString": "second"
+}

--- a/tests/flatten/0049-out.jsonld
+++ b/tests/flatten/0049-out.jsonld
@@ -1,0 +1,15 @@
+[
+  {
+    "@id": "ex:test",
+    "http://example.org/valueOf": [
+      {
+        "@value": "first"
+      }
+    ],
+    "http://example.org/toString": [
+      {
+        "@value": "second"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
These tests are particular to a bug in the jsonld.js implementation.  They could stay in the test suite of that lib, but I figured no harm in adding them to the main test suite to potentially catch issues in future javascript implementations.