### PR TITLE
compaction and expansion of indexes using a property

### DIFF
--- a/common/extract-examples.rb
+++ b/common/extract-examples.rb
@@ -211,7 +211,6 @@ ARGV.each do |input|
         ext = case element.attr('data-content-type')
         when nil, '', 'application/ld+json' then "jsonld"
         when 'application/json' then 'json'
-        when 'application/ld-frame+json' then 'jsonldf'
         when 'application/n-quads', 'nq' then 'nq'
         when 'text/html', 'html' then 'html'
         when 'text/turtle', 'ttl' then 'ttl'
@@ -307,7 +306,7 @@ ARGV.each do |input|
 
     # Perform example syntactic validation based on extension
     case ex[:ext]
-    when 'json', 'jsonld', 'jsonldf'
+    when 'json', 'jsonld'
       begin
         ::JSON.parse(content)
       rescue JSON::ParserError => exception
@@ -330,8 +329,9 @@ ARGV.each do |input|
         html_base = doc.at_xpath('/html/head/base/@href')
         ex[:base] = html_base.to_s if html_base
 
-        script_content = doc.at_xpath(xpath)
-        content = script_content.inner_html if script_content          
+        #script_content = doc.at_xpath(xpath)
+        #content = script_content.inner_html if script_content
+        content
       rescue Nokogiri::XML::SyntaxError => exception
         errors << "Example #{ex[:number]} at line #{ex[:line]} parse error: #{exception.message}"
         $stdout.write "F".colorize(:red)
@@ -363,6 +363,12 @@ ARGV.each do |input|
       end
     end
 
+    if content.is_a?(String)
+      content = StringIO.new(content)
+      # Set content_type so it can be parsed properly
+      content.define_singleton_method(:content_type) {ex[:content_type]} if ex[:content_type]
+    end
+
     options = ex[:options].to_s.split(',').inject({}) do |memo, pair|
       k, v = pair.split('=')
       v = case v
@@ -372,6 +378,7 @@ ARGV.each do |input|
       end
       memo.merge(k.to_sym => v)
     end
+    options[:validate] = true
 
     # Set API to use
     method = case
@@ -395,7 +402,7 @@ ARGV.each do |input|
       end
 
       method = :frame
-      args = [StringIO.new(examples[ex[:frame_for]][:content]), StringIO.new(content), options]
+      args = [StringIO.new(examples[ex[:frame_for]][:content]), content, options]
     elsif ex[:context_for]
       unless examples[ex[:context_for]]
         errors << "Example Context #{ex[:number]} at line #{ex[:line]} references unknown example #{ex[:context_for].inspect}"
@@ -406,12 +413,12 @@ ARGV.each do |input|
       # Either exapand with this external context, or compact using it
       case method
       when :expand
-        options[:externalContext] = StringIO.new(content)
+        options[:externalContext] = content
         options[:base] = ex[:base] if ex[:base]
         args = [StringIO.new(examples[ex[:context_for]][:content]), options]
       when :compact, :flatten, nil
         options[:base] = ex[:base] if ex[:base]
-        args = [StringIO.new(examples[ex[:context_for]][:content]), StringIO.new(content), options]
+        args = [StringIO.new(examples[ex[:context_for]][:content]), content, options]
       end
     elsif %w(jsonld html).include?(ex[:ext])
       # Either exapand with this external context, or compact using it
@@ -419,14 +426,14 @@ ARGV.each do |input|
       when :expand, :toRdf, :fromRdf
         options[:externalContext] = StringIO.new(ex[:context]) if ex[:context]
         options[:base] = ex[:base] if ex[:base]
-        args = [StringIO.new(content), options]
+        args = [content, options]
       when :compact, :flatten
         # Fixme how to find context?
         options[:base] = ex[:base] if ex[:base]
-        args = [StringIO.new(content), (StringIO.new(ex[:context]) if ex[:context]), options]
+        args = [content, (StringIO.new(ex[:context]) if ex[:context]), options]
       end
     else
-      args = [StringIO.new(content), options]
+      args = [content, options]
     end
 
     if ex[:result_for]
@@ -453,7 +460,7 @@ ARGV.each do |input|
           $stdout.write "F".colorize(:red)
           next
         end
-        StringIO.new(script_content.inner_html)
+        StringIO.new(examples[ex[:result_for]][:content])
       elsif examples[ex[:result_for]][:ext] == 'html' && ex[:target]
         # Only use the targeted script
         doc = Nokogiri::HTML.parse(examples[ex[:result_for]][:content])
@@ -466,6 +473,10 @@ ARGV.each do |input|
         StringIO.new(script_content.to_html)
       else
         StringIO.new(examples[ex[:result_for]][:content])
+      end
+
+      if examples[ex[:result_for]][:content_type]
+        args[0].define_singleton_method(:content_type) {examples[ex[:result_for]][:content_type]}
       end
 
       # :frame option indicates the frame to use on the referenced content
