### PR TITLE
Update spec and add tests for limiting `@type`-scoped terms to their typed object.

### DIFF
--- a/index.html
+++ b/index.html
@@ -974,14 +974,13 @@
     <p>The <a>active context</a> contains the active
       <a>term definitions</a> which specify how
       keys and values have to be interpreted as well as the current <a>base IRI</a>,
-      the <a>vocabulary mapping</a> and the <a>default language</a>. Each
-      <a>term definition</a> consists of:</p>
+      the <a>vocabulary mapping</a>, the <a>default language</a>,
+      <span class="changed">and an optional <dfn>previous context</dfn>,
+        used when a type-scoped <a>context</a> is defined</span>.
+      Each <a>term definition</a> consists of:</p>
     <ul>
       <li>an <dfn>IRI mapping</dfn>,</li>
       <li>a boolean flag <dfn>reverse property</dfn>,</li>
-      <li class="changed">a boolean flag <dfn>from type</dfn>,</li>
-      <li class="changed">a <dfn>previous definition</dfn>
-        used to record any previous <a>term definition</a>,</li>
       <li>an optional <dfn>type mapping</dfn>, or <dfn>language mapping</dfn>,</li>
       <li class="changed">an optional <a>context</a>,</li>
       <li class="changed">an optional <dfn>nest value</dfn>,</li>
@@ -1079,6 +1078,10 @@
         <li>If <var>local context</var> is not an <a>array</a>,
           set it to an <a>array</a> containing only
           <var>local context</var>.</li>
+        <li class="changed">
+          If <var>from type</var> is <code>true</code>, and <var>result</var>
+          does not have a <a>previous context</a>, set <a>previous context</a>
+          in <var>result</var> to <var>active context</var>.</li>
         <li>
           For each item <var>context</var> in <var>local context</var>:
           <ol>
@@ -1089,8 +1092,10 @@
                   an <a data-link-for="JsonLdErrorCode">invalid context nullification</a>
                   has been detected and processing is aborted.</li>
                 <li>Otherwise, set <var>result</var> to a
-                  newly-initialized <var>active context</var> and continue with the
-                  next <var>context</var>.
+                  newly-initialized <var>active context</var>,
+                  <span class="changed">setting <a>previous context</a> in <var>result</var>
+                    to the previous value of <var>result</var> if <var>from type</var> is <code>true</code></span>.
+                  Continue with the next <var>context</var>.
                   <span class="note">In JSON-LD 1.0, the <a>base IRI</a> was given
                     a default value here; this is now described conditionally
                     in <a href="#the-application-programming-interface" class="sectionRef"></a>.</span></li>
@@ -1275,8 +1280,7 @@
           <var>protected</var> which defaults to <code>false</code>,
           <var>from property</var>, defaulting to <code>false</code>,
           which is used to allow changes to protected terms,
-          and <var>from type</var>, defaulting to <code>false</code>,
-          which is used to mark <a>term definitions</a> associated with a type-scoped <a>context</a>.</span>.
+          and <var>from type</var>, defaulting to <code>false</code>.</span>.
         </p>
       <ol>
         <li>If <var>defined</var> contains the <a>member</a> <var>term</var> and the associated
@@ -1314,8 +1318,6 @@
           <code>@id</code>-<code>null</code>, set the
           <a>term definition</a> in <var>active context</var> to
           <code>null</code>,
-          <span class="changed">along with <a>from type</a> from <var>from type</var>
-            and <a>previous definition</a> from <var>previous definition</var>,</span>
           and set the value associated with <var>defined</var>'s
           <a>member</a> <var>term</var> to <code>true</code>, and return.</li>
         <li>Otherwise, if <var>value</var> is a <a>string</a>, convert it
@@ -1326,9 +1328,7 @@
           <a data-link-for="JsonLdErrorCode">invalid term definition</a>
           error has been detected and processing is aborted.
           <span class="changed">Set <var>simple term</var> to <code>false</code></span>.</li>
-        <li>Create a new <a>term definition</a>, <var>definition</var>,
-          including <a>from type</a> from <var>from type</var>
-            and <a>previous definition</a> from <var>previous definition</var>.</li>
+        <li>Create a new <a>term definition</a>, <var>definition</var>.</li>
         <li class="changed">If the <code>@protected</code> member in <var>value</var>
           is <code>true</code>, or there is no <code>@protected</code> member in <var>value</var>
           and the <var>protected</var> parameter is <code>true</code>,
@@ -1559,34 +1559,6 @@
     </section>
   </section> <!-- end of Term Creation -->
 
-  <section class="changed algorithm"><h2>Revert Type Scoped Terms</h2>
-    <p>This algorithm returns a new <a>context</a> based on the <a>active context</a>
-      where any <a>term definitions</a> which were created as part of a type-scoped <a>context</a>
-      are replaced with any previous term definitions, or removed.</p>
-
-    <p>The algorithm takes a single required parameter <var>active context</var></p>
-    <ol>
-      <li>If <var>active context</var> contains no <a>term definitions</a>
-        where <var>from type</var> is <code>true</code>, return <var>active context</var>.</li>
-      <li>Initialize <var>result</var> to the result of cloning <var>active context</var>.</li>
-      <li>For each <a>member</a> <a>term definition</a> with key <var>term</var> and value <var>definition</var> in <var>result</var>:
-        <ol>
-          <li>If <var>definition</var> has <var>from type</var> with a value of <code>true</code>:
-            <ol>
-              <li>Set <var>previous definition</var> to any <a>previous definition</a>
-                in <var>definition</var>.</li>
-              <li>If <var>previous definition</var> is undefined,
-                remove <var>term</var> and <var>definition</var> from <var>result</var>.</li>
-              <li>Otherwise, update the <a>member</a> value for <var>term</var> in <var>result</var>
-                with <var>previous definition</var>.</li>
-            </ol>
-          </li>
-        </ol>
-      </li>
-      <li>Return <var>result</var>.</li>
-    </ol>
-  </section>
-
   <section>
     <h2>IRI Expansion</h2>
 
@@ -1808,10 +1780,16 @@
         <li>If <var>element</var> is <code>null</code>, return <code>null</code>.</li>
         <li class="changed">If <var>active property</var> is <code>@default</code>,
           set the <a data-link-for="JsonLdOptions">frameExpansion</a> flag to <code>false</code>.</li>
+        <li class="changed">If <var>active property</var> has a <a>term definition</a> in <var>active context</var>
+          has a <a>local context</a>, set <var>property scoped context</var> to the that <a>local context</a>.</li>
         <li>If <var>element</var> is a <a>scalar</a>,
           <ol>
             <li>If <var>active property</var> is <code>null</code> or <code>@graph</code>,
               drop the free-floating <a>scalar</a> by returning <code>null</code>.</li>
+            <li class="changed">If <var>property scoped context</var> is defined,
+              set <var>active context</var> to the result of the
+              <a href="#context-processing-algorithm">Context Processing algorithm</a>,
+              passing <var>active context</var> and <var>property scoped context</var> as <var>local context</var>.</li>
             <li>Return the result of the
               <a href="#value-expansion">Value Expansion algorithm</a>, passing the
               <var>active context</var>, <var>active property</var>, and
@@ -1845,15 +1823,25 @@
           </ol>
         </li>
         <li>Otherwise <var>element</var> is a <a class="changed">dictionary</a>.</li>
+        <li class="changed">If <var>active context</var> has a <a>previous context</a>,
+          the <a>context</a> is type-scoped.
+          If <var>from map</var> is undefined or <code>false</code>,
+          and <var>element</var> does not contain a <a>member</a> expanding to <code>@value</code>,
+          and <var>element</var> does not consist of a single member expanding to <code>@id</code>,
+          set <var>active context</var> to <a>previous context</a> from <var>active context</var>,
+          as the scope of a term-scoped <a>context</a> does not apply when processing new <a>node objects</a>.</li>
+        <li class="changed">If <var>property scoped context</var> is defined,
+          set <var>active context</var> to the result of the
+          <a href="#context-processing-algorithm">Context Processing algorithm</a>,
+          passing <var>active context</var> and <var>property scoped context</var> as <var>local context</var>.</li>
         <li>If <var>element</var> contains the <a>member</a> <code>@context</code>, set
           <var>active context</var> to the result of the
           <a href="#context-processing-algorithm">Context Processing algorithm</a>,
           passing <var>active context</var> and the value of the
           <code>@context</code> <a>member</a> as <var>local context</var>.</li>
-        <li>Unless the <var>from map</var> flag is true,
-          replace <var>active context</var> with the result of the
-          <a href="#revert-type-scoped-terms">Revert Type Scoped Terms</a> algorithm,
-          passing <var>active context</var>.</li>
+        <li class="changed">Set <var>type scoped context</var> to <var>active context</var>.
+          This is used for expanding values that may be relevant to any previous
+          type-scoped <a>context</a>.</li>
         <li class="changed">For each <var>key</var>/<var>value</var> pair in <var>element</var>
           where <var>key</var> expands to <code>@type</code> using the
           <a href="#iri-expansion">IRI Expansion algorithm</a>,
@@ -1918,7 +1906,8 @@
                   error has been detected and processing is aborted. Otherwise,
                   set <var>expanded value</var> to the result of using the
                   <a href="#iri-expansion">IRI Expansion algorithm</a>, passing
-                  <var>active context</var>, <code>true</code> for <var>vocab</var>,
+                  <var class="changed">type scoped context</var> for <var>active context</var>,
+                  <code>true</code> for <var>vocab</var>,
                   and <code>true</code> for <var>document relative</var> to expand the <var>value</var>
                   or each of its items.
                   <span class="changed">
@@ -2060,15 +2049,8 @@
                 <li>Continue with the next <var>key</var> from <var>element</var>.</li>
               </ol>
             </li>
-            <li class="changed">If <var>key</var>'s <a>term definition</a> in <var>active context</var>
-              has a <a>local context</a>, set <var>term context</var> to the result of the
-              <a href="#context-processing-algorithm">Context Processing algorithm</a>,
-              passing <var>active context</var>, the value of the
-              <var>key</var>'s <a>local context</a> as <var>local context</var>,
-              and <code>true</code> for <var>from property</var>. Otherwise,
-              set <var>term context</var> to <var>active context</var>.</li>
             <li>Set <var>container mapping</var> to <var>key</var>'s <a>container mapping</a> in
-              <var class="changed">term context</var>.</li>
+              <var>active context</var>.</li>
             <li class="changed">If <var>key</var>'s <a>term definition</a> in <var>active context</var>
               has a <a>type mapping</a> of <code>@json</code>,
               set <var>expanded value</var> to a new <a>dictionary</a>, set the <a>member</a>
@@ -2123,9 +2105,8 @@
                   <ol>
                     <li class="changed">If <var>container mapping</var> includes <code>@type</code>:
                       <ol>
-                        <li>Set <var>map context</var> to the result of calling the
-                          <a href="#revert-type-scoped-terms">Revert Type Scoped Terms</a> algorithm
-                          passing <var>term context</var> as <var>active context</var>.</li>
+                        <li>Set <var>map context</var> to the <a>previous context</a>
+                          from <var>active context</var> if it exists, or <var>active context</var> otherwise.</li>
                         <li>If <var>index</var>'s <a>term definition</a> in
                           <var>map context</var> has a <a>local context</a>, update
                           <var>map context</var> to the result of the
@@ -2135,7 +2116,7 @@
                           as <var>local context</var>.</li>
                       </ol>
                     </li>
-                    <li>Otherwise, set <var>map context</var> to <var>term context</var>.</li>
+                    <li>Otherwise, set <var>map context</var> to <var>active context</var>.</li>
                     <li>Set <var>expanded index</var> to the result of using the
                       <a href="#iri-expansion">IRI Expansion algorithm</a>,
                       passing <var>active context</var>, <var>index</var>, and <code>true</code>
@@ -2195,7 +2176,7 @@
               </ol>
             </li>
             <li>Otherwise, initialize <var>expanded value</var> to the result of
-              using this algorithm recursively, passing <var class="changed">term context</var> as <var>active context</var>,
+              using this algorithm recursively, passing <var>active context</var>,
               <var>key</var> for <var>active property</var>, <var>value</var> for <var>element</var>,
               <span class="changed">and the <a data-link-for="JsonLdOptions">frameExpansion</a>
                 and <a data-link-for="JsonLdOptions">ordered</a> flags</span>.</li>

--- a/index.html
+++ b/index.html
@@ -975,16 +975,23 @@
       <a>term definitions</a> which specify how
       keys and values have to be interpreted as well as the current <a>base IRI</a>,
       the <a>vocabulary mapping</a> and the <a>default language</a>. Each
