### PR TITLE
Detect an attempt to compact an IRI which results in an absolute IRI

### DIFF
--- a/index.html
+++ b/index.html
@@ -3547,7 +3547,7 @@
           not confused with a <a>compact IRI</a>,
           if the <a data-cite="RFC3986#section-3.1">IRI scheme</a> of <var>var</var>
           matches any term in <a>active context</a> with <a>prefix flag</a> set to <code>true</code>,
-          and <var>var</var> has no <a datacite="https://tools.ietf.org/html/rfc3986#section-3.2">IRI authority</a> (beginning with double-forward-slash (<code>//</code>),
+          and <var>var</var> has no <a data-cite="RFC3986#section-3.1">IRI authority</a> (beginning with double-forward-slash (<code>//</code>),
           an <a data-link-for="JsonLdErrorCode">IRI confused with prefix</a> error has been detected,
           and processing is aborted.</li>
         <li>If <var>vocab</var> is <code>false</code>,
@@ -6032,7 +6032,7 @@
         <dt><dfn>invalid vocab mapping</dfn></dt>
         <dd>An invalid <a>vocabulary mapping</a> has been detected,
           i.e., it is neither an <a>IRI</a> nor <code>null</code>.</dd>
-        <dt class="changed">IRI confused with prefix</dt>
+        <dt class="changed"><dfn>IRI confused with prefix</dfn></dt>
         <dd>When compacting an <a>absolute IRI</a> would result in an <a>absolute IRI</a>
           which could be confused with a compact IRI (because its <a data-cite="RFC3986#section-3.1">IRI scheme</a> matches a <a>term definition</a> and it has no <a data-cite="RFC3986#section-3.1">IRI authority</a>).</dd>
         <dt><dfn>keyword redefinition</dfn></dt>

--- a/index.html
+++ b/index.html
@@ -3293,6 +3293,11 @@
         <a>base IRI</a>. Finally, if the <a>IRI</a> or
         <a>keyword</a> still could not be compacted, it is returned
         as is.</p>
+
+      <p class="changed">In the case were this algorithm would return the input <a>IRI</a> as is,
+        and that <a>IRI</a> can be mistaken for a <a>compact IRI</a> in the <a>active context</a>,
+        this algorithm will raise an error,
+        because it has no way to return an unambiguous representation of the original <a>IRI</a>.</p>
     </section>
 
     <section class="algorithm">

--- a/index.html
+++ b/index.html
@@ -3546,7 +3546,7 @@
         <li class="changed">To ensure that the <a>absolute IRI</a> <var>var</var> is
           not confused with a <a>compact IRI</a>,
           if the <a data-cite="RFC3986#section-3.1">IRI scheme</a> of <var>var</var>
-          matches any term in <a>active context</a>,
+          matches any term in <a>active context</a> with <a>prefix flag</a> set to <code>true</code>,
           and <var>var</var> has no <a datacite="https://tools.ietf.org/html/rfc3986#section-3.2">IRI authority</a> (beginning with double-forward-slash (<code>//</code>),
           an <a data-link-for="JsonLdErrorCode">IRI confused with prefix</a> error has been detected,
           and processing is aborted.</li>

--- a/index.html
+++ b/index.html
@@ -3547,7 +3547,7 @@
           not confused with a <a>compact IRI</a>,
           if the <a data-cite="RFC3986#section-3.1">IRI scheme</a> of <var>var</var>
           matches any term in <a>active context</a>,
-          an <a data-link-for="JsonLdErrorCode">iri confused with prefix</a> error has been detected,
+          an <a data-link-for="JsonLdErrorCode">IRI confused with prefix</a> error has been detected,
           and processing is aborted.</li>
         <li>If <var>vocab</var> is <code>false</code>,
           transform <var>var</var> to a <a>relative IRI</a> using
@@ -5923,7 +5923,7 @@
             "invalid value object",
             "invalid value object value",
             "invalid vocab mapping",
-            "iri confused with prefix",
+            "IRI confused with prefix",
             "keyword redefinition",
             "loading document failed",
             "loading remote context failed",
@@ -6031,7 +6031,7 @@
         <dt><dfn>invalid vocab mapping</dfn></dt>
         <dd>An invalid <a>vocabulary mapping</a> has been detected,
           i.e., it is neither an <a>IRI</a> nor <code>null</code>.</dd>
-        <dt class="changed">iri confused with prefix</dt>
+        <dt class="changed">IRI confused with prefix</dt>
         <dd>When compacting an <a>absolute IRI</a> would result in an <a>absolute IRI</a>
           with an <a data-cite="RFC3986#section-3.1">IRI scheme</a> could be confused with a term.</dd>
         <dt><dfn>keyword redefinition</dfn></dt>

--- a/index.html
+++ b/index.html
@@ -3516,7 +3516,7 @@
           <a data-lt="active context">active context's</a> <a>vocabulary mapping</a>.
           Try to create a <a>compact IRI</a>, starting by initializing
           <var>compact IRI</var> to <code>null</code>. This variable will be used to
-          tore the created <a>compact IRI</a>, if any.</li>
+          store the created <a>compact IRI</a>, if any.</li>
         <li>For each key <a>term</a> and value <a>term definition</a> in
           the <var>active context</var>:
           <ol>
@@ -3543,6 +3543,12 @@
           </ol>
         </li>
         <li>If <var>compact IRI</var> is not <code>null</code>, return <var>compact IRI</var>.</li>
+        <li class="changed">To ensure that the <a>absolute IRI</a> <var>var</var> is
+          not confused with a <a>compact IRI</a>,
+          if the <a data-cite="RFC3986#section-3.1">IRI scheme</a> of <var>var</var>
+          matches any term in <a>active context</a>,
+          an <a data-link-for="JsonLdErrorCode">iri confused with prefix</a> error has been detected,
+          and processing is aborted.</li>
         <li>If <var>vocab</var> is <code>false</code>,
           transform <var>var</var> to a <a>relative IRI</a> using
           the <span class="changed"><a>base IRI</a> from <var>active context</var>, if it exists</span>.</li>
@@ -5917,6 +5923,7 @@
             "invalid value object",
             "invalid value object value",
             "invalid vocab mapping",
+            "iri confused with prefix",
             "keyword redefinition",
             "loading document failed",
             "loading remote context failed",
@@ -6024,6 +6031,9 @@
         <dt><dfn>invalid vocab mapping</dfn></dt>
         <dd>An invalid <a>vocabulary mapping</a> has been detected,
           i.e., it is neither an <a>IRI</a> nor <code>null</code>.</dd>
+        <dt class="changed">iri confused with prefix</dt>
+        <dd>When compacting an <a>absolute IRI</a> would result in an <a>absolute IRI</a>
+          with an <a data-cite="RFC3986#section-3.1">IRI scheme</a> could be confused with a term.</dd>
         <dt><dfn>keyword redefinition</dfn></dt>
         <dd>A <a>keyword</a> redefinition has been detected.</dd>
         <dt><dfn>loading document failed</dfn></dt>
@@ -6190,6 +6200,9 @@
       This allows a mechanism for documenting the content of a context using HTML.</li>
     <li>Consolidate <a>RemoteDocument</a> processing into the <a>LoadDocumentCallback</a>
       including variations on HTML processing.</li>
+    <li>The <a href="#iri-compaction">IRI compaction algorithm</a> may generate an error if the result is an
+      <a>absolute IRI</a> where the scheme part could be confused with a term in the
+      <a>active context</a>.</li>
   </ul>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -3547,6 +3547,7 @@
           not confused with a <a>compact IRI</a>,
           if the <a data-cite="RFC3986#section-3.1">IRI scheme</a> of <var>var</var>
           matches any term in <a>active context</a>,
+          and <var>var</var> has no <a datacite="https://tools.ietf.org/html/rfc3986#section-3.2">IRI authority</a> (beginning with double-forward-slash (<code>//</code>),
           an <a data-link-for="JsonLdErrorCode">IRI confused with prefix</a> error has been detected,
           and processing is aborted.</li>
         <li>If <var>vocab</var> is <code>false</code>,
@@ -6033,7 +6034,7 @@
           i.e., it is neither an <a>IRI</a> nor <code>null</code>.</dd>
         <dt class="changed">IRI confused with prefix</dt>
         <dd>When compacting an <a>absolute IRI</a> would result in an <a>absolute IRI</a>
-          with an <a data-cite="RFC3986#section-3.1">IRI scheme</a> could be confused with a term.</dd>
+          which could be confused with a compact IRI (because its <a data-cite="RFC3986#section-3.1">IRI scheme</a> matches a <a>term definition</a> and it has no <a data-cite="RFC3986#section-3.1">IRI authority</a>).</dd>
         <dt><dfn>keyword redefinition</dfn></dt>
         <dd>A <a>keyword</a> redefinition has been detected.</dd>
         <dt><dfn>loading document failed</dfn></dt>
@@ -6201,7 +6202,7 @@
     <li>Consolidate <a>RemoteDocument</a> processing into the <a>LoadDocumentCallback</a>
       including variations on HTML processing.</li>
     <li>The <a href="#iri-compaction">IRI compaction algorithm</a> may generate an error if the result is an
-      <a>absolute IRI</a> where the scheme part could be confused with a term in the
+      <a>absolute IRI</a> which could be confused with a compact IRI in the
       <a>active context</a>.</li>
   </ul>
 </section>

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -1149,6 +1149,15 @@
       "context": "compact/e001-context.jsonld",
       "expect": "compaction to list of lists"
     }, {
+      "@id": "#te002",
+      "@type": [ "jld:NegativeEvaluationTest", "jld:CompactTest" ],
+      "name": "Absolute IRI confused with Compact IRI",
+      "purpose": "Verifies that IRI compaction detects when the result is an absolute IRI with a scheme matching a term.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "compact/e002-in.jsonld",
+      "context": "compact/e002-context.jsonld",
+      "expect": "IRI confused with prefix"
+    }, {
       "@id": "#ten01",
       "@type": [ "jld:NegativeEvaluationTest", "jld:CompactTest" ],
       "name": "Nest term not defined",

--- a/tests/compact/e002-context.jsonld
+++ b/tests/compact/e002-context.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "tag": "http://example.org/ns/tag/"
+  }
+}

--- a/tests/compact/e002-in.jsonld
+++ b/tests/compact/e002-in.jsonld
@@ -1,0 +1,3 @@
+[{
+  "tag:champin.net,2019:prop": {"@value": "hello world"}
+}]


### PR DESCRIPTION
…where the scheme matches a term in the active context.

Fixes #104.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/110.html" title="Last updated on Jun 17, 2019, 8:29 PM UTC (d2302d9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/110/1466f97...d2302d9.html" title="Last updated on Jun 17, 2019, 8:29 PM UTC (d2302d9)">Diff</a>