@@ -519,13 +530,7 @@ ARGV.each do |input|
         args[0] = RDF::Reader.for(file_extension: ext).new(args[0])
         JSON::LD::API.fromRdf(*args)
       when :toRdf
-        if ext == 'html'
-          # If the referenced example is HTML, read it using the RDFa reader
-          # FIXME: the API may be updated to provide a native mechanism for this
-          RDF::Dataset.new statements: RDF::RDFa::Reader.new(*args)
-        else
-          RDF::Dataset.new statements: JSON::LD::API.toRdf(*args)
-        end
+        RDF::Dataset.new statements: JSON::LD::API.toRdf(*args)
       else
         JSON::LD::API.method(method).call(*args)
       end
@@ -548,7 +553,7 @@ ARGV.each do |input|
         # Compare to expected to result
         case ex[:ext]
         when 'ttl', 'trig', 'nq', 'html'
-          reader = RDF::Reader.for(file_extension: ex[:ext]).new(StringIO.new(content))
+          reader = RDF::Reader.for(file_extension: ex[:ext]).new(content)
           expected = RDF::Dataset.new(statements: reader)
           $stderr.puts "expected:\n" + expected.to_trig if verbose
         when 'table'
@@ -569,7 +574,7 @@ ARGV.each do |input|
             end
           end
         else
-          expected = ::JSON.parse(content)
+          expected = ::JSON.parse(content.read)
           $stderr.puts "expected: " + expected.to_json(JSON::LD::JSON_STATE) if verbose
         end
 

--- a/index.html
+++ b/index.html
@@ -926,6 +926,7 @@
       <span class="changed">an optional <a>context</a></span>,
       <span class="changed">an optional <dfn>nest value</dfn>,</span>
       <span class="changed">an optional <dfn>prefix flag</dfn>,</span>
+      <span class="changed">an optional <dfn>index mapping</dfn>,</span>
       <span class="changed">a <dfn>protected</dfn>, used to mark this as a protected term,</span>
       and an optional <dfn>container mapping</dfn>.
       A <a>term definition</a> can not only be used to map a <a>term</a>
@@ -1371,6 +1372,20 @@
               has been detected and processing is aborted.</li>
             <li>Set the <a>container mapping</a> of <var>definition</var> to
               <var>container</var>.</li>
+          </ol>
+        </li>
+        <li class="changed">If <var>value</var> contains the <a>member</a> <code>@index</code>:
+          <ol>
+            <li>If <a>processing mode</a> is <code>json-ld-1.0</code> or
+              <a>container mapping</a> does not include <code>@index</code>,
+              an <a data-link-for="JsonLdErrorCode">invalid term definition</a>
+              has been detected and processing is aborted.</li>
+            <li>Initialize <var>index</var> to the value associated with the
+              <code>@index</code> <a>member</a>, which MUST a <a>string</a> expanding to an <a>absolute IRI</a>.
+              Otherwise, an
+              <a data-link-for="JsonLdErrorCode">invalid term definition</a>
+              has been detected and processing is aborted.</li>
+            <li>Set the <a>index mapping</a> of <var>definition</var> to <var>index</var></li>
           </ol>
         </li>
         <li class="changed">If <var>value</var> contains the <a>member</a> <code>@context</code>:
@@ -1956,8 +1971,10 @@
               <var>value</var> is a <a class="changed">dictionary</a> then <var>value</var>
               is expanded from an map as follows:
               <ol>
-                <li>Initialize <var>expanded value</var> to an empty
-                  <a>array</a>.</li>
+                <li>Initialize <var>expanded value</var> to an empty <a>array</a>.</li>
+                <li class="changed">Initialize <var>index key</var> to
+                  the <var>key</var>'s <a>index mapping</a> in <a>active context</a>,
+                  or <code>@index</code>, if it does not exist.</li>
                 <li>For each key-value pair <var>index</var>-<var>index value</var>
                   in <var>value</var>, ordered lexicographically by <var>index</var>
                   <span class="changed">if <a data-link-for="JsonLdOptions">ordered</a> is <code>true</code></span>:
@@ -1987,36 +2004,41 @@
                         and <a data-link-for="JsonLdOptions">ordered</a> flags</span>.</li>
                     <li>For each <var>item</var> in <var>index value</var>:
                       <ol class="algorithm changed">