-      <a>term definition</a> consists of an <dfn>IRI mapping</dfn>, a boolean
-      flag <dfn>reverse property</dfn>, an optional <dfn>type mapping</dfn>
-      or <dfn>language mapping</dfn>,
-      <span class="changed">an optional <a>context</a></span>,
-      <span class="changed">an optional <dfn>nest value</dfn>,</span>
-      <span class="changed">an optional <dfn>prefix flag</dfn>,</span>
-      <span class="changed">an optional <dfn>index mapping</dfn>,</span>
-      <span class="changed">a <dfn>protected</dfn>, used to mark this as a protected term,</span>
-      and an optional <dfn>container mapping</dfn>.
-      A <a>term definition</a> can not only be used to map a <a>term</a>
+      <a>term definition</a> consists of:</p>
+    <ul>
+      <li>an <dfn>IRI mapping</dfn>,</li>
+      <li>a boolean flag <dfn>reverse property</dfn>,</li>
+      <li class="changed">a boolean flag <dfn>from type</dfn>,</li>
+      <li class="changed">a <dfn>previous definition</dfn>
+        used to record any previous <a>term definition</a>,</li>
+      <li>an optional <dfn>type mapping</dfn>, or <dfn>language mapping</dfn>,</li>
+      <li class="changed">an optional <a>context</a>,</li>
+      <li class="changed">an optional <dfn>nest value</dfn>,</li>
+      <li class="changed">an optional <dfn>prefix flag</dfn>,</li>
+      <li class="changed">an optional <dfn>index mapping</dfn>,</li>
+      <li class="changed">a <dfn>protected</dfn>, used to mark this as a protected term,</li>
+      <li>and an optional <dfn>container mapping</dfn></li>.
+    </ul>
+
+    <p>A <a>term definition</a> can not only be used to map a <a>term</a>
       to an IRI, but also to map a <a>term</a> to a <a>keyword</a>,
       in which case it is referred to as a <dfn>keyword alias</dfn>.</p>
 
@@ -1055,13 +1062,15 @@
 
       <p>This algorithm specifies how a new <a>active context</a> is updated
         with a <a>local context</a>. The algorithm takes two required
-        <span class="changed">and two optional</span>
+        <span class="changed">and three optional</span>
         input variables.
         The required inputs are an <var>active context</var> and a <var>local context</var>.
         The optional inputs are an <a>array</a> <var>remote contexts</var>,
-        defaulting to a new empty <a>array</a>, which is used to detect cyclical context inclusions.
-        <span class="changed">and <var>from term</var>, defaulting to <code>false</code>,
-          which is used to allow changes to protected terms.</span>.
+        defaulting to a new empty <a>array</a>, which is used to detect cyclical context inclusions,
+        <span class="changed">, <var>from property</var>, defaulting to <code>false</code>,
+          which is used to allow changes to protected terms,
+          and <var>from type</var>, defaulting to <code>false</code>,
+          which is used to mark <a>term definitions</a> associated with a type-scoped <a>context</a>.</span>.
       </p>
 
       <ol>
@@ -1075,7 +1084,7 @@
           <ol>
             <li>If <var>context</var> is <code>null</code>:
               <ol>
-                <li class="changed">If <var>from term</var> is <code>false</code> and <var>active context</var>
+                <li class="changed">If <var>from property</var> is <code>false</code> and <var>active context</var>
                   contains any <a>protected</a> <a>term definitions</a>,
                   an <a data-link-for="JsonLdErrorCode">invalid context nullification</a>
                   has been detected and processing is aborted.</li>
@@ -1213,7 +1222,7 @@
               <var>defined</var>,
               <span class="changed">the value of the <code>@protected</code>
                 member from <var>context</var>, if any, for <var>protected</var></span>,
-                and <var>from term</var>.</li>
+                <var>from property</var>, and <var>from type</var>.</li>
           </ol>
         </li>
         <li>Return <var>result</var>.</li>
@@ -1258,14 +1267,16 @@
     <section class="algorithm">
       <h3>Algorithm</h3>
 
-      <p>The algorithm has four required <span class="changed">and two optional</span> inputs.
+      <p>The algorithm has four required <span class="changed">and three optional</span> inputs.
         The required inputs are
         an <var>active context</var>, a <var>local context</var>,
         a <var>term</var>, and a map <var>defined</var>.
         <span class="changed">The optional inputs are
           <var>protected</var> which defaults to <code>false</code>,
-          and <var>from term</var>, defaulting to <code>false</code>,
-          which is used to allow changes to protected terms.</span>.
+          <var>from property</var>, defaulting to <code>false</code>,
+          which is used to allow changes to protected terms,
+          and <var>from type</var>, defaulting to <code>false</code>,
+          which is used to mark <a>term definitions</a> associated with a type-scoped <a>context</a>.</span>.
         </p>
       <ol>
         <li>If <var>defined</var> contains the <a>member</a> <var>term</var> and the associated
@@ -1290,18 +1301,22 @@
           <var>term</var> MUST NOT be a <a>keyword</a> and a
           <a data-link-for="JsonLdErrorCode">keyword redefinition</a>
           error has been detected and processing is aborted.</li>
-        <li class="changed">If <var>from term</var> is <code>false</code>
-          and <var>active context</var> has an existing
-          <a>term definition</a> for <var>term</var> which is protected,
+        <li class="changed">Set <var>previous definition</var> to any existing
+          <a>term definition</a> for <var>term</var> in <var>active context</var>.</li>
+        <li class="changed">If <var>from property</var> is <code>false</code>
+          and <var>previous definition</var> exists and is protected,
           a <a data-link-for="JsonLdErrorCode">protected term redefinition</a> error has been detected,
           and processing is aborted.</li>
-        <li>Otherwise, remove any existing <a>term definition</a> for <var>term</var> in
+        <li>Otherwise, remove any <var>previous definition</var> from
           <var>active context</var>.</li>
         <li>If <var>value</var> is <code>null</code> or <var>value</var>
           is a <a class="changed">dictionary</a> containing the key-value pair
           <code>@id</code>-<code>null</code>, set the
           <a>term definition</a> in <var>active context</var> to
-          <code>null</code>, set the value associated with <var>defined</var>'s
+          <code>null</code>,
+          <span class="changed">along with <a>from type</a> from <var>from type</var>
+            and <a>previous definition</a> from <var>previous definition</var>,</span>
+          and set the value associated with <var>defined</var>'s
           <a>member</a> <var>term</var> to <code>true</code>, and return.</li>
         <li>Otherwise, if <var>value</var> is a <a>string</a>, convert it
           to a <a class="changed">dictionary</a> consisting of a single <a>member</a> whose
@@ -1311,7 +1326,9 @@
           <a data-link-for="JsonLdErrorCode">invalid term definition</a>
           error has been detected and processing is aborted.
           <span class="changed">Set <var>simple term</var> to <code>false</code></span>.</li>
-        <li>Create a new <a>term definition</a>, <var>definition</var>.</li>
+        <li>Create a new <a>term definition</a>, <var>definition</var>,
+          including <a>from type</a> from <var>from type</var>
+            and <a>previous definition</a> from <var>previous definition</var>.</li>
         <li class="changed">If the <code>@protected</code> member in <var>value</var>
           is <code>true</code>, or there is no <code>@protected</code> member in <var>value</var>
           and the <var>protected</var> parameter is <code>true</code>,
@@ -1484,7 +1501,7 @@
               <code>@context</code> <a>member</a>, which is treated as a <var>local context</var>.</li>
             <li>Invoke the <a href="#context-processing-algorithm">Context Processing algorithm</a>
               using the <var>active context</var>, <var>context</var> as <var>local context</var>,
-              and <code>true</code> for <var>from term</var>.
+              and <code>true</code> for <var>from property</var>.
               If any error is detected, an
               <a data-link-for="JsonLdErrorCode">invalid scoped context</a> error
               has been detected and processing is aborted.</li>
@@ -1541,6 +1558,34 @@
       </ol>
     </section>
   </section> <!-- end of Term Creation -->
+
+  <section class="changed algorithm"><h2>Revert Type Scoped Terms</h2>
+    <p>This algorithm returns a new <a>context</a> based on the <a>active context</a>
+      where any <a>term definitions</a> which were created as part of a type-scoped <a>context</a>
+      are replaced with any previous term definitions, or removed.</p>
+
+    <p>The algorithm takes a single required parameter <var>active context</var></p>
+    <ol>
+      <li>If <var>active context</var> contains no <a>term definitions</a>
+        where <var>from type</var> is <code>true</code>, return <var>active context</var>.</li>
+      <li>Initialize <var>result</var> to the result of cloning <var>active context</var>.</li>
+      <li>For each <a>member</a> <a>term definition</a> with key <var>term</var> and value <var>definition</var> in <var>result</var>:
+        <ol>
+          <li>If <var>definition</var> has <var>from type</var> with a value of <code>true</code>:
+            <ol>
+              <li>Set <var>previous definition</var> to any <a>previous definition</a>
+                in <var>definition</var>.</li>
+              <li>If <var>previous definition</var> is undefined,
+                remove <var>term</var> and <var>definition</var> from <var>result</var>.</li>
+              <li>Otherwise, update the <a>member</a> value for <var>term</var> in <var>result</var>
+                with <var>previous definition</var>.</li>
+            </ol>
+          </li>
+        </ol>
+      </li>
+      <li>Return <var>result</var>.</li>
+    </ol>
+  </section>
 
   <section>
     <h2>IRI Expansion</h2>
@@ -1723,14 +1768,16 @@
     <section class="algorithm">
       <h3>Algorithm</h3>
 
-      <p>The algorithm takes three required <span class="changed">and two optional</span> input variables.
+      <p>The algorithm takes three required <span class="changed">and three optional</span> input variables.
         The required inputs are an <var>active context</var>,
         an <var>active property</var>, and an <var>element</var> to be expanded.
         <span class="changed">The optional inputs are the
           <a data-link-for="JsonLdOptions">frameExpansion</a>
           flag allowing special forms of input used for <a data-cite="JSON-LD11-FRAMING#dfn-framing">frame expansion</a>,
-          and the <a data-link-for="JsonLdOptions">ordered</a> flag, used to order
-          <a>dictionary member</a> keys lexicographically, where noted</span>.
+          the <a data-link-for="JsonLdOptions">ordered</a> flag, used to order
+          <a>dictionary member</a> keys lexicographically, where noted,
+          and the <var>from map</var> flag, used to control reverting
+          previous <a>term definitions</a> in the <a>active context</a> associated with a type-scoped <a>context</a>.</span>
         To begin, the <var>active property</var> is set to <code>null</code>,
         and <var>element</var> is set to the <a>JSON-LD input</a>.
         <span class="changed">If not passed, the both flags are set to <code>false</code></span>.</p>
@@ -1780,7 +1827,8 @@
                   algorithm recursively, passing <var>active context</var>,
                   <var>active property</var>, <var>item</var> as <var>element</var>,
                   <span class="changed">the <a data-link-for="JsonLdOptions">frameExpansion</a>
-                    and <a data-link-for="JsonLdOptions">ordered</a></span> flags.</li>
+                    <a data-link-for="JsonLdOptions">ordered</a></span>,
+                    and <var>from map</var> flags.</li>
                 <li class="changed">If the <a>container mapping</a>
                   of <var>active property</var> includes <code>@list</code>,
                   and <var>expanded item</var> is an
@@ -1802,6 +1850,10 @@
           <a href="#context-processing-algorithm">Context Processing algorithm</a>,
           passing <var>active context</var> and the value of the
           <code>@context</code> <a>member</a> as <var>local context</var>.</li>
+        <li>Unless the <var>from map</var> flag is true,
+          replace <var>active context</var> with the result of the
+          <a href="#revert-type-scoped-terms">Revert Type Scoped Terms</a> algorithm,
+          passing <var>active context</var>.</li>
         <li class="changed">For each <var>key</var>/<var>value</var> pair in <var>element</var>
           where <var>key</var> expands to <code>@type</code> using the
           <a href="#iri-expansion">IRI Expansion algorithm</a>,
@@ -1813,8 +1865,9 @@
               has a <a>local context</a>, set <var>active context</var> to the result
               to the result of the
               <a href="#context-processing-algorithm">Context Processing algorithm</a>,
