### PR TITLE
Compact IRI expansion with prefix flag false

### DIFF
--- a/index.html
+++ b/index.html
@@ -1695,9 +1695,13 @@
               <a href="#context-processing-algorithm">Context Processing</a>.</li>
             <li>If <var>active context</var> contains a <a>term definition</a>
               for <var>prefix</var>
-              <span class="changed">having a non-<code>null</code> <a>IRI mapping</a></span>,
+              <span class="changed">having a non-<code>null</code> <a>IRI mapping</a>
+                and the <a>prefix flag</a> of the <a>term definition</a> is <code>true</code></span>,
               return the result of concatenating the <a>IRI mapping</a>
-              associated with <var>prefix</var> and <var>suffix</var>.</li>
+              associated with <var>prefix</var> and <var>suffix</var>.
+              <p class="ednote">A more conservative change, although more involved,
+                would to restrict looking at the <a>prefix flag</a> unless
+                the <a>processing mode</a> is <code>json-ld-1.1</code>.</p></li>
             <li><span class="changed">If <var>value</var> has the form of an <a>absolute IRI</a></span>,
               return <var>value</var>.</li>
           </ol>

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -271,7 +271,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "Expanding blank node labels",
       "purpose": "Blank nodes are not relabeled during expansion",
-      "option": {"processingMode": "json-ld-1.0"},
+      "option": {"specVersion": "json-ld-1.0"},
       "input": "expand/0038-in.jsonld",
       "expect": "expand/0038-out.jsonld"
     }, {
@@ -2347,6 +2347,14 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr28-in.jsonld",
       "expect": "protected term redefinition"
+    }, {
+      "@id": "#tpr29",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Does not expand a Compact IRI using a non-prefix term.",
+      "purpose": "Expansion of Compact IRIs considers if the term can be used as a prefix.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/pr29-in.jsonld",
+      "expect": "expand/pr29-out.jsonld"
     }, {
       "@id": "#ttn01",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],

--- a/tests/expand/0014-in.jsonld
+++ b/tests/expand/0014-in.jsonld
@@ -13,7 +13,7 @@
     "set": "@set",
     "value": "@value",
     "type": "@type",
-    "xsd": { "@id": "http://www.w3.org/2001/XMLSchema#" }
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
   },
   "property1": {
     "uri": "ex:example2",

--- a/tests/expand/0048-in.jsonld
+++ b/tests/expand/0048-in.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": {
     "term": "http://example.com/terms-are-not-considered-in-id",
-    "compact-iris": "http://example.com/compact-iris-",
+    "compact-iris": "http://example.com/compact-iris#",
     "property": "http://example.com/property",
     "@vocab": "http://example.org/vocab-is-not-considered-for-id"
   },

--- a/tests/expand/0048-out.jsonld
+++ b/tests/expand/0048-out.jsonld
@@ -3,7 +3,7 @@
     "@id": "https://w3c.github.io/json-ld-api/tests/expand/term",
     "http://example.com/property": [
       {
-        "@id": "http://example.com/compact-iris-are-considered",
+        "@id": "http://example.com/compact-iris#are-considered",
         "http://example.com/property": [
           { "@value": "@id supports the following values: relative, absolute, and compact IRIs" }
         ]

--- a/tests/expand/pr29-in.jsonld
+++ b/tests/expand/pr29-in.jsonld
@@ -3,5 +3,6 @@
     "@version": 1.1,
     "tag": {"@id": "http://example.org/ns/tag/", "@prefix": false}
   },
-  "tag:champin.net,2019:prop": "This is not treated as a Compact IRI"
+  "tag:champin.net,2019:prop": "This is not treated as a Compact IRI",
+  "tag": "tricky"
 }

--- a/tests/expand/pr29-in.jsonld
+++ b/tests/expand/pr29-in.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "tag": {"@id": "http://example.org/ns/tag/", "@prefix": false}
+  },
+  "tag:champin.net,2019:prop": "This is not treated as a Compact IRI"
+}