-                        <li>If <var>container mapping</var> includes
-                          <code>@graph</code> and if <var>item</var> is not a
-                          <a>graph object</a>, set <var>item</var> to a new
-                          <a>dictionary</a> containing the key-value pair
-                          <code>@graph</code>-<var>item</var>, ensuring that the
-                          value is represented using an <a>array</a>.</li>
-                        <li>If <var>container mapping</var> includes <code>@index</code>
-                          and <var>item</var> does not have the <a>member</a>
-                          <code>@index</code> and <var>expanded index</var> is not <code>@none</code>,
-                          add the key-value pair
-                          (<code>@index</code>-<var>index</var>) to <var>item</var>.</li>
+                        <li>If <var>container mapping</var> includes <code>@graph</code>
+                          and if <var>item</var> is not a <a>graph object</a>,
+                          set <var>item</var> to a new <a>dictionary</a> containing the key-value pair
+                          <code>@graph</code>-<var>item</var>,
+                          ensuring that the value is represented using an <a>array</a>.</li>
+                        <li class="changed">If <var>container mapping</var> includes <code>@index</code>,
+                          <var>index key</var> is not <code>@index</code>,
+                          <var>item</var> does not have a <a>member</a> <code>@index</code>
+                          and <var>expanded index</var> is not <code>@none</code>,
+                          set <var>index property values</var> to the concatenation of
+                          <var>expanded index</var> with any existing values of
+                          <var>index key</var> in <var>item</var>.
+                          Add the key-value pair (<var>expanded index</var>-<var>index property values</var>) to <var>item</var>.
+                          If expanded value is a value object,
+                          it MUST NOT contain any extra properties;
+                          an <a data-link-for="JsonLdErrorCode">invalid value object</a>
+                          error has been detected and processing is aborted.</li>
+                        <li>Otherwise, if <var>container mapping</var> includes <code>@index</code>,
+                          <var>item</var> does not have a <a>member</a> <code>@index</code>,
+                          and <var>expanded index</var> is not <code>@none</code>,
+                          add the key-value pair (<code>@index</code>-<var>index</var>) to <var>item</var>.</li>
                         <li>Otherwise, if <var>container mapping</var> includes <code>@id</code>
-                          and <var>item</var> does not have the <a>member</a>
-                          <code>@id</code>, add the key-value pair
-                          (<code>@id</code>-<var>expanded index</var>) to
-                          <var>item</var>, where <var>expanded index</var> is set to the result of
-                          using the
+                          and <var>item</var> does not have the <a>member</a> <code>@id</code>,
+                          add the key-value pair (<code>@id</code>-<var>expanded index</var>) to <var>item</var>,
+                          where <var>expanded index</var> is set to the result of using the
                           <a href="#iri-expansion">IRI Expansion algorithm</a>,
                           passing <var>active context</var>, <var>index</var>, and <code>true</code>
                           for <var>document relative</var>, unless <var>expanded index</var>
                           is already set to <code>@none</code>.</li>
                         <li>Otherwise, if <var>container mapping</var> includes <code>@type</code>
-                          set <var>types</var> to the concatenation of
-                          <var>expanded index</var> with any existing values of
-                          <code>@type</code> in <var>item</var>.
+                          set <var>types</var> to the concatenation of <var>expanded index</var>
+                          with any existing values of <code>@type</code> in <var>item</var>.
                           If <var>expanded index</var> is <code>@none</code>,
                           do not concatenate <var>expanded index</var> to <var>types</var>.
-                          Add the key-value pair
-                          (<code>@type</code>-<var>types</var>) to
-                          <var>item</var>.</li>
+                          Add the key-value pair (<code>@type</code>-<var>types</var>) to <var>item</var>.</li>
                         <li>Append <var>item</var> to <var>expanded value</var>.</li>
                       </ol>
                     </li>
@@ -2776,17 +2798,31 @@
                       either <code>@language</code>, <code>@index</code>, <code>@id</code>, or <code>@type</code>
                       based on the contents of <var>container</var>, as <var>var</var>, and <code>true</code>
                       for <var>vocab</var>.</li>
+                    <li class="changed">Set <var>index key</var> to the value of <a>index mapping</a> in
+                      the <a>term definition</a> associated with <var>item active property</var> in <var>active context</var>,
+                      or <code>@index</code>, if no such value exists.</li>
                     <li>If <var>container</var> includes <code>@language</code> and
                       <var>expanded item</var> contains a
                       <code>@value</code> <a>member</a>, then set <var>compacted item</var>
                       to the value associated with its <code>@value</code> <a>member</a>.
                       Set <var>map key</var> to the value of <code>@language</code> in <var>expanded item</var>, if any.</li>
-                    <li>If <var>container</var> includes <code>@index</code> set <var>map key</var> to the value of <code>@index</code> in <var>expanded item</var>, if any,
+                    <li>Otherwise, if <var>container</var> includes <code>@index</code>
+                      and <var>index key</var> is <code>@index</code>,
+                      set <var>map key</var> to the value of <code>@index</code> in <var>expanded item</var>, if any,
                       and remove <var>container key</var> from <var>compacted item</var>.</li>
-                    <li class="changed">If <var>container</var> includes <code>@id</code>, set
+                    <li class="changed">Otherwise, if <var>container</var> includes <code>@index</code>
+                      and <var>index key</var> is not <code>@index</code>,
+                      Set <var>map key</var> to the first value of <var>container key</var> in <var>compacted item</var>, if any.
+                      If there are remaining values in <var>compacted item</var>
+                      for <var>compacted container</var>, set the value of
+                      <var>compacted container</var> in <var>compacted value</var>
+                      to those remaining values. Otherwise, remove that
+                      <a>member</a> from <var>compacted item</var>.
+                    </li>
+                    <li class="changed">Otherwise, if <var>container</var> includes <code>@id</code>, set
                       <var>map key</var> to the value of <var>container key</var> in
                       <var>compacted item</var> and remove <var>container key</var> from <var>compacted item</var>.</li>