-              passing <var>active context</var> and the value of the
-              <var>term</var>'s <a>local context</a> as <var>local context</var>.</li>
+              passing <var>active context</var>, the value of the
+              <var>term</var>'s <a>local context</a> as <var>local context</var>,
+              <span class="changed">and <code>true</code> for <var>from type</var></span>.</li>
           </ol>
         </li>
         <li>Initialize an empty <a class="changed">dictionary</a>, <var>result</var>.</li>
@@ -2012,7 +2065,7 @@
               <a href="#context-processing-algorithm">Context Processing algorithm</a>,
               passing <var>active context</var>, the value of the
               <var>key</var>'s <a>local context</a> as <var>local context</var>,
-              and <code>true</code> for <var>from term</var>. Otherwise,
+              and <code>true</code> for <var>from property</var>. Otherwise,
               set <var>term context</var> to <var>active context</var>.</li>
             <li>Set <var>container mapping</var> to <var>key</var>'s <a>container mapping</a> in
               <var class="changed">term context</var>.</li>
@@ -2068,15 +2121,21 @@
                   in <var>value</var>, ordered lexicographically by <var>index</var>
                   <span class="changed">if <a data-link-for="JsonLdOptions">ordered</a> is <code>true</code></span>:
                   <ol>
-                    <li class="changed">If <var>container mapping</var> includes <code>@type</code>,
-                      and <var>index</var>'s <a>term definition</a> in
-                      <var>term context</var> has a <a>local context</a>, set
-                      <var>map context</var> to the result of the <a
-                      href="#context-processing-algorithm">Context Processing
-                      algorithm</a>, passing <var>term context</var> as <var>active context</var> and the
-                      value of the <var>index</var>'s <a>local context</a> as
-                      <var>local context</var>. Otherwise, set <var>map context</var>
-                      to <var>term context</var>.</li>
+                    <li class="changed">If <var>container mapping</var> includes <code>@type</code>:
+                      <ol>
+                        <li>Set <var>map context</var> to the result of calling the
+                          <a href="#revert-type-scoped-terms">Revert Type Scoped Terms</a> algorithm
+                          passing <var>term context</var> as <var>active context</var>.</li>
+                        <li>If <var>index</var>'s <a>term definition</a> in
+                          <var>map context</var> has a <a>local context</a>, update
+                          <var>map context</var> to the result of the
+                          <a href="#context-processing-algorithm">Context Processingalgorithm</a>,
+                          passing <var>map context</var> as <var>active context</var>
+                          and the value of the <var>index</var>'s <a>local context</a>
+                          as <var>local context</var>.</li>
+                      </ol>
+                    </li>
+                    <li>Otherwise, set <var>map context</var> to <var>term context</var>.</li>
                     <li>Set <var>expanded index</var> to the result of using the
                       <a href="#iri-expansion">IRI Expansion algorithm</a>,
                       passing <var>active context</var>, <var>index</var>, and <code>true</code>
@@ -2459,7 +2518,7 @@
               <a href="#context-processing-algorithm">Context Processing algorithm</a>,
               passing <var>active context</var>, the value of the
               <var>active property</var>'s <a>local context</a> as <var>local context</var>,
-              <span class="changed">and <code>true</code> for <var>from term</var></span>.</li>
+              <span class="changed">and <code>true</code> for <var>from property</var></span>.</li>
             <li>Set <var>inverse context</var> using the
               <a href="#inverse-context-creation">Inverse Context Creation algorithm</a>
               using <var>active context</var>.</li>
@@ -2517,13 +2576,17 @@
           <var>active property</var> equals <code>@reverse</code>,
           otherwise to <code>false</code>.</li>
         <li>Initialize <var>result</var> to an empty <a class="changed">dictionary</a>.</li>
+        <li>Replace <var>active context</var> with the result of the
+          <a href="#revert-type-scoped-terms">Revert Type Scoped Terms</a> algorithm,
+          passing <var>active context</var>.</li>
         <li class="changed">If <var>element</var> has a <code>@type</code> <a>member</a>,
           create a new array <var>compacted types</var> initialized
           by transforming each <var>expanded type</var> of that <a>member</a>
           into it's compacted form using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
           passing <var>active context</var>, <var>inverse context</var>,
-          <var>expanded type</var> for <var>var</var>, and
-          <code>true</code> for <var>vocab</var>. Then, for each <var>term</var>
+          <var>expanded type</var> for <var>var</var>, <code>true</code> for <var>vocab</var>,
+          and <code>true</code> for <var>from type</var>.
+          Then, for each <var>term</var>
           in <var>compacted types</var> ordered lexicographically:
           <ol>
             <li>If the <a>term definition</a> for <var>term</var> has a

--- a/index.html
+++ b/index.html
@@ -2129,7 +2129,7 @@
                         <li>If <var>index</var>'s <a>term definition</a> in
                           <var>map context</var> has a <a>local context</a>, update
                           <var>map context</var> to the result of the
-                          <a href="#context-processing-algorithm">Context Processingalgorithm</a>,
+                          <a href="#context-processing-algorithm">Context Processing algorithm</a>,
                           passing <var>map context</var> as <var>active context</var>
                           and the value of the <var>index</var>'s <a>local context</a>
                           as <var>local context</var>.</li>

--- a/index.html
+++ b/index.html
@@ -3384,12 +3384,10 @@
                 <li>If the value does not contain an <code>@id</code> <a>member</a>,
                   append the values <code>@graph@id</code> and <code>@graph@id@set</code>
                   to <var>containers</var>.</li>
-                <li>Append the values <code>@index</code>, <code>@index@set</code>,
-                  and <code>@set</code>
+                <li>Append the values <code>@index</code> and <code>@index@set</code>
                   to <var>containers</var>.</li>
                 <li>Set <var>type/language</var> to <code>@type</code>
                   and set <var>type/language value</var> to <code>@id</code>.</li>
-                <li>Append <code>@set</code> to <var>containers</var>.</li>
               </ol>
             </li>
             <li>Otherwise:

--- a/index.html
+++ b/index.html
@@ -1824,7 +1824,7 @@
         </li>
         <li>Otherwise <var>element</var> is a <a class="changed">dictionary</a>.</li>
         <li class="changed">If <var>active context</var> has a <a>previous context</a>,
-          the <a>context</a> is type-scoped.
+          the <var>active context</var> is type-scoped.
           If <var>from map</var> is undefined or <code>false</code>,
           and <var>element</var> does not contain a <a>member</a> expanding to <code>@value</code>,
           and <var>element</var> does not consist of a single member expanding to <code>@id</code>,
@@ -2492,19 +2492,9 @@
         <span class="changed">If not passed, the both flags are set to <code>false</code></span>.</p>
 
       <ol>
-        <li class="changed">If the <a>term definition</a> for <var>active property</var> has a
-          <a>local context</a>:
-          <ol>
-            <li>Set <var>active context</var> to the result of the
-              <a href="#context-processing-algorithm">Context Processing algorithm</a>,
-              passing <var>active context</var>, the value of the
-              <var>active property</var>'s <a>local context</a> as <var>local context</var>,
-              <span class="changed">and <code>true</code> for <var>from property</var></span>.</li>
-            <li>Set <var>inverse context</var> using the
-              <a href="#inverse-context-creation">Inverse Context Creation algorithm</a>
-              using <var>active context</var>.</li>
-          </ol>
-        </li>
+        <li class="changed">Set <var>type scoped context</var> to <var>active context</var>.
+          This is used for compacting values that may be relevant to any previous
+          type-scoped <a>context</a>.</li>
         <li>If <var>element</var> is a <a>scalar</a>, it is already in its most
           compact form, so simply return <var>element</var>.</li>
         <li>If <var>element</var> is an <a>array</a>:
@@ -2534,8 +2524,27 @@
             <li>Return <var>result</var>.</li>
           </ol>
         </li>
-        <li>Otherwise <var>element</var> is a <a class="changed">dictionary</a>.
-          If <var>element</var> has an <code>@value</code> or <code>@id</code>
+        <li>Otherwise <var>element</var> is a <a class="changed">dictionary</a>.</li>
+        <li class="changed">If <var>active context</var> has a <a>previous context</a>,
+          the <var>active context</var> is type-scoped.
+          If <var>element</var> does not contain an <code>@value</code> <a>member</a>,
+          and <var>element</var> does not consist of a single <code>@id</code> member,
+          set <var>active context</var> to <a>previous context</a> from <var>active context</var>,
+          as the scope of a term-scoped <a>context</a> does not apply when processing new <a>node objects</a>.</li>
+        <li class="changed">If the <a>term definition</a> for <var>active property</var> has a
+          <a>local context</a>:
+          <ol>
+            <li>Set <var>active context</var> to the result of the
+              <a href="#context-processing-algorithm">Context Processing algorithm</a>,
+              passing <var>active context</var>, the value of the
+              <var>active property</var>'s <a>local context</a> as <var>local context</var>,
+              <span class="changed">and <code>true</code> for <var>from property</var></span>.</li>
+            <li>Set <var>inverse context</var> using the
+              <a href="#inverse-context-creation">Inverse Context Creation algorithm</a>
+              using <var>active context</var>.</li>
+          </ol>
+        </li>
+        <li>If <var>element</var> has an <code>@value</code> or <code>@id</code>
           <a>member</a> and the result of using the
           <a href="#value-compaction">Value Compaction algorithm</a>,
           passing <var>active context</var>, <var>inverse context</var>,
@@ -2557,9 +2566,6 @@
           <var>active property</var> equals <code>@reverse</code>,
           otherwise to <code>false</code>.</li>
         <li>Initialize <var>result</var> to an empty <a class="changed">dictionary</a>.</li>
-        <li>Replace <var>active context</var> with the result of the
-          <a href="#revert-type-scoped-terms">Revert Type Scoped Terms</a> algorithm,
-          passing <var>active context</var>.</li>
         <li class="changed">If <var>element</var> has a <code>@type</code> <a>member</a>,
           create a new array <var>compacted types</var> initialized
           by transforming each <var>expanded type</var> of that <a>member</a>
@@ -2570,13 +2576,13 @@
           Then, for each <var>term</var>
           in <var>compacted types</var> ordered lexicographically:
           <ol>
-            <li>If the <a>term definition</a> for <var>term</var> has a
+            <li>If the <a>term definition</a> for <var>term</var> in <var>type scoped context</var> has a
               <a>local context</a>:
               <ol>
                 <li>Set <var>active context</var> to the result of the
                   <a href="#context-processing-algorithm">Context Processing algorithm</a>,
                   passing <var>active context</var> and the value of <var>term</var>'s
-                  <a>local context</a> as <var>local context</var>.</li>
+                  <a>local context</a> in <var>type scoped context</var> as <var>local context</var>.</li>
                 <li>Set <var>inverse context</var> using the
                   <a href="#inverse-context-creation">Inverse Context Creation algorithm</a>
                   using <var>active context</var>.</li>
@@ -2588,54 +2594,66 @@
           in <var>element</var>, ordered lexicographically by <var>expanded property</var>
           <span class="changed">if <a data-link-for="JsonLdOptions">ordered</a> is <code>true</code></span>:
           <ol>
