### PR TITLE
toRdf tests for @prefix

### DIFF
--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -880,6 +880,14 @@
       "input": "toRdf/0129-in.jsonld",
       "expect": "toRdf/0129-out.nq"
     }, {
+      "@id": "#t0130",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Compact IRIs and prefix",
+      "purpose": "1.1 extension of toRdf-0088",
+      "input": "toRdf/0130-in.jsonld",
+      "expect": "toRdf/0130-out.nq",
+      "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.1"}
+    }, {
       "@id": "#th001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
       "name": "Transforms embedded JSON-LD script element",

--- a/tests/toRdf/0088-in.jsonld
+++ b/tests/toRdf/0088-in.jsonld
@@ -1,15 +1,14 @@
 {
   "@context": {
     "term": "http://example.com/terms-are-not-considered-in-id",
-    "compact-iris": "http://example.com/compact-iris-",
     "property": "http://example.com/property",
     "@vocab": "http://example.org/vocab-is-not-considered-for-id"
   },
   "@id": "term",
   "property": [
     {
-      "@id": "compact-iris:are-considered",
-      "property": "@id supports the following values: relative, absolute, and compact IRIs"
+      "@id": "http://example.com/absolute-iri",
+      "property": "@id supports the following values: relative and absolute IRIs"
     },
     {
       "@id": "../parent-node",

--- a/tests/toRdf/0088-in.jsonld
+++ b/tests/toRdf/0088-in.jsonld
@@ -1,14 +1,20 @@
 {
   "@context": {
     "term": "http://example.com/terms-are-not-considered-in-id",
+    "unsafe-compact-iris": "http://example.com/unsafe-compact-iris-",
+    "safe-compact-iris": "http://example.com/safe-compact-iris/",
     "property": "http://example.com/property",
     "@vocab": "http://example.org/vocab-is-not-considered-for-id"
   },
   "@id": "term",
   "property": [
     {
-      "@id": "http://example.com/absolute-iri",
-      "property": "@id supports the following values: relative and absolute IRIs"
+      "@id": "unsafe-compact-iris:are-considered",
+      "property": "@id supports the following values: relative, absolute, and compact IRIs ending with gen-delim character"
+    },
+    {
+      "@id": "safe-compact-iris:are-considered",
+      "property": "@id supports the following values: relative, absolute, and compact IRIs ending with gen-delim character"
     },
     {
       "@id": "../parent-node",

--- a/tests/toRdf/0088-out.nq
+++ b/tests/toRdf/0088-out.nq
@@ -1,4 +1,3 @@
 <http://example.com/absolute-iri> <http://example.com/property> "@id supports the following values: relative and absolute IRIs" .
 <https://w3c.github.io/json-ld-api/tests/parent-node> <http://example.com/property> "relative IRIs get resolved against the document's base IRI" .
-<https://w3c.github.io/json-ld-api/tests/toRdf/term> <http://example.com/property> <http://example.com/compact-iris-are-considered> .
 <https://w3c.github.io/json-ld-api/tests/toRdf/term> <http://example.com/property> <https://w3c.github.io/json-ld-api/tests/parent-node> .

--- a/tests/toRdf/0088-out.nq
+++ b/tests/toRdf/0088-out.nq
@@ -1,3 +1,4 @@
-<http://example.com/absolute-iri> <http://example.com/property> "@id supports the following values: relative and absolute IRIs" .
+<http://example.com/safe-compact-iris/are-considered> <http://example.com/property> "@id supports the following values: relative, absolute, and compact IRIs ending with gen-delim character" .
 <https://w3c.github.io/json-ld-api/tests/parent-node> <http://example.com/property> "relative IRIs get resolved against the document's base IRI" .
+<https://w3c.github.io/json-ld-api/tests/toRdf/term> <http://example.com/property> <http://example.com/safe-compact-iris/are-considered> .
 <https://w3c.github.io/json-ld-api/tests/toRdf/term> <http://example.com/property> <https://w3c.github.io/json-ld-api/tests/parent-node> .

--- a/tests/toRdf/0088-out.nq
+++ b/tests/toRdf/0088-out.nq
@@ -1,4 +1,4 @@
-<http://example.com/compact-iris-are-considered> <http://example.com/property> "@id supports the following values: relative, absolute, and compact IRIs" .
+<http://example.com/absolute-iri> <http://example.com/property> "@id supports the following values: relative and absolute IRIs" .
 <https://w3c.github.io/json-ld-api/tests/parent-node> <http://example.com/property> "relative IRIs get resolved against the document's base IRI" .
 <https://w3c.github.io/json-ld-api/tests/toRdf/term> <http://example.com/property> <http://example.com/compact-iris-are-considered> .
 <https://w3c.github.io/json-ld-api/tests/toRdf/term> <http://example.com/property> <https://w3c.github.io/json-ld-api/tests/parent-node> .

--- a/tests/toRdf/0130-in.jsonld
+++ b/tests/toRdf/0130-in.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "term": "http://example.com/terms-are-not-considered-in-id",
+    "compact-iris": { "@id": "http://example.com/compact-iris-", "@prefix": true },
+    "safe-compact-iris": "http://example.com/safe-compact-iris/",
+    "property": "http://example.com/property",
+    "@vocab": "http://example.org/vocab-is-not-considered-for-id"
+  },
+  "@id": "term",
+  "property": [
+    {
+      "@id": "compact-iris:are-considered",
+      "property": "Compact IRIs with term definition ending with non-gen-delim character are only allowed with @prefix true"
+    },
+    {
+      "@id": "safe-compact-iris:are-considered",
+      "property": "Compact IRIs with term definition ending with gen-delim character are always allowed"
+    },
+    {
+      "@id": "../parent-node",
+      "property": "relative IRIs get resolved against the document's base IRI"
+    }
+  ]
+}

--- a/tests/toRdf/0130-in.jsonld
+++ b/tests/toRdf/0130-in.jsonld
@@ -2,7 +2,8 @@
   "@context": {
     "@version": 1.1,
     "term": "http://example.com/terms-are-not-considered-in-id",
-    "compact-iris": { "@id": "http://example.com/compact-iris-", "@prefix": true },
+    "unsafe-compact-iris": "http://example.com/unsafe-compact-iris-",
+    "prefix-compact-iris": { "@id": "http://example.com/prefix-compact-iris-", "@prefix": true },
     "safe-compact-iris": "http://example.com/safe-compact-iris/",
     "property": "http://example.com/property",
     "@vocab": "http://example.org/vocab-is-not-considered-for-id"
@@ -10,7 +11,11 @@
   "@id": "term",
   "property": [
     {
-      "@id": "compact-iris:are-considered",
+      "@id": "unsafe-compact-iris:are-not-considered",
+      "property": "Compact IRIs with term definition ending with non-gen-delim character are not allowed"
+    },
+    {
+      "@id": "prefix-compact-iris:are-considered",
       "property": "Compact IRIs with term definition ending with non-gen-delim character are only allowed with @prefix true"
     },
     {

--- a/tests/toRdf/0130-out.nq
+++ b/tests/toRdf/0130-out.nq
@@ -1,6 +1,6 @@
-<http://example.com/compact-iris-are-considered> <http://example.com/property> "Compact IRIs with term definition ending with non-gen-delim character are only allowed with @prefix true" .
+<http://example.com/prefix-compact-iris-are-considered> <http://example.com/property> "Compact IRIs with term definition ending with non-gen-delim character are only allowed with @prefix true" .
 <http://example.com/safe-compact-iris/are-considered> <http://example.com/property> "Compact IRIs with term definition ending with gen-delim character are always allowed" .
 <https://w3c.github.io/json-ld-api/tests/parent-node> <http://example.com/property> "relative IRIs get resolved against the document's base IRI" .
-<https://w3c.github.io/json-ld-api/tests/toRdf/term> <http://example.com/property> <http://example.com/compact-iris-are-considered> .
+<https://w3c.github.io/json-ld-api/tests/toRdf/term> <http://example.com/property> <http://example.com/prefix-compact-iris-are-considered> .
 <https://w3c.github.io/json-ld-api/tests/toRdf/term> <http://example.com/property> <http://example.com/safe-compact-iris/are-considered> .
 <https://w3c.github.io/json-ld-api/tests/toRdf/term> <http://example.com/property> <https://w3c.github.io/json-ld-api/tests/parent-node> .

--- a/tests/toRdf/0130-out.nq
+++ b/tests/toRdf/0130-out.nq
@@ -1,0 +1,6 @@
+<http://example.com/compact-iris-are-considered> <http://example.com/property> "Compact IRIs with term definition ending with non-gen-delim character are only allowed with @prefix true" .
+<http://example.com/safe-compact-iris/are-considered> <http://example.com/property> "Compact IRIs with term definition ending with gen-delim character are always allowed" .
+<https://w3c.github.io/json-ld-api/tests/parent-node> <http://example.com/property> "relative IRIs get resolved against the document's base IRI" .
+<https://w3c.github.io/json-ld-api/tests/toRdf/term> <http://example.com/property> <http://example.com/compact-iris-are-considered> .
+<https://w3c.github.io/json-ld-api/tests/toRdf/term> <http://example.com/property> <http://example.com/safe-compact-iris/are-considered> .
+<https://w3c.github.io/json-ld-api/tests/toRdf/term> <http://example.com/property> <https://w3c.github.io/json-ld-api/tests/parent-node> .


### PR DESCRIPTION
This PR does two things:

1. It modifies toRdf-0088 so that the compact IRI term definition that ends with a non-gen-delim character is removed, as this is not allowed anymore unless `@prefix` is used. This is needed, as this is a breaking change in 1.0:
    > This represents a small change to the 1.0 algorithm to prevent IRIs that are not really intended to be used as prefixes from being used for creating compact IRIs.

2. toRdf-0130 is added as an extension of toRdf-0088, and makes use of this new `@prefix` feature.