### PR TITLE
added missing normative/informative class in intro

### DIFF
--- a/index.html
+++ b/index.html
@@ -320,7 +320,7 @@
     <div data-include="common/typographical-conventions.html"></div>
   </section>
 
-  <section>
+  <section class="normative">
     <h2>Terminology</h2>
 
     <p>This document uses the following terms as defined in JSON [[RFC8288]]. Refer
@@ -342,7 +342,7 @@
 
   </section>
 
-  <section>
+  <section class="informative">
     <h3>Example Conventions</h3>
     <p>Note that in the examples used in this document, output
       is of necessity shown in serialized form as JSON. While the algorithms


### PR DESCRIPTION
I added these class for the sake of homogeneity (and also because I'm not sure how "normativeness" propagates through subsections...

I set "Terminology" as normative because it is so in the other specs. The "Example conventions" looked informative to me, but I prefer to check.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/95.html" title="Last updated on May 24, 2019, 4:31 PM UTC (05a64b9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/95/c71d460...05a64b9.html" title="Last updated on May 24, 2019, 4:31 PM UTC (05a64b9)">Diff</a>