### PR TITLE
Add checks for terms including a colon

### DIFF
--- a/index.html
+++ b/index.html
@@ -1307,6 +1307,12 @@
               i.e., it contains no colon (<code>:</code>), an
               <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
               error has been detected and processing is aborted.</li>
+            <li class="changed">If the <var>term</var> contains a colon (<code>:</code>)
+              and the result of expanding <var>term</var>
+              using the <a href="#iri-expansion">IRI Expansion algorithm</a>
+              is not the same as the <a>IRI mapping</a> of <var>definition</var>,
+              an <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
+              error has been detected and processing is aborted.</li>
             <li>If <var>value</var> contains an <code>@container</code> <a>member</a>,
               set the <a>container mapping</a> of <var>definition</var>
               to its value; if its value is neither <code>@set</code>, nor
@@ -1340,6 +1346,12 @@
               <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
               error has been detected and processing is aborted; if it equals <code>@context</code>, an
               <a data-link-for="JsonLdErrorCode">invalid keyword alias</a>
+              error has been detected and processing is aborted.</li>
+            <li class="changed">If the <var>term</var> contains a colon (<code>:</code>)
+              and the result of expanding <var>term</var>
+              using the <a href="#iri-expansion">IRI Expansion algorithm</a>
+              is not the same as the <a>IRI mapping</a> of <var>definition</var>,
+              an <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
               error has been detected and processing is aborted.</li>
             <li class="changed">If <var>term</var> does not contain a colon (<code>:</code>),
               <span class="changed"><var>simple term</var> is <code>true</code></span>, and the,
@@ -5937,6 +5949,8 @@
       <strong>recursive context inclusion</strong> error with a <a data-link-for="JsonLdErrorCode">context overflow</a> error.</li>
     <li>Added support for <code>"@type": "@none"</code> in a <a>term definition</a> to prevent value compaction.</li>
     <li>Added support for <a>JSON literals</a>.</li>
+    <li><a>Term definitions</a> with keys which are of the form of a <a>compact IRI</a> or <a>absolute IRI</a> MUST NOT
+      expand to an <a>IRI</a> other than the expansion of the key itself.</li>
   </ul>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -1307,12 +1307,6 @@
               i.e., it contains no colon (<code>:</code>), an
               <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
               error has been detected and processing is aborted.</li>
-            <li class="changed">If the <var>term</var> contains a colon (<code>:</code>)
-              and the result of expanding <var>term</var>
-              using the <a href="#iri-expansion">IRI Expansion algorithm</a>
-              is not the same as the <a>IRI mapping</a> of <var>definition</var>,
-              an <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
-              error has been detected and processing is aborted.</li>
             <li>If <var>value</var> contains an <code>@container</code> <a>member</a>,
               set the <a>container mapping</a> of <var>definition</var>
               to its value; if its value is neither <code>@set</code>, nor
@@ -1348,6 +1342,7 @@
               <a data-link-for="JsonLdErrorCode">invalid keyword alias</a>
               error has been detected and processing is aborted.</li>
             <li class="changed">If the <var>term</var> contains a colon (<code>:</code>)
+              anywhere but as the last character of <var>term</var>,
               and the result of expanding <var>term</var>
               using the <a href="#iri-expansion">IRI Expansion algorithm</a>
               is not the same as the <a>IRI mapping</a> of <var>definition</var>,

--- a/tests/compact/ep09-context.jsonld
+++ b/tests/compact/ep09-context.jsonld
@@ -1,5 +1,6 @@
 {
   "@context": {
-    "foo:bar": {"@id": "http://example/foo/bar/", "@prefix": true}
+    "foo": "http://example/foo/",
+    "foo:bar": {"@id": "http://example/foo/bar", "@prefix": true}
   }
 }

--- a/tests/compact/p007-context.jsonld
+++ b/tests/compact/p007-context.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
     "foo": "http://example.org/",
-    "foo:bar": "foo:baz/"
+    "foo:bar": {"@type": "@id"}
   }
 }

--- a/tests/compact/p007-in.jsonld
+++ b/tests/compact/p007-in.jsonld
@@ -1,4 +1,4 @@
 {
-  "@id": "http://example.org/baz/a",
-  "http://example.org/baz/b": "c"
+  "@id": "http://example.org/bar/a",
+  "http://example.org/bar/b": "c"
 }

--- a/tests/compact/p007-out.jsonld
+++ b/tests/compact/p007-out.jsonld
@@ -1,8 +1,8 @@
 {
   "@context": {
     "foo": "http://example.org/",
-    "foo:bar": "foo:baz/"
+    "foo:bar": {"@type": "@id"}
   },
-  "@id": "foo:baz/a",
-  "foo:baz/b": "c"
+  "@id": "foo:bar/a",
+  "foo:bar/b": "c"
 }

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -187,7 +187,8 @@
       "name": "Term definition with @id: @type",
       "purpose": "Expanding term mapping to @type uses @type syntax",
       "input": "expand/0026-in.jsonld",