-                    <li class="changed">If <var>container</var> is <code>@type</code>,
+                    <li class="changed">Otherwise, if <var>container</var> is <code>@type</code>,
                       set <var>map key</var> to the first value of <var>container key</var> in <var>compacted item</var>, if any.
                       If there are remaining values in <var>compacted item</var>
                       for <var>compacted container</var>, set the value of

--- a/index.html
+++ b/index.html
@@ -2017,7 +2017,7 @@
                           <var>expanded index</var> with any existing values of
                           <var>index key</var> in <var>item</var>.
                           Add the key-value pair (<var>expanded index</var>-<var>index property values</var>) to <var>item</var>.
-                          If expanded value is a value object,
+                          If <var>item</var> is a value object,
                           it MUST NOT contain any extra properties;
                           an <a data-link-for="JsonLdErrorCode">invalid value object</a>
                           error has been detected and processing is aborted.</li>
@@ -2563,7 +2563,7 @@
                   for <var>element</var>,
                   <span class="changed">and the <a data-link-for="JsonLdOptions">compactArrays</a>
                     and <a data-link-for="JsonLdOptions">ordered</a> flags</span>.</li>
-                <li>Add <var>expanded value</var> as the value of <code>@preserve</code>
+                <li>Add <var>compacted value</var> as the value of <code>@preserve</code>
                   in <var>result</var> unless <var>expanded value</var> is an empty <a>array</a>.</li>
               </ol>
             </li>
@@ -2814,8 +2814,8 @@
                       and <var>index key</var> is not <code>@index</code>,
                       Set <var>map key</var> to the first value of <var>container key</var> in <var>compacted item</var>, if any.
                       If there are remaining values in <var>compacted item</var>
-                      for <var>compacted container</var>, set the value of
-                      <var>compacted container</var> in <var>compacted value</var>
+                      for <var>container key</var>, set the value of
+                      <var>container key</var> in <var>compacted item</var>
                       to those remaining values. Otherwise, remove that
                       <a>member</a> from <var>compacted item</var>.
                     </li>
@@ -2825,8 +2825,8 @@
                     <li class="changed">Otherwise, if <var>container</var> is <code>@type</code>,
                       set <var>map key</var> to the first value of <var>container key</var> in <var>compacted item</var>, if any.
                       If there are remaining values in <var>compacted item</var>
-                      for <var>compacted container</var>, set the value of
-                      <var>compacted container</var> in <var>compacted value</var>
+                      for <var>container key</var>, set the value of
+                      <var>container key</var> in <var>compacted item</var>
                       to those remaining values. Otherwise, remove that
                       <a>member</a> from <var>compacted item</var>.</li>
                     <li class="changed">If <var>compacted item</var> is not an

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -1599,6 +1599,60 @@
       "context": "compact/p008-context.jsonld",
       "expect": "compact/p008-out.jsonld"
     }, {
+      "@id": "#tpi01",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "property-valued index indexes property value, instead of property (value)",
+      "purpose": "Compacting property-valued indexes.",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"},
+      "input": "compact/pi01-in.jsonld",
+      "context": "compact/pi01-context.jsonld",
+      "expect": "compact/pi01-out.jsonld"
+    }, {
+      "@id": "#tpi02",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "property-valued index indexes property value, instead of property (multiple values)",
+      "purpose": "Compacting property-valued indexes.",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"},
+      "input": "compact/pi02-in.jsonld",
+      "context": "compact/pi02-context.jsonld",
+      "expect": "compact/pi02-out.jsonld"
+    }, {
+      "@id": "#tpi03",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "property-valued index indexes property value, instead of property (node)",
+      "purpose": "Compacting property-valued indexes.",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"},
+      "input": "compact/pi03-in.jsonld",
+      "context": "compact/pi03-context.jsonld",
+      "expect": "compact/pi03-out.jsonld"
+    }, {
+      "@id": "#tpi04",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "property-valued index indexes property value, instead of property (multiple nodes)",
+      "purpose": "Compacting property-valued indexes.",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"},
+      "input": "compact/pi04-in.jsonld",
+      "context": "compact/pi04-context.jsonld",
+      "expect": "compact/pi04-out.jsonld"
+    }, {
+      "@id": "#tpi05",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "property-valued index indexes using @none if no property value exists",
+      "purpose": "Compacting property-valued indexes.",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"},
+      "input": "compact/pi05-in.jsonld",
+      "context": "compact/pi05-context.jsonld",
+      "expect": "compact/pi05-out.jsonld"
+    }, {
+      "@id": "#tpi06",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "property-valued index indexes using @none if no property value does not compact to string",
+      "purpose": "Compacting property-valued indexes.",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"},
+      "input": "compact/pi06-in.jsonld",
+      "context": "compact/pi06-context.jsonld",
+      "expect": "compact/pi06-out.jsonld"
+    }, {
       "@id": "#tr001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Expands and compacts to document base by default",

--- a/tests/compact/pi01-context.jsonld
+++ b/tests/compact/pi01-context.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@base": "http://example.com/",
+    "@vocab": "http://example.com/",
+    "author": {"@type": "@id", "@container": "@index", "@index": "prop"}
+  }
+}

