### PR TITLE
Update public mailing list

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -79,7 +79,7 @@ Implementations create their own infrastructure for running the test suite. In p
 If you would like to contribute a new test or a fix to an existing test,
 please follow these steps:
 
-1. Notify the JSON-LD mailing list, json-ld-wg@w3.org,
+1. Notify the JSON-LD mailing list, public-json-ld-wg@w3.org,
    that you will be creating a new test or fix and the purpose of the
    change.
 2. Clone the git repository: git://github.com/w3c/json-ld-wg.git


### PR DESCRIPTION
This updates the mailing list mentioned in the tests/README.md under in the contributing section.

It's what I found looking for `json-ld-wg@w3.org`, linked from https://www.w3.org/2018/json-ld-wg/.