-            <li>If <var>expanded property</var> is <code>@id</code> or
-              <code>@type</code>:
-                <ol>
-                  <li>If <var>expanded value</var> is a <a>string</a>,
-                    then initialize <var>compacted value</var> to the result
-                    of using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
-                    passing <var>active context</var>, <var>inverse context</var>,
-                    <var>expanded value</var> for <var>var</var>,
-                    and <code>true</code> for <var>vocab</var> if
-                    <var>expanded property</var> is <code>@type</code>,
-                    <code>false</code> otherwise.</li>
-                  <li>Otherwise, <var>expanded value</var> must be a
-                    <code>@type</code> <a>array</a>:
-                    <ol>
-                      <li>Initialize <var>compacted value</var> to an empty
-                        <a>array</a>.</li>
-                      <li>For each item <var>expanded type</var> in
-                        <var>expanded value</var>:
-                        <ol>
-                          <li>Set <var>term</var> to the result of
-                            of using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
-                            passing <var>active context</var>, <var>inverse context</var>,
-                            <var>expanded type</var> for <var>var</var>, and
-                            <code>true</code> for <var>vocab</var>.</li>
-                          <li>Append <var>term</var>, to <var>compacted value</var>.</li>
-                        </ol>
-                      </li>
-                      <li>If <var>compacted value</var> contains only one
-                        item (it has a length of <code>1</code>), then
-                        set <var>compacted value</var> to its only item.</li>
-                    </ol>
-                  </li>
-                  <li>Initialize <var>alias</var> to the result of using the
-                    <a href="#iri-compaction">IRI Compaction algorithm</a>,
-                    passing <var>active context</var>, <var>inverse context</var>,
-                    <var>expanded property</var> for <var>var</var>,
-                    and <code>true</code> for <var>vocab</var>.</li>
-                  <li class="changed">If <a>processing mode</a> is <code>json-ld-1.1</code>,
-                    <var>element</var> does not have an <code>@value</code> member,
-                    <var>expanded property</var> is <code>@type</code>,
-                    and the <a>term definition</a> for <var>alias</var> in the
-                    <var>active context</var> has a <a>container mapping</a> including <code>@set</code>,
-                    ensure that <var>compacted value</var> is an <a>array</a>.</li>
-                  <li>Add a <a>member</a> <var>alias</var> to <var>result</var> whose value is
-                    set to <var>compacted value</var> and continue to the next
-                    <var>expanded property</var>.</li>
-                </ol>
-              </li>
+            <li>If <var>expanded property</var> is <code>@id</code>:
+              <ol>
+                <li>If <var>expanded value</var> is a <a>string</a>,
+                  then initialize <var>compacted value</var> to the result
+                  of using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
+                  passing <var>active context</var>, <var>inverse context</var>,
+                  and <var>expanded value</var> for <var>var</var>.</li>
+                <li>Initialize <var>alias</var> to the result of using the
+                  <a href="#iri-compaction">IRI Compaction algorithm</a>,
+                  passing <var>active context</var>, <var>inverse context</var>,
+                  <var>expanded property</var> for <var>var</var>,
+                  and <code>true</code> for <var>vocab</var>.</li>
+                <li>Add a <a>member</a> <var>alias</var> to <var>result</var> whose value is
+                  set to <var>compacted value</var> and continue to the next
+                  <var>expanded property</var>.</li>
+              </ol>
+            </li>
+            <li>If <var>expanded property</var> is <code>@type</code>:
+              <ol>
+                <li>If <var>expanded value</var> is a <a>string</a>,
+                  then initialize <var>compacted value</var> to the result
+                  of using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
+                  passing <var>type scoped context</var> for <var>active context</var>, <var>inverse context</var>,
+                  <var>expanded value</var> for <var>var</var>,
+                  and <code>true</code> for <var>vocab</var>.</li>
+                <li>Otherwise, <var>expanded value</var> must be a
+                  <code>@type</code> <a>array</a>:
+                  <ol>
+                    <li>Initialize <var>compacted value</var> to an empty
+                      <a>array</a>.</li>
+                    <li>For each item <var>expanded type</var> in
+                      <var>expanded value</var>:
+                      <ol>
+                        <li>Set <var>term</var> to the result of
+                          of using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
+                          passing <var>type scoped context</var> for <var>active context</var>, <var>inverse context</var>,
+                          <var>expanded type</var> for <var>var</var>, and
+                          <code>true</code> for <var>vocab</var>.</li>
+                        <li>Append <var>term</var>, to <var>compacted value</var>.</li>
+                      </ol>
+                    </li>
+                    <li>If <var>compacted value</var> contains only one
+                      item (it has a length of <code>1</code>), then
+                      set <var>compacted value</var> to its only item.</li>
+                  </ol>
+                </li>
+                <li>Initialize <var>alias</var> to the result of using the
+                  <a href="#iri-compaction">IRI Compaction algorithm</a>,
+                  passing <var>active context</var>, <var>inverse context</var>,
+                  <var>expanded property</var> for <var>var</var>,
+                  and <code>true</code> for <var>vocab</var>.</li>
+                <li class="changed">If <a>processing mode</a> is <code>json-ld-1.1</code>,
+                  and the <a>term definition</a> for <var>alias</var> in the
+                  <var>active context</var> has a <a>container mapping</a> including <code>@set</code>,
+                  ensure that <var>compacted value</var> is an <a>array</a>.</li>
+                <li>Add a <a>member</a> <var>alias</var> to <var>result</var> whose value is
+                  set to <var>compacted value</var> and continue to the next
+                  <var>expanded property</var>.</li>
+              </ol>
+            </li>
             <li>If <var>expanded property</var> is <code>@reverse</code>:
               <ol>
                 <li>Initialize <var>compacted value</var> to the result of using this

--- a/index.html
+++ b/index.html
@@ -3384,8 +3384,12 @@
                 <li>If the value does not contain an <code>@id</code> <a>member</a>,
                   append the values <code>@graph@id</code> and <code>@graph@id@set</code>
                   to <var>containers</var>.</li>
-                <li>Append the values <code>@index</code> and <code>@index@set</code>
+                <li>Append the values <code>@index</code>, <code>@index@set</code>,
+                  and <code>@set</code>
                   to <var>containers</var>.</li>
+                <li>Set <var>type/language</var> to <code>@type</code>
+                  and set <var>type/language value</var> to <code>@id</code>.</li>
+                <li>Append <code>@set</code> to <var>containers</var>.</li>
               </ol>
             </li>
             <li>Otherwise:

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -1122,6 +1122,15 @@
       "expect": "compact/c023-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tc024",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "type-scoped + property-scoped + values evaluates against previous context",
+      "purpose": "type-scoped + property-scoped + values evaluates against previous context",
+      "input": "compact/c024-in.jsonld",
+      "context": "compact/c024-context.jsonld",
+      "expect": "compact/c024-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#te001",
       "@type": [ "jld:NegativeEvaluationTest", "jld:CompactTest" ],
       "name": "Compaction to list of lists",

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -1685,8 +1685,8 @@
       "name": "Check illegal overriding of protected term from type-scoped context",
       "purpose": "Check error when overriding a protected term from type-scoped context.",
       "option": {"specVersion": "json-ld-1.1"},
-      "input": "compact/pr02-in.jsonld",
-      "context": "compact/pr02-context.jsonld",
+      "input": "compact/pr03-in.jsonld",
+      "context": "compact/pr03-context.jsonld",
       "expect": "protected term redefinition"
     }, {
       "@id": "#tpr04",

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -1707,7 +1707,6 @@
       "context": "compact/pr05-context.jsonld",
       "expect": "compact/pr05-out.jsonld"
     }, {
-    }, {
       "@id": "#tr001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Expands and compacts to document base by default",

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -1086,6 +1086,15 @@
       "expect": "compact/c019-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tc020",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "type-scoped value",
+      "purpose": "type-scoped value",
+      "input": "compact/c020-in.jsonld",
+      "context": "compact/c020-context.jsonld",
+      "expect": "compact/c020-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#te001",
       "@type": [ "jld:NegativeEvaluationTest", "jld:CompactTest" ],
       "name": "Compaction to list of lists",

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -989,7 +989,7 @@
     }, {
       "@id": "#tc009",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
-      "name": "deep @context affects nested nodes",
+      "name": "deep @type-scoped @context does NOT affect nested nodes",
       "purpose": "scoped context on @type",
       "input": "compact/c009-in.jsonld",
       "context": "compact/c009-context.jsonld",
@@ -1022,6 +1022,15 @@
       "context": "compact/c012-context.jsonld",
       "expect": "compact/c012-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tc013",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "deep property-term scoped @context in @type-scoped @context affects nested nodes",
+      "purpose": "scoped context on @type",
+      "input": "compact/c013-in.jsonld",
+      "context": "compact/c013-context.jsonld",
+      "expect": "compact/c013-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}    
     }, {
       "@id": "#te001",
       "@type": [ "jld:NegativeEvaluationTest", "jld:CompactTest" ],

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -1131,6 +1131,15 @@
       "expect": "compact/c024-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tc025",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "type-scoped + graph container",
+      "purpose": "type-scoped + graph container",
+      "input": "compact/c025-in.jsonld",
+      "context": "compact/c025-context.jsonld",
+      "expect": "compact/c025-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#te001",
       "@type": [ "jld:NegativeEvaluationTest", "jld:CompactTest" ],
       "name": "Compaction to list of lists",

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -1095,6 +1095,15 @@
       "expect": "compact/c020-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tc021",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "type-scoped value mix",
+      "purpose": "type-scoped value mix",
+      "input": "compact/c021-in.jsonld",
+      "context": "compact/c021-context.jsonld",
+      "expect": "compact/c021-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#te001",
       "@type": [ "jld:NegativeEvaluationTest", "jld:CompactTest" ],
       "name": "Compaction to list of lists",

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -1698,6 +1698,16 @@
       "context": "compact/pr04-context.jsonld",
       "expect": "compact/pr04-out.jsonld"
     }, {
+      "@id": "#tpr05",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Check legal overriding of type-scoped protected term from nested node",
+      "purpose": "Check legal overriding of type-scoped protected term from nested node.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "compact/pr05-in.jsonld",
+      "context": "compact/pr05-context.jsonld",
+      "expect": "compact/pr05-out.jsonld"
+    }, {
+    }, {
       "@id": "#tr001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Expands and compacts to document base by default",

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -1032,6 +1032,60 @@
       "expect": "compact/c013-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}    
     }, {
+      "@id": "#tc014",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "type-scoped context nullification",
+      "purpose": "type-scoped context nullification",
+      "input": "compact/c014-in.jsonld",
+      "context": "compact/c014-context.jsonld",
+      "expect": "compact/c014-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tc015",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "type-scoped base",
+      "purpose": "type-scoped base",
+      "input": "compact/c015-in.jsonld",
+      "context": "compact/c015-context.jsonld",
+      "expect": "compact/c015-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tc016",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "type-scoped vocab",
+      "purpose": "type-scoped vocab",
+      "input": "compact/c016-in.jsonld",
+      "context": "compact/c016-context.jsonld",
+      "expect": "compact/c016-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tc017",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "multiple type-scoped contexts are properly reverted",
+      "purpose": "multiple type-scoped contexts are property reverted",
+      "input": "compact/c017-in.jsonld",
+      "context": "compact/c017-context.jsonld",
+      "expect": "compact/c017-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tc018",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "multiple type-scoped types resolved against previous context",
+      "purpose": "multiple type-scoped types resolved against previous context",
+      "input": "compact/c018-in.jsonld",
+      "context": "compact/c018-context.jsonld",
+      "expect": "compact/c018-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tc019",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "type-scoped context with multiple property scoped terms",
+      "purpose": "type-scoped context with multiple property scoped terms",
+      "input": "compact/c019-in.jsonld",
+      "context": "compact/c019-context.jsonld",
+      "expect": "compact/c019-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#te001",
       "@type": [ "jld:NegativeEvaluationTest", "jld:CompactTest" ],
       "name": "Compaction to list of lists",

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -1104,6 +1104,24 @@
       "expect": "compact/c021-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tc022",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "type-scoped property-scoped contexts including @type:@vocab",
+      "purpose": "type-scoped property-scoped contexts including @type:@vocab",
+      "input": "compact/c022-in.jsonld",
+      "context": "compact/c022-context.jsonld",
+      "expect": "compact/c022-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tc023",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "composed type-scoped property-scoped contexts including @type:@vocab",
+      "purpose": "composed type-scoped property-scoped contexts including @type:@vocab",
+      "input": "compact/c023-in.jsonld",
+      "context": "compact/c023-context.jsonld",
+      "expect": "compact/c023-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#te001",
       "@type": [ "jld:NegativeEvaluationTest", "jld:CompactTest" ],
       "name": "Compaction to list of lists",

--- a/tests/compact/c009-out.jsonld
+++ b/tests/compact/c009-out.jsonld
@@ -4,5 +4,5 @@
     "Foo": {"@context": {"baz": {"@type": "@vocab"}}}
   },
   "@type": "Foo",
-  "bar": {"baz": "buzz"}
+  "bar": {"baz": {"@id": "http://example/buzz"}}
 }

--- a/tests/compact/c013-context.jsonld
+++ b/tests/compact/c013-context.jsonld
@@ -1,0 +1,14 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "Foo": {
+      "@context": {
+        "bar": {
+          "@context": {
+            "baz": {"@type": "@vocab"}
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/compact/c013-in.jsonld
+++ b/tests/compact/c013-in.jsonld
@@ -2,7 +2,7 @@
   {
     "@type": ["http://example/Foo"],
     "http://example/bar": [{
-      "http://example/baz": [{"@value": "buzz"}]
+      "http://example/baz": [{"@id": "http://example/buzz"}]
     }]
   }
 ]

--- a/tests/compact/c013-out.jsonld
+++ b/tests/compact/c013-out.jsonld
@@ -1,0 +1,16 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "Foo": {
+      "@context": {
+        "bar": {
+          "@context": {
+            "baz": {"@type": "@vocab"}
+          }
+        }
+      }
+    }
+  },
+  "@type": "Foo",
+  "bar": {"baz": "buzz"}
+}

--- a/tests/compact/c014-context.jsonld
+++ b/tests/compact/c014-context.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "foo": "http://example/foo",
+    "Type": {
+      "@context": [
+        null
+      ]
+    }
+  }
+}