--- a/tests/compact/pi01-in.jsonld
+++ b/tests/compact/pi01-in.jsonld
@@ -1,0 +1,8 @@
+[{
+  "@id": "http://example.com/article",
+  "http://example.com/author": [
+    {"@id": "http://example.com/person/1", "http://example.com/prop": [{"@value": "regular"}]},
+    {"@id": "http://example.com/person/2", "http://example.com/prop": [{"@value": "guest"}]},
+    {"@id": "http://example.com/person/3", "http://example.com/prop": [{"@value": "guest"}]}
+  ]
+}]

--- a/tests/compact/pi01-out.jsonld
+++ b/tests/compact/pi01-out.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@base": "http://example.com/",
+    "@vocab": "http://example.com/",
+    "author": {"@type": "@id", "@container": "@index", "@index": "prop"}
+  },
+  "@id": "article",
+  "author": {
+    "regular": {"@id": "person/1"},
+    "guest": [{"@id": "person/2"}, {"@id": "person/3"}]
+  }
+}

--- a/tests/compact/pi02-context.jsonld
+++ b/tests/compact/pi02-context.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@base": "http://example.com/",
+    "@vocab": "http://example.com/",
+    "author": {"@type": "@id", "@container": "@index", "@index": "prop"}
+  }
+}

--- a/tests/compact/pi02-in.jsonld
+++ b/tests/compact/pi02-in.jsonld
@@ -1,0 +1,8 @@
+[{
+  "@id": "http://example.com/article",
+  "http://example.com/author": [
+    {"@id": "http://example.com/person/1", "http://example.com/prop": [{"@value": "regular"}, {"@value": "foo"}]},
+    {"@id": "http://example.com/person/2", "http://example.com/prop": [{"@value": "guest"}, {"@value": "foo"}]},
+    {"@id": "http://example.com/person/3", "http://example.com/prop": [{"@value": "guest"}, {"@value": "foo"}]}
+  ]
+}]

--- a/tests/compact/pi02-out.jsonld
+++ b/tests/compact/pi02-out.jsonld
@@ -1,0 +1,16 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@base": "http://example.com/",
+    "@vocab": "http://example.com/",
+    "author": {"@type": "@id", "@container": "@index", "@index": "prop"}
+  },
+  "@id": "article",
+  "author": {
+    "regular": {"@id": "person/1", "prop": "foo"},
+    "guest": [
+      {"@id": "person/2", "prop": "foo"},
+      {"@id": "person/3", "prop": "foo"}
+    ]
+  }
+}

--- a/tests/compact/pi03-context.jsonld
+++ b/tests/compact/pi03-context.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@base": "http://example.com/",
+    "@vocab": "http://example.com/",
+    "author": {"@type": "@vocab", "@container": "@index", "@index": "prop"},
+    "prop": {"@type": "@id"}
+  }
+}

--- a/tests/compact/pi03-in.jsonld
+++ b/tests/compact/pi03-in.jsonld
@@ -1,0 +1,8 @@
+[{
+  "@id": "http://example.com/article",
+  "http://example.com/author": [
+    {"@id": "http://example.com/person/1", "http://example.com/prop": [{"@id": "http://example.com/regular"}]},
+    {"@id": "http://example.com/person/2", "http://example.com/prop": [{"@id": "http://example.com/guest"}]},
+    {"@id": "http://example.com/person/3", "http://example.com/prop": [{"@id": "http://example.com/guest"}]}
+  ]
+}]

--- a/tests/compact/pi03-out.jsonld
+++ b/tests/compact/pi03-out.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@base": "http://example.com/",
+    "@vocab": "http://example.com/",
+    "author": {"@type": "@vocab", "@container": "@index", "@index": "prop"},
+    "prop": {"@type": "@id"}
+  },
+  "@id": "article",
+  "author": {
+    "regular": {"@id": "person/1"},
+    "guest": [
+      {"@id": "person/2"},
+      {"@id": "person/3"}
+    ]
+  }
+}

--- a/tests/compact/pi04-context.jsonld
+++ b/tests/compact/pi04-context.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@base": "http://example.com/",
+    "@vocab": "http://example.com/",
+    "author": {"@type": "@vocab", "@container": "@index", "@index": "prop"},
+    "prop": {"@type": "@id"}
+  }
+}

--- a/tests/compact/pi04-in.jsonld
+++ b/tests/compact/pi04-in.jsonld
@@ -1,0 +1,8 @@
+[{
+  "@id": "http://example.com/article",
+  "http://example.com/author": [
+    {"@id": "http://example.com/person/1", "http://example.com/prop": [{"@id": "http://example.com/regular"}, {"@id": "http://example.com/foo"}]},
+    {"@id": "http://example.com/person/2", "http://example.com/prop": [{"@id": "http://example.com/guest"}, {"@id": "http://example.com/foo"}]},
+    {"@id": "http://example.com/person/3", "http://example.com/prop": [{"@id": "http://example.com/guest"}, {"@id": "http://example.com/foo"}]}
+  ]
+}]