--- a/tests/expand/pr29-out.jsonld
+++ b/tests/expand/pr29-out.jsonld
@@ -1,5 +1,12 @@
 [
   {
+    "http://example.org/ns/tag/": [
+      {
+        "@value": "tricky"
+      }
+    ]
+  },
+  {
     "tag:champin.net,2019:prop": [
       {
         "@value": "This is not treated as a Compact IRI"

--- a/tests/expand/pr29-out.jsonld
+++ b/tests/expand/pr29-out.jsonld
@@ -1,0 +1,9 @@
+[
+  {
+    "tag:champin.net,2019:prop": [
+      {
+        "@value": "This is not treated as a Compact IRI"
+      }
+    ]
+  }
+]

--- a/tests/flatten-manifest.jsonld
+++ b/tests/flatten-manifest.jsonld
@@ -103,7 +103,8 @@
       "name": "@set of @value objects with keyword aliases",
       "purpose": "Flattening aliased @set and @value",
       "input": "flatten/0014-in.jsonld",
-      "expect": "flatten/0014-out.jsonld"
+      "expect": "flatten/0014-out.jsonld",
+      "option": {"specVersion": "json-ld-1.0"}
     }, {
       "@id": "#t0015",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
@@ -264,7 +265,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
       "name": "Flattening blank node labels",
       "purpose": "Blank nodes are not relabeled during expansion",
-      "option": {"processingMode": "json-ld-1.0"},
+      "option": {"specVersion": "json-ld-1.0"},
       "input": "flatten/0038-in.jsonld",
       "expect": "flatten/0038-out.jsonld"
     }, {

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -348,7 +348,8 @@
       "name": "@set of @value objects with keyword aliases",
       "purpose": "RDF version of expand-0014",
       "input": "toRdf/0054-in.jsonld",
-      "expect": "toRdf/0054-out.nq"
+      "expect": "toRdf/0054-out.nq",
+      "option": {"specVersion": "json-ld-1.0"}
     }, {
       "@id": "#t0055",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],

--- a/tests/toRdf/0088-in.jsonld
+++ b/tests/toRdf/0088-in.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": {
     "term": "http://example.com/terms-are-not-considered-in-id",
-    "compact-iris": "http://example.com/compact-iris-",
+    "compact-iris": "http://example.com/compact-iris#",
     "property": "http://example.com/property",
     "@vocab": "http://example.org/vocab-is-not-considered-for-id"
   },

--- a/tests/toRdf/0088-out.nq
+++ b/tests/toRdf/0088-out.nq
@@ -1,4 +1,4 @@
-<http://example.com/compact-iris-are-considered> <http://example.com/property> "@id supports the following values: relative, absolute, and compact IRIs" .
+<http://example.com/compact-iris#are-considered> <http://example.com/property> "@id supports the following values: relative, absolute, and compact IRIs" .
 <https://w3c.github.io/json-ld-api/tests/parent-node> <http://example.com/property> "relative IRIs get resolved against the document's base IRI" .
-<https://w3c.github.io/json-ld-api/tests/toRdf/term> <http://example.com/property> <http://example.com/compact-iris-are-considered> .
+<https://w3c.github.io/json-ld-api/tests/toRdf/term> <http://example.com/property> <http://example.com/compact-iris#are-considered> .
 <https://w3c.github.io/json-ld-api/tests/toRdf/term> <http://example.com/property> <https://w3c.github.io/json-ld-api/tests/parent-node> .


### PR DESCRIPTION
Update tests and Expand IRI to not consider terms where the _prefix flag_ is false when considering Compact IRIs.

Fixes w3c/json-ld-wg#90 and fixes w3c/json-ld-wg#87.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/109.html" title="Last updated on Jun 15, 2019, 1:39 PM UTC (bb9c9b4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/109/1466f97...bb9c9b4.html" title="Last updated on Jun 15, 2019, 1:39 PM UTC (bb9c9b4)">Diff</a>