--- a/tests/compact/c014-in.jsonld
+++ b/tests/compact/c014-in.jsonld
@@ -1,0 +1,8 @@
+[{
+  "http://example/foo": [{
+    "@value": "will-exist"
+  }],
+  "http://example/p": [{
+    "@type": ["http://example/Type"]
+  }]
+}]

--- a/tests/compact/c014-out.jsonld
+++ b/tests/compact/c014-out.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "foo": "http://example/foo",
+    "Type": {
+      "@context": [
+        null
+      ]
+    }
+  },
+  "foo": "will-exist",
+  "p": {
+    "@type": "Type"
+  }
+}

--- a/tests/compact/c015-context.jsonld
+++ b/tests/compact/c015-context.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "@base": "http://example/base-base",
+    "@vocab": "http://example/",
+    "foo": "http://example/foo",
+    "Type": {
+      "@context": {
+        "@base": "http://example/typed-base"
+      }
+    }
+  }
+}

--- a/tests/compact/c015-in.jsonld
+++ b/tests/compact/c015-in.jsonld
@@ -1,0 +1,10 @@
+[{
+  "@id": "http://example/base-base#base-id",
+  "http://example/p": [{
+    "@id": "http://example/typed-base#typed-id",
+    "@type": ["http://example/Type"],
+    "http://example/nested": [{
+      "@id": "http://example/base-base#nested-id"
+    }]
+  }]
+}]

--- a/tests/compact/c015-in.jsonld
+++ b/tests/compact/c015-in.jsonld
@@ -3,8 +3,14 @@
   "http://example/p": [{
     "@id": "http://example/typed-base#typed-id",
     "@type": ["http://example/Type"],
-    "http://example/nested": [{
-      "@id": "http://example/base-base#nested-id"
+    "http://example/subjectReference": [{
+      "@id": "http://example/typed-base#subject-reference-id"
+    }],
+    "http://example/nestedNode": [{
+      "@id": "http://example/base-base#nested-id",
+      "http://example/foo": [{
+        "@value": "bar"
+      }]
     }]
   }]
 }]

--- a/tests/compact/c015-out.jsonld
+++ b/tests/compact/c015-out.jsonld
@@ -13,8 +13,12 @@
   "p": {
     "@id": "#typed-id",
     "@type": "Type",
-    "nested": {
-      "@id": "#nested-id"
+    "subjectReference": {
+      "@id": "#subject-reference-id"
+    },
+    "nestedNode": {
+      "@id": "#nested-id",
+      "foo": "bar"
     }
   }
 }

--- a/tests/compact/c015-out.jsonld
+++ b/tests/compact/c015-out.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@base": "http://example/base-base",
+    "@vocab": "http://example/",
+    "foo": "http://example/foo",
+    "Type": {
+      "@context": {
+        "@base": "http://example/typed-base"
+      }
+    }
+  },
+  "@id": "#base-id",
+  "p": {
+    "@id": "#typed-id",
+    "@type": "Type",
+    "nested": {
+      "@id": "#nested-id"
+    }
+  }
+}

--- a/tests/compact/c016-context.jsonld
+++ b/tests/compact/c016-context.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "Type": {
+      "@context": {
+        "@vocab": "http://example.com/"
+      }
+    }
+  }
+}

--- a/tests/compact/c016-in.jsonld
+++ b/tests/compact/c016-in.jsonld
@@ -1,0 +1,16 @@
+[{
+  "http://example.org/foo": [{
+    "@value": "org"
+  }],
+  "http://example.org/p": [{
+    "@type": ["http://example.org/Type"],
+    "http://example.com/foo": [{
+      "@value": "com"
+    }],
+    "http://example.com/nested": [{
+      "http://example.org/nested-prop": [{
+        "@value": "org"
+      }]
+    }]
+  }]
+}]

--- a/tests/compact/c016-out.jsonld
+++ b/tests/compact/c016-out.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "Type": {
+      "@context": {
+        "@vocab": "http://example.com/"
+      }
+    }
+  },
+  "foo": "org",
+  "p": {
+    "@type": "Type",
+    "foo": "com",
+    "nested": {
+      "nested-prop": "org"
+    }
+  }
+}

--- a/tests/compact/c017-context.jsonld
+++ b/tests/compact/c017-context.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "Bar": {
+      "@context": [
+        {
+          "prop": "http://example/bar-prop"
+        }
+      ]
+    },
+    "Foo": {
+      "@context": [
+        {
+          "prop": "http://example/foo-prop"
+        }
+      ]
+    }
+  }
+}

--- a/tests/compact/c017-in.jsonld
+++ b/tests/compact/c017-in.jsonld
@@ -1,0 +1,14 @@
+[{
+  "@type": [
+    "http://example/Foo",
+    "http://example/Bar"
+  ],
+  "http://example/foo-prop": [{
+    "@value": "foo"
+  }],
+  "http://example/nested": [{
+    "http://example/prop": [{
+      "@value": "vocab"
+    }]
+  }]
+}]

--- a/tests/compact/c017-out.jsonld
+++ b/tests/compact/c017-out.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "Bar": {
+      "@context": [
+        {
+          "prop": "http://example/bar-prop"
+        }
+      ]
+    },
+    "Foo": {
+      "@context": [
+        {
+          "prop": "http://example/foo-prop"
+        }
+      ]
+    }
+  },
+  "@type": ["Foo", "Bar"],
+  "prop": "foo",
+  "nested": {
+    "prop": "vocab"
+  }
+}

--- a/tests/compact/c018-context.jsonld
+++ b/tests/compact/c018-context.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "Bar": {
+      "@context": [
+        null,
+        {
+          "prop": "http://example/bar-prop"
+        }
+      ]
+    },
+    "Foo": {
+      "@context": [
+        null,
+        {
+          "prop": "http://example/foo-prop"
+        }
+      ]
+    }
+  }
+}

--- a/tests/compact/c018-in.jsonld
+++ b/tests/compact/c018-in.jsonld
@@ -1,0 +1,11 @@
+[{
+  "@type": [
+    "http://example/Foo",
+    "http://example/Bar"
+  ],
+  "http://example/foo-prop": [
+    {
+      "@value": "foo"
+    }
+  ]
+}]

--- a/tests/compact/c018-out.jsonld
+++ b/tests/compact/c018-out.jsonld
@@ -1,0 +1,24 @@
+
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "Bar": {
+      "@context": [
+        null,
+        {
+          "prop": "http://example/bar-prop"
+        }
+      ]
+    },
+    "Foo": {
+      "@context": [
+        null,
+        {
+          "prop": "http://example/foo-prop"
+        }
+      ]
+    }
+  },
+  "@type": ["Foo", "Bar"],
+  "prop": "foo"
+}

--- a/tests/compact/c019-context.jsonld
+++ b/tests/compact/c019-context.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "prop": "http://example/base-prop",
+    "Type": {
+      "@context": {
+        "foo": {
+          "@context": {
+            "prop": "http://example/foo-prop"
+          }
+        },
+        "bar": {
+          "@context": {
+            "prop": "http://example/bar-prop"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/compact/c019-in.jsonld
+++ b/tests/compact/c019-in.jsonld
@@ -1,0 +1,26 @@
+[{
+  "@type": [
+    "http://example/Type"
+  ],
+  "http://example/foo": [{
+    "http://example/foo-prop": [
+      {
+        "@value": "foo"
+      }
+    ]
+  }],
+  "http://example/bar": [{
+    "http://example/bar-prop": [
+      {
+        "@value": "bar"
+      }
+    ]
+  }],
+  "http://example/baz": [{
+    "http://example/base-prop": [
+      {
+        "@value": "baz"
+      }
+    ]
+  }]
+}]

--- a/tests/compact/c019-out.jsonld
+++ b/tests/compact/c019-out.jsonld
@@ -1,0 +1,30 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "prop": "http://example/base-prop",
+    "Type": {
+      "@context": {
+        "foo": {
+          "@context": {
+            "prop": "http://example/foo-prop"
+          }
+        },
+        "bar": {
+          "@context": {
+            "prop": "http://example/bar-prop"
+          }
+        }
+      }
+    }
+  },
+  "@type": "Type",
+  "foo": {
+    "prop": "foo"
+  },
+  "bar": {
+    "prop": "bar"
+  },
+  "baz": {
+    "prop": "baz"
+  }
+}

--- a/tests/compact/c020-context.jsonld
+++ b/tests/compact/c020-context.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "type": "@type",
+    "Type": {
+      "@context": {
+        "value": "@value"
+      }
+    }
+  }
+}

--- a/tests/compact/c020-in.jsonld
+++ b/tests/compact/c020-in.jsonld
@@ -1,0 +1,7 @@
+[{
+  "@type": ["http://example/Type"],
+  "http://example/v": [{
+    "@type": "http://example/value-type",
+    "@value": "value"
+  }]
+}]

--- a/tests/compact/c020-out.jsonld
+++ b/tests/compact/c020-out.jsonld
@@ -1,0 +1,16 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "type": "@type",
+    "Type": {
+      "@context": {
+        "value": "@value"
+      }
+    }
+  },
+  "type": "Type",
+  "v": {
+    "value": "value",
+    "type": "value-type"
+  }
+}

--- a/tests/compact/c021-context.jsonld
+++ b/tests/compact/c021-context.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "@vocab": "ex:",
+    "type": "@type",
+    "prop": "ex:untyped",
+    "Type": {
+      "@context": {
+        "prop": "ex:typed",
+        "value": "@value"
+      }
+    }
+  }
+}

--- a/tests/compact/c021-in.jsonld
+++ b/tests/compact/c021-in.jsonld
@@ -1,0 +1,19 @@
+[{
+  "ex:untyped": [{
+    "@type": ["ex:Type"],
+    "ex:typed": [{
+      "@value": "v1"
+    }, {
+      "@value": "v2"
+    }, {
+      "@value": "v3"
+    }, {
+      "ex:untyped": [{
+        "@value": "v4"
+      }, {
+        "@type": ["ex:Type"],
+        "ex:typed": [{"@value": "v5"}]
+      }]
+    }]
+  }]
+}]