--- a/tests/compact/pi04-out.jsonld
+++ b/tests/compact/pi04-out.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@base": "http://example.com/",
+    "@vocab": "http://example.com/",
+    "author": {"@type": "@vocab", "@container": "@index", "@index": "prop"},
+    "prop": {"@type": "@id"}
+  },
+  "@id": "article",
+  "author": {
+    "regular": {"@id": "person/1", "prop": "foo"},
+    "guest": [
+      {"@id": "person/2", "prop": "foo"},
+      {"@id": "person/3", "prop": "foo"}
+    ]
+  }
+}

--- a/tests/compact/pi05-context.jsonld
+++ b/tests/compact/pi05-context.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@base": "http://example.com/",
+    "@vocab": "http://example.com/",
+    "author": {"@type": "@id", "@container": "@index", "@index": "prop"}
+  }
+}

--- a/tests/compact/pi05-in.jsonld
+++ b/tests/compact/pi05-in.jsonld
@@ -1,0 +1,8 @@
+[{
+  "@id": "http://example.com/article",
+  "http://example.com/author": [
+    {"@id": "http://example.com/person/1"},
+    {"@id": "http://example.com/person/2"},
+    {"@id": "http://example.com/person/3"}
+  ]
+}]

--- a/tests/compact/pi05-out.jsonld
+++ b/tests/compact/pi05-out.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@base": "http://example.com/",
+    "@vocab": "http://example.com/",
+    "author": {"@type": "@id", "@container": "@index", "@index": "prop"}
+  },
+  "@id": "article",
+  "author": {
+    "@none": ["person/1", "person/2", "person/3"]
+  }
+}

--- a/tests/compact/pi06-context.jsonld
+++ b/tests/compact/pi06-context.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@base": "http://example.com/",
+    "@vocab": "http://example.com/",
+    "author": {"@type": "@id", "@container": "@index", "@index": "prop"}
+  }
+}

--- a/tests/compact/pi06-in.jsonld
+++ b/tests/compact/pi06-in.jsonld
@@ -1,0 +1,8 @@
+[{
+  "@id": "http://example.com/article",
+  "http://example.com/author": [
+    {"@id": "http://example.com/person/1", "http://example.com/prop": [{"@id": "http://example.com/regular"}]},
+    {"@id": "http://example.com/person/2", "http://example.com/prop": [{"@id": "http://example.com/guest"}]},
+    {"@id": "http://example.com/person/3", "http://example.com/prop": [{"@id": "http://example.com/guest"}]}
+  ]
+}]

--- a/tests/compact/pi06-out.jsonld
+++ b/tests/compact/pi06-out.jsonld
@@ -1,0 +1,16 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@base": "http://example.com/",
+    "@vocab": "http://example.com/",
+    "author": {"@type": "@id", "@container": "@index", "@index": "prop"}
+  },
+  "@id": "article",
+  "author": {
+    "@none": [
+      {"@id": "person/1", "prop": {"@id": "regular"}},
+      {"@id": "person/2", "prop": {"@id": "guest"}},
+      {"@id": "person/3", "prop": {"@id": "guest"}}
+    ]
+  }
+}

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -1785,6 +1785,94 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/p004-in.jsonld",
       "expect": "expand/p004-out.jsonld"
