### PR TITLE
Add toRdf tests for merging rootless base paths

### DIFF
--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -896,6 +896,13 @@
       "input": "toRdf/0131-in.jsonld",
       "expect": "toRdf/0131-out.nq"
     }, {
+      "@id": "#t0132",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "IRI Resolution (12)",
+      "purpose": "IRI resolution according to RFC3986.",
+      "input": "toRdf/0132-in.jsonld",
+      "expect": "toRdf/0132-out.nq"
+    }, {
       "@id": "#th001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
       "name": "Transforms embedded JSON-LD script element",

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -882,6 +882,20 @@
       "input": "toRdf/0129-in.jsonld",
       "expect": "toRdf/0129-out.nq"
     }, {
+      "@id": "#t0130",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "IRI Resolution (10)",
+      "purpose": "IRI resolution according to RFC3986.",
+      "input": "toRdf/0130-in.jsonld",
+      "expect": "toRdf/0130-out.nq"
+    }, {
+      "@id": "#t0131",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "IRI Resolution (11)",
+      "purpose": "IRI resolution according to RFC3986.",
+      "input": "toRdf/0131-in.jsonld",
+      "expect": "toRdf/0131-out.nq"
+    }, {
       "@id": "#th001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
       "name": "Transforms embedded JSON-LD script element",

--- a/tests/toRdf/0130-in.jsonld
+++ b/tests/toRdf/0130-in.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {"@base": "tag:example", "urn:ex:p": {"@type": "@id"}},
+  "@graph": [
+    {"@id": "urn:ex:s307", "urn:ex:p": "a"}
+  ]
+}

--- a/tests/toRdf/0130-out.nq
+++ b/tests/toRdf/0130-out.nq
@@ -1,0 +1,1 @@
+<urn:ex:s307> <urn:ex:p> <tag:a> .

--- a/tests/toRdf/0131-in.jsonld
+++ b/tests/toRdf/0131-in.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {"@base": "tag:example/foo", "urn:ex:p": {"@type": "@id"}},
+  "@graph": [
+    {"@id": "urn:ex:s308", "urn:ex:p": "a"}
+  ]
+}

--- a/tests/toRdf/0131-out.nq
+++ b/tests/toRdf/0131-out.nq
@@ -1,0 +1,1 @@
+<urn:ex:s308> <urn:ex:p> <tag:example/a> .

--- a/tests/toRdf/0132-in.jsonld
+++ b/tests/toRdf/0132-in.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {"@base": "tag:example/foo/", "urn:ex:p": {"@type": "@id"}},
+  "@graph": [
+    {"@id": "urn:ex:s309", "urn:ex:p": "a"}
+  ]
+}

--- a/tests/toRdf/0132-out.nq
+++ b/tests/toRdf/0132-out.nq
@@ -1,0 +1,1 @@
+<urn:ex:s309> <urn:ex:p> <tag:example/foo/a> .


### PR DESCRIPTION
This came up in an issue with jsonld-java:
https://github.com/jsonld-java/jsonld-java/issues/232

See second bullet point in:
https://tools.ietf.org/html/rfc3986#section-5.2.3