--- a/tests/compact/c021-out.jsonld
+++ b/tests/compact/c021-out.jsonld
@@ -1,0 +1,30 @@
+{
+  "@context": {
+    "@vocab": "ex:",
+    "type": "@type",
+    "prop": "ex:untyped",
+    "Type": {
+      "@context": {
+        "prop": "ex:typed",
+        "value": "@value"
+      }
+    }
+  },
+  "prop": {
+    "type": "Type",
+    "prop": [
+      "v1",
+      "v2",
+      "v3",
+      {
+        "prop": [
+          "v4",
+          {
+            "type": "Type",
+            "prop": "v5"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/compact/c022-context.jsonld
+++ b/tests/compact/c022-context.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "ex:",
+    "Type": {
+      "@context": {
+        "foo": {
+          "@id": "ex:foo",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "Foo": "ex:Foo",
+            "Bar": "ex:Bar"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/compact/c022-in.jsonld
+++ b/tests/compact/c022-in.jsonld
@@ -1,0 +1,4 @@
+[{
+  "@type": ["ex:Type"],
+  "ex:foo": [{"@id": "ex:Bar"}]
+}]

--- a/tests/compact/c022-out.jsonld
+++ b/tests/compact/c022-out.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "ex:",
+    "Type": {
+      "@context": {
+        "foo": {
+          "@id": "ex:foo",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "Foo": "ex:Foo",
+            "Bar": "ex:Bar"
+          }
+        }
+      }
+    }
+  },
+  "@type": "Type",
+  "foo": "Bar"
+}

--- a/tests/compact/c023-context.jsonld
+++ b/tests/compact/c023-context.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "Outer": {
+      "@id": "ex:Outer",
+      "@context": {
+        "nested": "ex:nested"
+      }
+    },
+    "Inner": {
+      "@id": "ex:Inner",
+      "@context": {
+        "@version": 1.1,
+        "foo": {
+          "@id": "ex:foo",
+          "@type": "@vocab",
+          "@context": {
+            "Foo": "ex:Foo"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/compact/c023-in.jsonld
+++ b/tests/compact/c023-in.jsonld
@@ -1,0 +1,7 @@
+[{
+  "@type": ["ex:Outer"],
+  "ex:nested": [{
+    "@type": ["ex:Inner"],
+    "ex:foo": [{"@id": "ex:Foo"}]
+  }]
+}]

--- a/tests/compact/c023-out.jsonld
+++ b/tests/compact/c023-out.jsonld
@@ -1,0 +1,29 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "Outer": {
+      "@id": "ex:Outer",
+      "@context": {
+        "nested": "ex:nested"
+      }
+    },
+    "Inner": {
+      "@id": "ex:Inner",
+      "@context": {
+        "@version": 1.1,
+        "foo": {
+          "@id": "ex:foo",
+          "@type": "@vocab",
+          "@context": {
+            "Foo": "ex:Foo"
+          }
+        }
+      }
+    }
+  },
+  "@type": "Outer",
+  "nested": {
+    "@type": "Inner",
+    "foo": "Foo"
+  }
+}

--- a/tests/compact/c024-context.jsonld
+++ b/tests/compact/c024-context.jsonld
@@ -1,0 +1,34 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "Outer": {
+      "@id": "ex:Outer",
+      "@context": {
+        "nested": "ex:nested"
+      }
+    },
+    "Inner": {
+      "@id": "ex:Inner",
+      "@context": {
+        "@version": 1.1,
+        "val": "@value",
+        "foo": {
+          "@id": "ex:foo",
+          "@container": "@set",
+          "@type": "ex:Number",
+          "@context": {
+            "value": "@value"
+          }
+        },
+        "bar": {
+          "@id": "ex:bar",
+          "@container": "@set",
+          "@type": "@id",
+          "@context": {
+            "@base": "http://example/"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/compact/c024-in.jsonld
+++ b/tests/compact/c024-in.jsonld
@@ -1,0 +1,11 @@
+[{
+  "@type": ["ex:Outer"],
+  "ex:nested": [{
+    "@type": ["ex:Inner"],
+    "ex:foo": {"@type": "ex:Number", "@value": "1"},
+    "ex:bar": [
+      {"@id": "http://example/a"},
+      {"@id": "http://example/b"}
+    ]
+  }]
+}]

--- a/tests/compact/c024-out.jsonld
+++ b/tests/compact/c024-out.jsonld
@@ -1,0 +1,40 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "Outer": {
+      "@id": "ex:Outer",
+      "@context": {
+        "nested": "ex:nested"
+      }
+    },
+    "Inner": {
+      "@id": "ex:Inner",
+      "@context": {
+        "@version": 1.1,
+        "val": "@value",
+        "foo": {
+          "@id": "ex:foo",
+          "@container": "@set",
+          "@type": "ex:Number",
+          "@context": {
+            "value": "@value"
+          }
+        },
+        "bar": {
+          "@id": "ex:bar",
+          "@container": "@set",
+          "@type": "@id",
+          "@context": {
+            "@base": "http://example/"
+          }
+        }
+      }
+    }
+  },
+  "@type": "Outer",
+  "nested": {
+    "@type": "Inner",
+    "foo": ["1"],
+    "bar": ["a", "b"]
+  }
+}

--- a/tests/compact/c025-context.jsonld
+++ b/tests/compact/c025-context.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "type": "@type",
+    "Outer": {
+      "@id": "ex:Outer",
+      "@context": {
+        "nested": {
+          "@id": "ex:nested",
+          "@type": "@id",
+          "@container": "@graph"
+        }
+      }
+    },
+    "Inner": {
+      "@id": "ex:Inner",
+      "@context": {
+        "foo": "ex:foo"
+      }
+    }
+  }
+}

--- a/tests/compact/c025-in.jsonld
+++ b/tests/compact/c025-in.jsonld
@@ -1,0 +1,9 @@
+[{
+  "@type": ["ex:Outer"],
+  "ex:nested": [{
+    "@graph": [{
+      "@type": ["ex:Inner"],
+      "ex:foo": [{"@value": "bar"}]
+    }]
+  }]
+}]

--- a/tests/compact/c025-out.jsonld
+++ b/tests/compact/c025-out.jsonld
@@ -1,0 +1,27 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "type": "@type",
+    "Outer": {
+      "@id": "ex:Outer",
+      "@context": {
+        "nested": {
+          "@id": "ex:nested",
+          "@type": "@id",
+          "@container": "@graph"
+        }
+      }
+    },
+    "Inner": {
+      "@id": "ex:Inner",
+      "@context": {
+        "foo": "ex:foo"
+      }
+    }
+  },
+  "type": "Outer",
+  "nested": {
+    "type": "Inner",
+    "foo": "bar"
+  }
+}

--- a/tests/compact/pr03-context.jsonld
+++ b/tests/compact/pr03-context.jsonld
@@ -3,6 +3,6 @@
     "@version": 1.1,
     "@vocab": "http://example.com/",
     "protected": {"@protected": true},
-    "Type": {"@context": {"protected": {"@type": "@id"},}}
+    "Type": {"@context": {"protected": {"@type": "@id"}}}
   }
 }

--- a/tests/compact/pr05-context.jsonld
+++ b/tests/compact/pr05-context.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": [{
+    "@version": 1.1,
+    "@protected": true,
+    "@vocab": "http://example.com/",
+    "Parent": {"@context": {"@protected": true, "foo": {"@type": "@id"}}}
+  }, {
+    "@version": 1.1,
+    "@protected": true,
+    "Child": {"@context": {"@protected": true, "foo": {"@type": "@id"}}}
+  }]
+}

--- a/tests/compact/pr05-in.jsonld
+++ b/tests/compact/pr05-in.jsonld
@@ -1,0 +1,20 @@
+[
+  {
+    "@type": [
+      "http://example.com/Parent"
+    ],
+    "http://example.com/foo": [
+      {
+        "@type": [
+          "http://example.com/Child"
+        ],
+        "http://example.com/foo": [
+          {
+            "@id": "http://example.com/test"
+          }
+        ]
+      }
+    ]
+  }
+]
+

--- a/tests/compact/pr05-out.jsonld
+++ b/tests/compact/pr05-out.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": [{
+    "@version": 1.1,
+    "@protected": true,
+    "@vocab": "http://example.com/",
+    "Parent": {"@context": {"@protected": true, "foo": {"@type": "@id"}}}
+  }, {
+    "@version": 1.1,
+    "@protected": true,
+    "Child": {"@context": {"@protected": true, "foo": {"@type": "@id"}}}
+  }],
+  "@type": "Parent",
+  "foo": {
+    "@type": "Child",
+    "foo": "http://example.com/test"
+  }
+}

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -993,6 +993,14 @@
       "expect": "expand/c019-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tc020",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "type-scoped value",
+      "purpose": "type-scoped value",
+      "input": "expand/c020-in.jsonld",
+      "expect": "expand/c020-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#te001",
       "@type": [ "jld:NegativeEvaluationTest", "jld:ExpandTest" ],
       "name": "Keywords cannot be aliased to other keywords",

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -1009,6 +1009,22 @@
       "expect": "expand/c021-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tc022",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "type-scoped property-scoped contexts including @type:@vocab",
+      "purpose": "type-scoped property-scoped contexts including @type:@vocab",
+      "input": "expand/c022-in.jsonld",
+      "expect": "expand/c022-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tc023",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "composed type-scoped property-scoped contexts including @type:@vocab",
+      "purpose": "composed type-scoped property-scoped contexts including @type:@vocab",
+      "input": "expand/c023-in.jsonld",
+      "expect": "expand/c023-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#te001",
       "@type": [ "jld:NegativeEvaluationTest", "jld:ExpandTest" ],
       "name": "Keywords cannot be aliased to other keywords",

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -936,6 +936,14 @@
       "input": "expand/c012-in.jsonld",
       "expect": "expand/c012-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tc013",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "type maps use scoped context from type index and not scoped context from containing",