+    }, {
+      "@id": "#tpi01",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "error if @version is not json-ld-1.1 for property-valued index",
+      "purpose": "Expanding index maps where index is a property.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/pi01-in.jsonld",
+      "expect": "invalid term definition"
+    }, {
+      "@id": "#tpi02",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "error if @container does not include @index for property-valued index",
+      "purpose": "Expanding index maps where index is a property.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/pi02-in.jsonld",
+      "expect": "invalid term definition"
+    }, {
+      "@id": "#tpi03",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "error if @index is a keyword for property-valued index",
+      "purpose": "Expanding index maps where index is a property.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/pi03-in.jsonld",
+      "expect": "invalid term definition"
+    }, {
+      "@id": "#tpi04",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "error if @index is not a string for property-valued index",
+      "purpose": "Expanding index maps where index is a property.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/pi04-in.jsonld",
+      "expect": "invalid term definition"
+    }, {
+      "@id": "#tpi05",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "error if attempting to add property to value object for property-valued index",
+      "purpose": "Expanding index maps where index is a property.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/pi05-in.jsonld",
+      "expect": "invalid value object"
+    }, {
+      "@id": "#tpi06",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "property-valued index expands to property value, instead of @index (value)",
+      "purpose": "Expanding index maps where index is a property.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/pi06-in.jsonld",
+      "expect": "expand/pi06-out.jsonld"
+    }, {
+      "@id": "#tpi07",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "property-valued index appends to property value, instead of @index (value)",
+      "purpose": "Expanding index maps where index is a property.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/pi07-in.jsonld",
+      "expect": "expand/pi07-out.jsonld"
+    }, {
+      "@id": "#tpi08",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "property-valued index expands to property value, instead of @index (node)",
+      "purpose": "Expanding index maps where index is a property.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/pi08-in.jsonld",
+      "expect": "expand/pi08-out.jsonld"
+    }, {
+      "@id": "#tpi09",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "property-valued index appends to property value, instead of @index (node)",
+      "purpose": "Expanding index maps where index is a property.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/pi09-in.jsonld",
+      "expect": "expand/pi09-out.jsonld"
+    }, {
+      "@id": "#tpi10",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "property-valued index does not output property for @none",
+      "purpose": "Expanding index maps where index is a property.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/pi10-in.jsonld",
+      "expect": "expand/pi10-out.jsonld"
+    }, {
+      "@id": "#tpi11",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "property-valued index adds property to graph object",
+      "purpose": "Expanding index maps where index is a property.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/pi11-in.jsonld",
+      "expect": "expand/pi11-out.jsonld"
    }, {
       "@id": "#tl001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],

--- a/tests/expand/pi01-in.jsonld
+++ b/tests/expand/pi01-in.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "@vocab": "http://example.com/",
+    "container": {"@container": "@index", "@index": "prop"}
+  },
+  "@id": "http://example.com/annotationsTest",
+  "container": {
+    "en": "The Queen",
+    "de": [ "Die Königin", "Ihre Majestät" ]
+  }
+}

--- a/tests/expand/pi02-in.jsonld
+++ b/tests/expand/pi02-in.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.com/",
+    "container": {"@index": "prop"}
+  },
+  "@id": "http://example.com/annotationsTest",
+  "container": {
+    "en": "The Queen",
+    "de": [ "Die Königin", "Ihre Majestät" ]
+  }
+}

--- a/tests/expand/pi03-in.jsonld
+++ b/tests/expand/pi03-in.jsonld
@@ -1,0 +1,16 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.com/",
+    "container": {
+      "@id": "http://example.com/container",
+      "@container": "@index",
+      "@index": "@index"
+    }
+  },
+  "@id": "http://example.com/annotationsTest",
+  "container": {
+    "en": "The Queen",
+    "de": [ "Die Königin", "Ihre Majestät" ]
+  }
+}

--- a/tests/expand/pi04-in.jsonld
+++ b/tests/expand/pi04-in.jsonld
@@ -1,0 +1,16 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.com/",
+    "container": {
+      "@id": "http://example.com/container",
+      "@container": "@index",
+      "@index": true
+    }
+  },
+  "@id": "http://example.com/annotationsTest",
+  "container": {
+    "en": "The Queen",
+    "de": [ "Die Königin", "Ihre Majestät" ]
+  }
+}

--- a/tests/expand/pi05-in.jsonld
+++ b/tests/expand/pi05-in.jsonld
@@ -1,0 +1,16 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.com/",
+    "container": {
+      "@id": "http://example.com/container",
+      "@container": "@index",
+      "@index": "prop"
+    }
+  },
+  "@id": "http://example.com/annotationsTest",
+  "container": {
+    "en": "The Queen",
+    "de": [ "Die Königin", "Ihre Majestät" ]
+  }
+}

--- a/tests/expand/pi06-in.jsonld
+++ b/tests/expand/pi06-in.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@base": "http://example.com/",
+    "@vocab": "http://example.com/",
+    "author": {"@type": "@id", "@container": "@index", "@index": "prop"}
+  },
+  "@id": "article",
+  "author": {
+    "regular": "person/1",
+    "guest": ["person/2", "person/3"]
+  }
+}

--- a/tests/expand/pi06-out.jsonld
+++ b/tests/expand/pi06-out.jsonld
@@ -1,0 +1,8 @@
+[{
+  "@id": "http://example.com/article",
+  "http://example.com/author": [
+    {"@id": "http://example.com/person/2", "http://example.com/prop": [{"@value": "guest"}]},
+    {"@id": "http://example.com/person/3", "http://example.com/prop": [{"@value": "guest"}]},
+    {"@id": "http://example.com/person/1", "http://example.com/prop": [{"@value": "regular"}]}
+  ]
+}]

--- a/tests/expand/pi07-in.jsonld
+++ b/tests/expand/pi07-in.jsonld
@@ -1,0 +1,16 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@base": "http://example.com/",
+    "@vocab": "http://example.com/",
+    "author": {"@type": "@id", "@container": "@index", "@index": "prop"}
+  },
+  "@id": "article",
+  "author": {
+    "regular": {"@id": "person/1", "http://example.com/prop": "foo"},
+    "guest": [
+      {"@id": "person/2", "prop": "foo"},
+      {"@id": "person/3", "prop": "foo"}
+    ]
+  }
+}

