### PR TITLE
The LoadDocumentCallback returns a broken Promise

### DIFF
--- a/index.html
+++ b/index.html
@@ -5627,7 +5627,7 @@
         have to implement to be used to retrieve remote documents and contexts.</p>
 
       <pre class="idl" data-transform="unComment"><!--
-        callback LoadDocumentCallback = Promise&lt;USVString> (USVString url);
+        callback LoadDocumentCallback = Promise&lt;RemoteDocument> (USVString url);
       --></pre>
 
       <dl>


### PR DESCRIPTION
Should be of type `RemoteDocument`, not `USVString`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/86.html" title="Last updated on May 3, 2019, 5:44 PM UTC (b610779)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/86/8cf5a5a...b610779.html" title="Last updated on May 3, 2019, 5:44 PM UTC (b610779)">Diff</a>