+      "purpose": "scoped context on @type",
+      "input": "expand/c013-in.jsonld",
+      "expect": "expand/c013-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
    }, {
       "@id": "#te001",
       "@type": [ "jld:NegativeEvaluationTest", "jld:ExpandTest" ],

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -1033,6 +1033,14 @@
       "expect": "expand/c024-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tc025",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "type-scoped + graph container",
+      "purpose": "type-scoped + graph container",
+      "input": "expand/c025-in.jsonld",
+      "expect": "expand/c025-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#te001",
       "@type": [ "jld:NegativeEvaluationTest", "jld:ExpandTest" ],
       "name": "Keywords cannot be aliased to other keywords",

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -1025,6 +1025,14 @@
       "expect": "expand/c023-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tc024",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "type-scoped + property-scoped + values evaluates against previous context",
+      "purpose": "type-scoped + property-scoped + values evaluates against previous context",
+      "input": "expand/c024-in.jsonld",
+      "expect": "expand/c024-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#te001",
       "@type": [ "jld:NegativeEvaluationTest", "jld:ExpandTest" ],
       "name": "Keywords cannot be aliased to other keywords",

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -907,7 +907,7 @@
     }, {
       "@id": "#tc009",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "deep @context affects nested nodes",
+      "name": "deep @type-scoped @context does NOT affect nested nodes",
       "purpose": "scoped context on @type",
       "input": "expand/c009-in.jsonld",
       "expect": "expand/c009-out.jsonld",
@@ -927,6 +927,14 @@
       "purpose": "scoped context on @type",
       "input": "expand/c011-in.jsonld",
       "expect": "expand/c011-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tc012",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "deep property-term scoped @context in @type-scoped @context affects nested nodes",
+      "purpose": "scoped context on @type",
+      "input": "expand/c012-in.jsonld",
+      "expect": "expand/c012-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
    }, {
       "@id": "#te001",

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -945,6 +945,54 @@
       "expect": "expand/c013-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
    }, {
+      "@id": "#tc014",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "type-scoped context nullification",
+      "purpose": "type-scoped context nullification",
+      "input": "expand/c014-in.jsonld",
+      "expect": "expand/c014-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+   }, {
+      "@id": "#tc015",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "type-scoped base",
+      "purpose": "type-scoped base",
+      "input": "expand/c015-in.jsonld",
+      "expect": "expand/c015-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+   }, {
+      "@id": "#tc016",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "type-scoped vocab",
+      "purpose": "type-scoped vocab",
+      "input": "expand/c016-in.jsonld",
+      "expect": "expand/c016-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+   }, {
+      "@id": "#tc017",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "multiple type-scoped contexts are properly reverted",
+      "purpose": "multiple type-scoped contexts are property reverted",
+      "input": "expand/c017-in.jsonld",
+      "expect": "expand/c017-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+   }, {
+      "@id": "#tc018",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "multiple type-scoped types resolved against previous context",
+      "purpose": "multiple type-scoped types resolved against previous context",
+      "input": "expand/c018-in.jsonld",
+      "expect": "expand/c018-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+   }, {
+      "@id": "#tc019",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "type-scoped context with multiple property scoped terms",
+      "purpose": "type-scoped context with multiple property scoped terms",
+      "input": "expand/c019-in.jsonld",
+      "expect": "expand/c019-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+   }, {
       "@id": "#te001",
       "@type": [ "jld:NegativeEvaluationTest", "jld:ExpandTest" ],
       "name": "Keywords cannot be aliased to other keywords",

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -1001,6 +1001,14 @@
       "expect": "expand/c020-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tc021",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "type-scoped value mix",
+      "purpose": "type-scoped value mix",
+      "input": "expand/c021-in.jsonld",
+      "expect": "expand/c021-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#te001",
       "@type": [ "jld:NegativeEvaluationTest", "jld:ExpandTest" ],
       "name": "Keywords cannot be aliased to other keywords",

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -2187,6 +2187,14 @@
       "input": "expand/pr21-in.jsonld",
       "expect": "invalid context nullification"
    }, {
+      "@id": "#tpr22",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Check legal overriding of type-scoped protected term from nested node.",
+      "purpose": "Check legal overriding of type-scoped protected term from nested node.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/pr22-in.jsonld",
+      "expect": "expand/pr22-out.jsonld"
+   }, {
       "@id": "#ttn01",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "@type: @none is illegal in 1.0.",

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -944,7 +944,7 @@
       "input": "expand/c013-in.jsonld",
       "expect": "expand/c013-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
-   }, {
+    }, {
       "@id": "#tc014",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "type-scoped context nullification",
@@ -952,7 +952,7 @@
       "input": "expand/c014-in.jsonld",
       "expect": "expand/c014-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
-   }, {
+    }, {
       "@id": "#tc015",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "type-scoped base",
@@ -960,7 +960,7 @@
       "input": "expand/c015-in.jsonld",
       "expect": "expand/c015-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
-   }, {
+    }, {
       "@id": "#tc016",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "type-scoped vocab",
@@ -968,7 +968,7 @@
       "input": "expand/c016-in.jsonld",
       "expect": "expand/c016-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
-   }, {
+    }, {
       "@id": "#tc017",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "multiple type-scoped contexts are properly reverted",
@@ -976,7 +976,7 @@
       "input": "expand/c017-in.jsonld",
       "expect": "expand/c017-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
-   }, {
+    }, {
       "@id": "#tc018",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "multiple type-scoped types resolved against previous context",
@@ -984,7 +984,7 @@
       "input": "expand/c018-in.jsonld",
       "expect": "expand/c018-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
-   }, {
+    }, {
       "@id": "#tc019",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "type-scoped context with multiple property scoped terms",
@@ -992,7 +992,7 @@
       "input": "expand/c019-in.jsonld",
       "expect": "expand/c019-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
-   }, {
+    }, {
       "@id": "#te001",
       "@type": [ "jld:NegativeEvaluationTest", "jld:ExpandTest" ],
       "name": "Keywords cannot be aliased to other keywords",
@@ -1315,7 +1315,7 @@
       "input": "expand/ec01-in.jsonld",
       "expect": "invalid term definition",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
-   }, {
+    }, {
       "@id": "#tem01",
       "@type": [ "jld:NegativeEvaluationTest", "jld:ExpandTest" ],
       "name": "Invalid container mapping",
@@ -1818,7 +1818,7 @@
       "input": "expand/m016-in.jsonld",
       "expect": "expand/m016-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
-   }, {
+    }, {
       "@id": "#tn001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "Expands input using @nest",
@@ -1994,7 +1994,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pi11-in.jsonld",
       "expect": "expand/pi11-out.jsonld"
-   }, {
+    }, {
       "@id": "#tl001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "Language map with null value",
@@ -2002,7 +2002,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/l001-in.jsonld",
       "expect": "expand/l001-out.jsonld"
-   }, {
+    }, {
       "@id": "#tli01",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "@list containing @list",
@@ -2010,7 +2010,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/li01-in.jsonld",
       "expect": "expand/li01-out.jsonld"
-   }, {
+    }, {
       "@id": "#tli02",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "@list containing empty @list",
@@ -2018,7 +2018,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/li02-in.jsonld",
       "expect": "expand/li02-out.jsonld"
-   }, {
+    }, {
       "@id": "#tli03",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "@list containing @list (with coercion)",
@@ -2026,7 +2026,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/li03-in.jsonld",
       "expect": "expand/li03-out.jsonld"
-   }, {
+    }, {
       "@id": "#tli04",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "@list containing empty @list (with coercion)",
@@ -2034,7 +2034,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/li04-in.jsonld",
       "expect": "expand/li04-out.jsonld"
-   }, {
+    }, {
       "@id": "#tli05",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "coerced @list containing an array",
@@ -2042,7 +2042,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/li05-in.jsonld",
       "expect": "expand/li05-out.jsonld"
-   }, {
+    }, {
       "@id": "#tli06",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "coerced @list containing an empty array",
@@ -2050,7 +2050,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/li06-in.jsonld",
       "expect": "expand/li06-out.jsonld"
-   }, {
+    }, {
       "@id": "#tli07",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "coerced @list containing deep arrays",
@@ -2058,7 +2058,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/li07-in.jsonld",
       "expect": "expand/li07-out.jsonld"
-   }, {
+    }, {
       "@id": "#tli08",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "coerced @list containing deep empty arrays",
@@ -2066,7 +2066,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/li08-in.jsonld",
       "expect": "expand/li08-out.jsonld"
-   }, {
+    }, {
       "@id": "#tli09",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "coerced @list containing multiple lists",
@@ -2074,7 +2074,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/li09-in.jsonld",
       "expect": "expand/li09-out.jsonld"
-   }, {
+    }, {
       "@id": "#tli10",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "coerced @list containing mixed list values",
@@ -2082,7 +2082,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/li10-in.jsonld",
       "expect": "expand/li10-out.jsonld"
-   }, {
+    }, {
       "@id": "#tpr01",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "Protect a term",
@@ -2090,7 +2090,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr01-in.jsonld",
       "expect": "protected term redefinition"
-   }, {
+    }, {
       "@id": "#tpr02",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "Set a term to not be protected",
@@ -2098,7 +2098,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr02-in.jsonld",
       "expect": "expand/pr02-out.jsonld"
-   }, {
+    }, {
       "@id": "#tpr03",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "Protect all terms in context",
@@ -2106,7 +2106,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr03-in.jsonld",
       "expect": "protected term redefinition"
-   }, {
+    }, {
       "@id": "#tpr04",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "Do not protect term with @protected: false",
@@ -2114,7 +2114,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr04-in.jsonld",
       "expect": "protected term redefinition"
-   }, {
+    }, {
       "@id": "#tpr05",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "Clear active context with protected terms from an embedded context",
@@ -2122,7 +2122,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr05-in.jsonld",
       "expect": "invalid context nullification"
-   }, {
+    }, {
       "@id": "#tpr06",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "Clear active context of protected terms from a term.",
@@ -2130,7 +2130,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr06-in.jsonld",
       "expect": "expand/pr06-out.jsonld"
-   }, {
+    }, {
       "@id": "#tpr08",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "Term with protected scoped context.",
@@ -2138,7 +2138,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr08-in.jsonld",
       "expect": "protected term redefinition"
-   }, {
+    }, {
       "@id": "#tpr09",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "Attempt to redefine term in other protected context.",
@@ -2146,7 +2146,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr09-in.jsonld",
       "expect": "protected term redefinition"
-   }, {
+    }, {
       "@id": "#tpr10",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "Simple protected and unprotected terms.",
@@ -2154,7 +2154,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr10-in.jsonld",
       "expect": "expand/pr10-out.jsonld"
-   }, {
+    }, {
       "@id": "#tpr11",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "Fail to override protected term.",
@@ -2162,7 +2162,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr11-in.jsonld",
       "expect": "protected term redefinition"
-   }, {
+    }, {
       "@id": "#tpr12",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "Scoped context fail to override protected term.",
@@ -2170,7 +2170,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr12-in.jsonld",
       "expect": "protected term redefinition"
-   }, {
+    }, {
       "@id": "#tpr13",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "Override unprotected term.",
@@ -2178,7 +2178,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr13-in.jsonld",
       "expect": "expand/pr13-out.jsonld"
-   }, {
+    }, {
       "@id": "#tpr14",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "Clear protection with null context.",
@@ -2186,7 +2186,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr14-in.jsonld",
       "expect": "expand/pr14-out.jsonld"
-   }, {
+    }, {
       "@id": "#tpr15",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "Clear protection with array with null context",
@@ -2194,7 +2194,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr15-in.jsonld",
       "expect": "expand/pr15-out.jsonld"
-   }, {
+    }, {
       "@id": "#tpr16",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "Override protected terms after null.",
@@ -2202,7 +2202,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr16-in.jsonld",
       "expect": "expand/pr16-out.jsonld"
-   }, {
+    }, {
       "@id": "#tpr17",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "Fail to override protected terms with type.",
@@ -2210,7 +2210,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr17-in.jsonld",
       "expect": "invalid context nullification"
-   }, {
+    }, {
       "@id": "#tpr18",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "Fail to override protected terms with type+null+ctx.",
@@ -2218,7 +2218,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr18-in.jsonld",
       "expect": "invalid context nullification"
-   }, {
+    }, {
       "@id": "#tpr19",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "Mix of protected and unprotected terms.",
@@ -2226,7 +2226,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr19-in.jsonld",
       "expect": "expand/pr19-out.jsonld"
-   }, {
+    }, {
       "@id": "#tpr20",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "Fail with mix of protected and unprotected terms with type+null+ctx.",
@@ -2234,7 +2234,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr20-in.jsonld",
       "expect": "invalid context nullification"
-   }, {
+    }, {
       "@id": "#tpr21",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "Fail with mix of protected and unprotected terms with type+null.",
@@ -2242,7 +2242,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr21-in.jsonld",
       "expect": "invalid context nullification"
-   }, {
+    }, {
       "@id": "#tpr22",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "Check legal overriding of type-scoped protected term from nested node.",
@@ -2250,7 +2250,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr22-in.jsonld",
       "expect": "expand/pr22-out.jsonld"
-   }, {
+    }, {
       "@id": "#ttn01",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "@type: @none is illegal in 1.0.",
@@ -2258,7 +2258,7 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/tn01-in.jsonld",
       "expect": "invalid type mapping"
-   }, {
+    }, {
       "@id": "#ttn02",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "@type: @none expands strings as value objects",

--- a/tests/expand/c012-in.jsonld
+++ b/tests/expand/c012-in.jsonld
@@ -1,0 +1,16 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "Foo": {
+      "@context": {
+        "bar": {
+          "@context": {
+            "baz": {"@type": "@vocab"}
+          }
+        }
+      }
+    }
+  },
+  "@type": "Foo",
+  "bar": {"baz": "buzz"}
+}

--- a/tests/expand/c012-out.jsonld
+++ b/tests/expand/c012-out.jsonld
@@ -2,7 +2,7 @@
   {
     "@type": ["http://example/Foo"],
     "http://example/bar": [{
-      "http://example/baz": [{"@value": "buzz"}]
+      "http://example/baz": [{"@id": "http://example/buzz"}]
     }]
   }
 ]

--- a/tests/expand/c013-in.jsonld
+++ b/tests/expand/c013-in.jsonld
@@ -1,0 +1,28 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "prop": {"@container": "@index"},
+    "foo": "http://example/base-foo",
+    "Outer": {
+      "@context": {
+        "prop": {
+          "@id": "http://example/outer-prop",
+          "@container": "@type"
+        }
+      }
+    },
+    "Inner": {"@context": {"foo": "http://example/inner-foo"}}
+  },
+  "@type": "Outer",
+  "prop": {
+    "Inner": {
+      "prop": {
+        "index": {
+          "@id": "http://example/inner-with-index",
+          "foo": "inner-foo"
+        }
+      }
+    }
+  },
+  "foo": "base-foo"
+}

--- a/tests/expand/c013-out.jsonld
+++ b/tests/expand/c013-out.jsonld
@@ -1,0 +1,12 @@
+[{
+ "@type": ["http://example/Outer"],
+ "http://example/base-foo": [{"@value": "base-foo"}],
+ "http://example/outer-prop": [{
+   "@type": ["http://example/Inner"],
+   "http://example/prop": [{
+     "@id": "http://example/inner-with-index",
+     "@index": "index",
+     "http://example/inner-foo": [{"@value": "inner-foo"}]
+   }]
+ }]
+}]

--- a/tests/expand/c014-in.jsonld
+++ b/tests/expand/c014-in.jsonld
@@ -1,0 +1,16 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "foo": "http://example/foo",
+    "Type": {
+      "@context": [
+        null
+      ]
+    }
+  },
+  "foo": "will-exist",
+  "p": {
+    "@type": "Type",
+    "foo": "will-not-exist"
+  }
+}

--- a/tests/expand/c014-out.jsonld
+++ b/tests/expand/c014-out.jsonld
@@ -1,0 +1,8 @@
+[{
+  "http://example/foo": [{
+    "@value": "will-exist"
+  }],
+  "http://example/p": [{
+    "@type": ["http://example/Type"]
+  }]
+}]

--- a/tests/expand/c015-in.jsonld
+++ b/tests/expand/c015-in.jsonld
@@ -13,8 +13,12 @@
   "p": {
     "@id": "#typed-id",
     "@type": "Type",
-    "nested": {
-      "@id": "#nested-id"
+    "subjectReference": {
+      "@id": "#subject-reference-id"
+    },
+    "nestedNode": {
+      "@id": "#nested-id",
+      "foo": "bar"
     }
   }
 }

--- a/tests/expand/c015-in.jsonld
+++ b/tests/expand/c015-in.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@base": "http://example/base-base",
+    "@vocab": "http://example/",
+    "foo": "http://example/foo",
+    "Type": {
+      "@context": {
+        "@base": "http://example/typed-base"
+      }
+    }
+  },
+  "@id": "#base-id",
+  "p": {
+    "@id": "#typed-id",
+    "@type": "Type",
+    "nested": {
+      "@id": "#nested-id"
+    }
+  }
+}

--- a/tests/expand/c015-out.jsonld
+++ b/tests/expand/c015-out.jsonld
@@ -1,0 +1,10 @@
+[{
+  "@id": "http://example/base-base#base-id",
+  "http://example/p": [{
+    "@id": "http://example/typed-base#typed-id",
+    "@type": ["http://example/Type"],
+    "http://example/nested": [{
+      "@id": "http://example/base-base#nested-id"
+    }]
+  }]
+}]