--- a/tests/expand/pi07-out.jsonld
+++ b/tests/expand/pi07-out.jsonld
@@ -1,0 +1,8 @@
+[{
+  "@id": "http://example.com/article",
+  "http://example.com/author": [
+    {"@id": "http://example.com/person/2", "http://example.com/prop": [{"@value": "guest"}, {"@value": "foo"}]},
+    {"@id": "http://example.com/person/3", "http://example.com/prop": [{"@value": "guest"}, {"@value": "foo"}]},
+    {"@id": "http://example.com/person/1", "http://example.com/prop": [{"@value": "regular"}, {"@value": "foo"}]}
+  ]
+}]

--- a/tests/expand/pi08-in.jsonld
+++ b/tests/expand/pi08-in.jsonld
@@ -1,0 +1,14 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@base": "http://example.com/",
+    "@vocab": "http://example.com/",
+    "author": {"@type": "@id", "@container": "@index", "@index": "prop"},
+    "prop": {"@type": "@vocab"}
+  },
+  "@id": "http://example.com/article",
+  "author": {
+    "regular": "person/1",
+    "guest": ["person/2", "person/3"]
+  }
+}

--- a/tests/expand/pi08-out.jsonld
+++ b/tests/expand/pi08-out.jsonld
@@ -1,0 +1,8 @@
+[{
+  "@id": "http://example.com/article",
+  "http://example.com/author": [
+    {"@id": "http://example.com/person/2", "http://example.com/prop": [{"@id": "http://example.com/guest"}]},
+    {"@id": "http://example.com/person/3", "http://example.com/prop": [{"@id": "http://example.com/guest"}]},
+    {"@id": "http://example.com/person/1", "http://example.com/prop": [{"@id": "http://example.com/regular"}]}
+  ]
+}]

--- a/tests/expand/pi09-in.jsonld
+++ b/tests/expand/pi09-in.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@base": "http://example.com/",
+    "@vocab": "http://example.com/",
+    "author": {"@type": "@id", "@container": "@index", "@index": "prop"},
+    "prop": {"@type": "@vocab"}
+  },
+  "@id": "http://example.com/article",
+  "author": {
+    "regular": {"@id": "person/1", "prop": "foo"},
+    "guest": [
+      {"@id": "person/2", "prop": "foo"},
+      {"@id": "person/3", "prop": "foo"}
+    ]
+  }
+}

--- a/tests/expand/pi09-out.jsonld
+++ b/tests/expand/pi09-out.jsonld
@@ -1,0 +1,8 @@
+[{
+  "@id": "http://example.com/article",
+  "http://example.com/author": [
+    {"@id": "http://example.com/person/2", "http://example.com/prop": [{"@id": "http://example.com/guest"}, {"@id": "http://example.com/foo"}]},
+    {"@id": "http://example.com/person/3", "http://example.com/prop": [{"@id": "http://example.com/guest"}, {"@id": "http://example.com/foo"}]},
+    {"@id": "http://example.com/person/1", "http://example.com/prop": [{"@id": "http://example.com/regular"}, {"@id": "http://example.com/foo"}]}
+  ]
+}]

--- a/tests/expand/pi10-in.jsonld
+++ b/tests/expand/pi10-in.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@base": "http://example.com/",
+    "@vocab": "http://example.com/",
+    "author": {"@type": "@id", "@container": "@index", "@index": "prop"},
+    "prop": {"@type": "@vocab"}
+  },
+  "@id": "http://example.com/article",
+  "author": {
+    "@none": {"@id": "person/1"},
+    "guest": [
+      {"@id": "person/2"},
+      {"@id": "person/3"}
+    ]
+  }
+}

--- a/tests/expand/pi10-out.jsonld
+++ b/tests/expand/pi10-out.jsonld
@@ -1,0 +1,8 @@
+[{
+  "@id": "http://example.com/article",
+  "http://example.com/author": [
+    {"@id": "http://example.com/person/1"},
+    {"@id": "http://example.com/person/2", "http://example.com/prop": [{"@id": "http://example.com/guest"}]},
+    {"@id": "http://example.com/person/3", "http://example.com/prop": [{"@id": "http://example.com/guest"}]}
+  ]
+}]

--- a/tests/expand/pi11-in.jsonld
+++ b/tests/expand/pi11-in.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/",
+    "input": {"@container": ["@graph", "@index"], "@index": "prop"}
+  },
+  "input": {
+    "g1": {"value": "x"}
+  }
+}

--- a/tests/expand/pi11-out.jsonld
+++ b/tests/expand/pi11-out.jsonld
@@ -1,0 +1,8 @@
+[{
+  "http://example.org/input": [{
+    "http://example.org/prop": [{"@value": "g1"}],
+    "@graph": [{
+      "http://example.org/value": [{"@value": "x"}]
+    }]
+  }]
+}]


### PR DESCRIPTION
Add API text and tests for compaction and expansion of indexes using a property.

For w3c/json-ld-syntax#145.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/74.html" title="Last updated on Mar 25, 2019, 5:09 PM UTC (70712fc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/74/c8c199f...70712fc.html" title="Last updated on Mar 25, 2019, 5:09 PM UTC (70712fc)">Diff</a>