-      "expect": "expand/0026-out.jsonld"
+      "expect": "expand/0026-out.jsonld",
+      "option": {"specVersion": "json-ld-1.0"}
     }, {
       "@id": "#t0027",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -502,7 +503,8 @@
       "name": "Redefine terms looking like compact IRIs",
       "purpose": "Term definitions may look like compact IRIs",
       "input": "expand/0071-in.jsonld",
-      "expect": "expand/0071-out.jsonld"
+      "expect": "expand/0071-out.jsonld",
+      "option": {"specVersion": "json-ld-1.0"}
     }, {
       "@id": "#t0072",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -1225,6 +1227,22 @@
       "purpose": "Verifies that an exception is raised on expansion when processing an invalid context attempting to define @container on a keyword",
       "input": "expand/e042-in.jsonld",
       "expect": "keyword redefinition"
+    }, {
+      "@id": "#te043",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "Term definition with @id: @type",
+      "purpose": "Expanding term mapping to @type uses @type syntax now illegal",
+      "input": "expand/e043-in.jsonld",
+      "expect": "invalid IRI mapping",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#te044",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "Redefine terms looking like compact IRIs",
+      "purpose": "Term definitions may look like compact IRIs, but must be consistent.",
+      "input": "expand/e044-in.jsonld",
+      "expect": "invalid IRI mapping",
+      "option": {"specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tec01",
       "@type": [ "jld:NegativeEvaluationTest", "jld:ExpandTest" ],

--- a/tests/expand/0025-in.jsonld
+++ b/tests/expand/0025-in.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": {
     "foo": "http://example.com/foo/",
-    "foo:bar": "http://example.com/bar",
+    "foo:bar": "http://example.com/foo/bar",
     "bar": {"@id": "foo:bar", "@type": "@id"},
     "_": "http://example.com/underscore/"
   },

--- a/tests/expand/0025-out.jsonld
+++ b/tests/expand/0025-out.jsonld
@@ -1,7 +1,7 @@
 [{
   "@type": [
     "http://example.com/foo/",
-    "http://example.com/bar",
+    "http://example.com/foo/bar",
     "http://example.com/underscore/"
   ]
 }]

--- a/tests/expand/e043-in.jsonld
+++ b/tests/expand/e043-in.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": {"@id": "@type", "@type": "@id"}
+  },
+  "@graph": [
+    {
+      "@id": "http://example.com/a",
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://example.com/b"
+    }, {
+      "@id": "http://example.com/c",
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
+        "http://example.com/d",
+        "http://example.com/e"
+      ]
+    }, {
+      "@id": "http://example.com/f",
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://example.com/g"
+    }
+  ]
+}

--- a/tests/expand/e044-in.jsonld
+++ b/tests/expand/e044-in.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": [
+    {
+      "v": "http://example.com/vocab#",
+      "v:term": "v:somethingElse",
+      "v:termId": { "@id": "v:somethingElseId" }
+    }
+  ],
+  "v:term": "value of v:term",
+  "v:termId": "value of v:termId"
+}

--- a/tests/expand/e045-in.jsonld
+++ b/tests/expand/e045-in.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": [
+    {
+      "v": "http://example.com/vocab#",
+      "v:term": "v:somethingElse",
+      "v:termId": { "@id": "v:somethingElseId" }
+    },
+    {
+      "v:term": "v:term",
+      "v:termId": { "@id": "v:termId" }
+    }
+  ],
+  "v:term": "value of v:term",
+  "v:termId": "value of v:termId"
+}

--- a/tests/flatten-manifest.jsonld
+++ b/tests/flatten-manifest.jsonld
@@ -187,7 +187,8 @@
       "name": "Term definition with @id: @type",
       "purpose": "Flattening term mapping to @type uses @type syntax",
       "input": "flatten/0026-in.jsonld",
-      "expect": "flatten/0026-out.jsonld"
+      "expect": "flatten/0026-out.jsonld",
+      "option": {"specVersion": "json-ld-1.0"}
     }, {
       "@id": "#t0027",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],

--- a/tests/flatten/0025-in.jsonld
+++ b/tests/flatten/0025-in.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": {
     "foo": "http://example.com/foo/",
-    "foo:bar": "http://example.com/bar",
+    "foo:bar": "http://example.com/foo/bar",
     "bar": {"@id": "foo:bar", "@type": "@id"},
     "_": "http://example.com/underscore/"
   },

--- a/tests/flatten/0025-out.jsonld
+++ b/tests/flatten/0025-out.jsonld
@@ -3,7 +3,7 @@
         "@id": "_:b0",
         "@type": [
             "http://example.com/foo/",
-            "http://example.com/bar",
+            "http://example.com/foo/bar",
             "http://example.com/underscore/"
         ]
     }

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -432,7 +432,8 @@
       "name": "Expanding term mapping to @type uses @type syntax",
       "purpose": "RDF version of expand-0026",
       "input": "toRdf/0066-in.jsonld",
-      "expect": "toRdf/0066-out.nq"
+      "expect": "toRdf/0066-out.nq",
+      "option": {"specVersion": "json-ld-1.0"}
     }, {
       "@id": "#t0067",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -748,7 +749,8 @@
       "name": "Redefine terms looking like compact IRIs",
       "purpose": "RDF version of expand-0071",
       "input": "toRdf/0111-in.jsonld",
-      "expect": "toRdf/0111-out.nq"
+      "expect": "toRdf/0111-out.nq",
+      "option": {"specVersion": "json-ld-1.0"}
     }, {
       "@id": "#t0112",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],

--- a/tests/toRdf/0065-in.jsonld
+++ b/tests/toRdf/0065-in.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": {
     "foo": "http://example.com/foo/",
-    "foo:bar": "http://example.com/bar",
+    "foo:bar": "http://example.com/foo/bar",
     "bar": {"@id": "foo:bar", "@type": "@id"},
     "_": "http://example.com/underscore/"
   },

--- a/tests/toRdf/0065-out.nq
+++ b/tests/toRdf/0065-out.nq
@@ -1,3 +1,3 @@
-_:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/bar> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/foo/> .
+_:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/foo/bar> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/underscore/> .


### PR DESCRIPTION
which do not expand in a natural way.

For w3c/json-ld-syntax#155


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/82.html" title="Last updated on Apr 24, 2019, 5:45 PM UTC (cffd00e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/82/ef43954...cffd00e.html" title="Last updated on Apr 24, 2019, 5:45 PM UTC (cffd00e)">Diff</a>