--- a/tests/expand/c015-out.jsonld
+++ b/tests/expand/c015-out.jsonld
@@ -3,8 +3,14 @@
   "http://example/p": [{
     "@id": "http://example/typed-base#typed-id",
     "@type": ["http://example/Type"],
-    "http://example/nested": [{
-      "@id": "http://example/base-base#nested-id"
+    "http://example/subjectReference": [{
+      "@id": "http://example/typed-base#subject-reference-id"
+    }],
+    "http://example/nestedNode": [{
+      "@id": "http://example/base-base#nested-id",
+      "http://example/foo": [{
+        "@value": "bar"
+      }]
     }]
   }]
 }]

--- a/tests/expand/c016-in.jsonld
+++ b/tests/expand/c016-in.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "Type": {
+      "@context": {
+        "@vocab": "http://example.com/"
+      }
+    }
+  },
+  "foo": "org",
+  "p": {
+    "@type": "Type",
+    "foo": "com",
+    "nested": {
+      "nested-prop": "org"
+    }
+  }
+}

--- a/tests/expand/c016-out.jsonld
+++ b/tests/expand/c016-out.jsonld
@@ -1,0 +1,16 @@
+[{
+  "http://example.org/foo": [{
+    "@value": "org"
+  }],
+  "http://example.org/p": [{
+    "@type": ["http://example.org/Type"],
+    "http://example.com/foo": [{
+      "@value": "com"
+    }],
+    "http://example.com/nested": [{
+      "http://example.org/nested-prop": [{
+        "@value": "org"
+      }]
+    }]
+  }]
+}]

--- a/tests/expand/c017-in.jsonld
+++ b/tests/expand/c017-in.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "Bar": {
+      "@context": [
+        {
+          "prop": "http://example/bar-prop"
+        }
+      ]
+    },
+    "Foo": {
+      "@context": [
+        {
+          "prop": "http://example/foo-prop"
+        }
+      ]
+    }
+  },
+  "@type": ["Foo", "Bar"],
+  "prop": "foo",
+  "nested": {
+    "prop": "vocab"
+  }
+}

--- a/tests/expand/c017-out.jsonld
+++ b/tests/expand/c017-out.jsonld
@@ -1,0 +1,14 @@
+[{
+  "@type": [
+    "http://example/Foo",
+    "http://example/Bar"
+  ],
+  "http://example/foo-prop": [{
+    "@value": "foo"
+  }],
+  "http://example/nested": [{
+    "http://example/prop": [{
+      "@value": "vocab"
+    }]
+  }]
+}]

--- a/tests/expand/c018-in.jsonld
+++ b/tests/expand/c018-in.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "Bar": {
+      "@context": [
+        null,
+        {
+          "prop": "http://example/bar-prop"
+        }
+      ]
+    },
+    "Foo": {
+      "@context": [
+        null,
+        {
+          "prop": "http://example/foo-prop"
+        }
+      ]
+    }
+  },
+  "@type": ["Foo", "Bar"],
+  "prop": "foo",
+  "nested": {
+    "prop": "will-not-exist"
+  }
+}

--- a/tests/expand/c018-out.jsonld
+++ b/tests/expand/c018-out.jsonld
@@ -1,0 +1,11 @@
+[{
+  "@type": [
+    "http://example/Foo",
+    "http://example/Bar"
+  ],
+  "http://example/foo-prop": [
+    {
+      "@value": "foo"
+    }
+  ]
+}]

--- a/tests/expand/c019-in.jsonld
+++ b/tests/expand/c019-in.jsonld
@@ -1,0 +1,30 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "prop": "http://example/base-prop",
+    "Type": {
+      "@context": {
+        "foo": {
+          "@context": {
+            "prop": "http://example/foo-prop"
+          }
+        },
+        "bar": {
+          "@context": {
+            "prop": "http://example/bar-prop"
+          }
+        }
+      }
+    }
+  },
+  "@type": "Type",
+  "foo": {
+    "prop": "foo"
+  },
+  "bar": {
+    "prop": "bar"
+  },
+  "baz": {
+    "prop": "baz"
+  }
+}

--- a/tests/expand/c019-out.jsonld
+++ b/tests/expand/c019-out.jsonld
@@ -1,0 +1,26 @@
+[{
+  "@type": [
+    "http://example/Type"
+  ],
+  "http://example/foo": [{
+    "http://example/foo-prop": [
+      {
+        "@value": "foo"
+      }
+    ]
+  }],
+  "http://example/bar": [{
+    "http://example/bar-prop": [
+      {
+        "@value": "bar"
+      }
+    ]
+  }],
+  "http://example/baz": [{
+    "http://example/base-prop": [
+      {
+        "@value": "baz"
+      }
+    ]
+  }]
+}]

--- a/tests/expand/c020-in.jsonld
+++ b/tests/expand/c020-in.jsonld
@@ -1,0 +1,16 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "type": "@type",
+    "Type": {
+      "@context": {
+        "value": "@value"
+      }
+    }
+  },
+  "type": "Type",
+  "v": {
+    "value": "value",
+    "type": "value-type"
+  }
+}

--- a/tests/expand/c020-out.jsonld
+++ b/tests/expand/c020-out.jsonld
@@ -1,0 +1,7 @@
+[{
+  "@type": ["http://example/Type"],
+  "http://example/v": [{
+    "@type": "http://example/value-type",
+    "@value": "value"
+  }]
+}]

--- a/tests/expand/c021-in.jsonld
+++ b/tests/expand/c021-in.jsonld
@@ -1,0 +1,34 @@
+{
+  "@context": {
+    "@vocab": "ex:",
+    "type": "@type",
+    "prop": "ex:untyped",
+    "Type": {
+      "@context": {
+        "prop": "ex:typed",
+        "value": "@value"
+      }
+    }
+  },
+  "prop": {
+    "type": "Type",
+    "prop": [
+      "v1",
+      {
+        "value": "v2"
+      },
+      {
+        "@value": "v3"
+      },
+      {
+        "prop": [
+          "v4",
+          {
+            "type": "Type",
+            "prop": "v5"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/expand/c021-out.jsonld
+++ b/tests/expand/c021-out.jsonld
@@ -1,0 +1,19 @@
+[{
+  "ex:untyped": [{
+    "@type": ["ex:Type"],
+    "ex:typed": [{
+      "@value": "v1"
+    }, {
+      "@value": "v2"
+    }, {
+      "@value": "v3"
+    }, {
+      "ex:untyped": [{
+        "@value": "v4"
+      }, {
+        "@type": ["ex:Type"],
+        "ex:typed": [{"@value": "v5"}]
+      }]
+    }]
+  }]
+}]

--- a/tests/expand/c022-in.jsonld
+++ b/tests/expand/c022-in.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "ex:",
+    "Type": {
+      "@context": {
+        "foo": {
+          "@id": "ex:foo",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "Foo": "ex:Foo",
+            "Bar": "ex:Bar"
+          }
+        }
+      }
+    }
+  },
+  "@type": "Type",
+  "foo": "Bar"
+}

--- a/tests/expand/c022-out.jsonld
+++ b/tests/expand/c022-out.jsonld
@@ -1,0 +1,4 @@
+[{
+  "@type": ["ex:Type"],
+  "ex:foo": [{"@id": "ex:Bar"}]
+}]

--- a/tests/expand/c023-in.jsonld
+++ b/tests/expand/c023-in.jsonld
@@ -1,0 +1,29 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "Outer": {
+      "@id": "ex:Outer",
+      "@context": {
+        "nested": "ex:nested"
+      }
+    },
+    "Inner": {
+      "@id": "ex:Inner",
+      "@context": {
+        "@version": 1.1,
+        "foo": {
+          "@id": "ex:foo",
+          "@type": "@vocab",
+          "@context": {
+            "Foo": "ex:Foo"
+          }
+        }
+      }
+    }
+  },
+  "@type": "Outer",
+  "nested": {
+    "@type": "Inner",
+    "foo": "Foo"
+  }
+}

--- a/tests/expand/c023-out.jsonld
+++ b/tests/expand/c023-out.jsonld
@@ -1,0 +1,7 @@
+[{
+  "@type": ["ex:Outer"],
+  "ex:nested": [{
+    "@type": ["ex:Inner"],
+    "ex:foo": [{"@id": "ex:Foo"}]
+  }]
+}]

--- a/tests/expand/c024-in.jsonld
+++ b/tests/expand/c024-in.jsonld
@@ -1,0 +1,40 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "Outer": {
+      "@id": "ex:Outer",
+      "@context": {
+        "nested": "ex:nested"
+      }
+    },
+    "Inner": {
+      "@id": "ex:Inner",
+      "@context": {
+        "@version": 1.1,
+        "val": "@value",
+        "foo": {
+          "@id": "ex:foo",
+          "@container": "@set",
+          "@type": "ex:Number",
+          "@context": {
+            "value": "@value"
+          }
+        },
+        "bar": {
+          "@id": "ex:bar",
+          "@container": "@set",
+          "@type": "@id",
+          "@context": {
+            "@base": "http://example/"
+          }
+        }
+      }
+    }
+  },
+  "@type": "Outer",
+  "nested": {
+    "@type": "Inner",
+    "foo": [{"value": "1"}, "2"],
+    "bar": [{"@id": "a"}, "b"]
+  }
+}

--- a/tests/expand/c024-out.jsonld
+++ b/tests/expand/c024-out.jsonld
@@ -1,0 +1,14 @@
+[{
+  "@type": ["ex:Outer"],
+  "ex:nested": [{
+    "@type": ["ex:Inner"],
+    "ex:foo": [
+      {"@value": "1"},
+      {"@type": "ex:Number", "@value": "2"}
+    ],
+    "ex:bar": [
+      {"@id": "http://example/a"},
+      {"@id": "http://example/b"}
+    ]
+  }]
+}]

--- a/tests/expand/c025-in.jsonld
+++ b/tests/expand/c025-in.jsonld
@@ -1,0 +1,27 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "type": "@type",
+    "Outer": {
+      "@id": "ex:Outer",
+      "@context": {
+        "nested": {
+          "@id": "ex:nested",
+          "@type": "@id",
+          "@container": "@graph"
+        }
+      }
+    },
+    "Inner": {
+      "@id": "ex:Inner",
+      "@context": {
+        "foo": "ex:foo"
+      }
+    }
+  },
+  "type": "Outer",
+  "nested": {
+    "type": "Inner",
+    "foo": "bar"
+  }
+}

--- a/tests/expand/c025-out.jsonld
+++ b/tests/expand/c025-out.jsonld
@@ -1,0 +1,9 @@
+[{
+  "@type": ["ex:Outer"],
+  "ex:nested": [{
+    "@graph": [{
+      "@type": ["ex:Inner"],
+      "ex:foo": [{"@value": "bar"}]
+    }]
+  }]
+}]

--- a/tests/expand/pr22-in.jsonld
+++ b/tests/expand/pr22-in.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": [{
+    "@version": 1.1,
+    "@protected": true,
+    "@vocab": "http://example.com/",
+    "Parent": {"@context": {"@protected": true, "foo": {"@type": "@id"}}}
+  }, {
+    "@version": 1.1,
+    "@protected": true,
+    "Child": {"@context": {"@protected": true, "foo": {"@type": "@id"}}}
+  }],
+  "@type": "Parent",
+  "foo": {
+    "@type": "Child",
+    "foo": "http://example.com/test"
+  }
+}

--- a/tests/expand/pr22-out.jsonld
+++ b/tests/expand/pr22-out.jsonld
@@ -1,0 +1,20 @@
+[
+  {
+    "@type": [
+      "http://example.com/Parent"
+    ],
+    "http://example.com/foo": [
+      {
+        "@type": [
+          "http://example.com/Child"
+        ],
+        "http://example.com/foo": [
+          {
+            "@id": "http://example.com/test"
+          }
+        ]
+      }
+    ]
+  }
+]
+


### PR DESCRIPTION
Related to https://github.com/w3c/json-ld-syntax/issues/174.

I've created this PR for jsonld.js with the necessary algorithm changes.

https://github.com/digitalbazaar/jsonld.js/pull/312

What do you think @gkellogg?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/89.html" title="Last updated on May 26, 2019, 11:25 PM UTC (c8a7e0a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/89/c71d460...c8a7e0a.html" title="Last updated on May 26, 2019, 11:25 PM UTC (c8a7e0a)">Diff</a>