### PR TITLE
Updates to add @propagate and @import

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
-  remote: git://github.com/ruby-rdf/json-ld.git
-  revision: 6f4b20de173ef27ff3959f5206b9a7cb813ecde7
+  remote: https://github.com/ruby-rdf/json-ld.git
+  revision: 74095b73cdb722b681f34d0f165599c9cb48d844
   branch: develop
   specs:
     json-ld (3.0.2)
@@ -26,7 +26,7 @@ GEM
       sxp (~> 1.0)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
-    haml (5.0.4)
+    haml (5.1.1)
       temple (>= 0.8.0)
       tilt
     hamster (3.0.0)
@@ -73,16 +73,16 @@ GEM
       sparql-client (~> 3.0)
     mini_portile2 (2.4.0)
     multi_json (1.13.1)
-    net-http-persistent (3.0.0)
+    net-http-persistent (3.0.1)
       connection_pool (~> 2.2)
-    nokogiri (1.10.1)
+    nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
     nokogumbo (1.5.0)
       nokogiri
-    public_suffix (3.0.3)
-    rack (2.0.6)
+    public_suffix (3.1.1)
+    rack (2.0.7)
     rake (12.3.2)
-    rdf (3.0.10)
+    rdf (3.0.12)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
     rdf-aggregate-repo (2.2.1)
@@ -96,8 +96,10 @@ GEM
       nokogiri (~> 1.8)
       rdf (>= 2.2.8, < 4.0)
       rdf-xsd (>= 2.2, < 4.0)
-    rdf-n3 (3.0.1)
+    rdf-n3 (3.1.0)
       rdf (~> 3.0)
+      sparql (~> 3.0)
+      sxp (~> 1.0)
     rdf-normalize (0.3.3)
       rdf (>= 2.2, < 4.0)
     rdf-rdfa (3.0.1)
@@ -111,28 +113,28 @@ GEM
       rdf (>= 2.2, < 4.0)
       rdf-rdfa (>= 2.2, < 4.0)
       rdf-xsd (>= 2.2, < 4.0)
-    rdf-reasoner (0.5.1)
+    rdf-reasoner (0.5.2)
       rdf (~> 3.0)
       rdf-vocab (~> 3.0)
       rdf-xsd (~> 3.0)
-    rdf-tabular (2.2.1)
+    rdf-tabular (2.2.2)
       addressable (~> 2.3)
       bcp47 (~> 0.3, >= 0.3.3)
       json-ld (>= 2.1, < 4.0)
-      rdf (>= 2.2, < 4.0)
-      rdf-vocab (>= 2.2, < 4.0)
-      rdf-xsd (>= 2.2, < 4.0)
+      rdf (~> 3.0)
+      rdf-vocab (~> 3.0)
+      rdf-xsd (~> 3.0)
     rdf-trig (3.0.1)
       ebnf (~> 1.1)
       rdf (~> 3.0)
       rdf-turtle (~> 3.0, >= 3.0.3)
     rdf-trix (2.2.1)
       rdf (>= 2.2, < 4.0)
-    rdf-turtle (3.0.5)
+    rdf-turtle (3.0.6)
       ebnf (~> 1.1)
       rdf (~> 3.0)
-    rdf-vocab (3.0.4)
-      rdf (~> 3.0)
+    rdf-vocab (3.0.7)
+      rdf (~> 3.0, >= 3.0.11)
     rdf-xsd (3.0.1)
       rdf (~> 3.0)
     shex (0.5.2)
@@ -171,4 +173,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.17.3
+   2.0.2

--- a/common/extract-examples.rb
+++ b/common/extract-examples.rb
@@ -10,6 +10,7 @@
 # - @data-options indicates the comma-separated option/value pairs to pass to the processor
 require 'getoptlong'
 require 'json'
+require 'json/ld/preloaded'
 require 'nokogiri'
 require 'linkeddata'
 require 'fileutils'

--- a/index.html
+++ b/index.html
@@ -1003,7 +1003,7 @@
       keys and values have to be interpreted as well as the current <a>base IRI</a>,
       the <a>vocabulary mapping</a>, the <a>default language</a>,
       <span class="changed">and an optional <dfn>previous context</dfn>,
-        used when a type-scoped <a>context</a> is defined</span>.
+        used when a non-propagated <a>context</a> is defined</span>.
       Each <a>term definition</a> consists of:</p>
     <ul>
       <li>an <dfn>IRI mapping</dfn>,</li>
@@ -1069,6 +1069,11 @@
         they affect how the other <a>entries</a> are processed. Please note that <code>@base</code> is
         ignored when processing remote contexts.</p>
 
+      <p class="changed">If <a>context</a> is not to be propagated,
+        a reference to the <var>previous context</var> is retained so that
+        it may be rolled back when a new <a>node object</a> is entered.
+        By default, all contexts are propagated, other than type-scoped contexts.</p>
+
       <p>Then, for every other <a>entry</a> in <a>local context</a>, we update
         the <a>term definition</a> in <var>result</var>. Since
         <a>term definitions</a> in a <a>local context</a>
@@ -1096,19 +1101,23 @@
         <span class="changed">, <var>from property</var>, defaulting to <code>false</code>,
           which is used to allow changes to protected terms,
           and <var>from type</var>, defaulting to <code>false</code>,
-          which is used to mark <a>term definitions</a> associated with a type-scoped <a>context</a>.</span>.
+          which is used to set the default for <var>propagated</var>
+          to mark <a>term definitions</a> associated with non-propagated <a>contexts</a>.</span>.
       </p>
 
       <ol>
         <li>Initialize <var>result</var> to the result of cloning
           <var>active context</var>.</li>
+        <li class="changed">If <var>local context</var> is an object containing the member <code>@propagate</code>,
+          its value MUST be <a>boolean</a> <code>true</code> or <code>false</code>,
+          set <var>propagate</var> to that value.</li>
+        <li class="changed">Otherwise, set <var>propagate</var> to <var>from type</var>.</li>
+        <li class="changed">If <var>propagate</var> is <code>false</code>, and <var>result</var>
+          does not have a <a>previous context</a>, set <a>previous context</a>
+          in <var>result</var> to <var>active context</var>.</li>
         <li>If <var>local context</var> is not an <a>array</a>,
           set it to an <a>array</a> containing only
           <var>local context</var>.</li>
-        <li class="changed">
-          If <var>from type</var> is <code>true</code>, and <var>result</var>
-          does not have a <a>previous context</a>, set <a>previous context</a>
-          in <var>result</var> to <var>active context</var>.</li>
         <li>
           For each item <var>context</var> in <var>local context</var>:
           <ol>
@@ -1242,12 +1251,24 @@
                   error has been detected and processing is aborted.</li>
               </ol>
             </li>
+            <li>If <var>context</var> has an <code>@propagate</code> <a>entry</a>
+              and its value is not <a>boolean</a> <code>true</code> or <code>false</code>,
+              or <a>processing mode</a> is <code>json-ld-1.0</code>,
+              an <a data-link-for="JsonLdErrorCode">invalid local context</a>
+              error has been detected and processing is aborted.
+              <span class="note"><var>previous context</var> was determined before.</span></li>
             <li>Create a <a class="changed">map</a> <var>defined</var> to use to keep
               track of whether or not a <a>term</a> has already been defined
               or currently being defined during recursion.</li>
             <li>For each <var>key</var>-<var>value</var> pair in <var>context</var> where
-              <var>key</var> is not <code>@base</code>, <code>@vocab</code>,
-              <code>@language</code>, <code>@protected</code>, or <code>@version</code>, invoke the
+              <var>key</var> is not
+              <code>@base</code>,
+              <code>@vocab</code>,
+              <code>@language</code>,
+              <code class="changed">@propagate</code>,
+              <code class="changed">@protected</code>, or
+              <code>@version</code>,
+              invoke the
               <a href="#create-term-definition">Create Term Definition algorithm</a>,
               passing <var>result</var> for <var>active context</var>,
               <var>context</var> for <var>local context</var>, <var>key</var>,
@@ -1791,7 +1812,7 @@
           the <a data-link-for="JsonLdOptions">ordered</a> flag, used to order
           <a>map entry</a> keys lexicographically, where noted,
           and the <var>from map</var> flag, used to control reverting
-          previous <a>term definitions</a> in the <a>active context</a> associated with a type-scoped <a>context</a>.</span>
+          previous <a>term definitions</a> in the <a>active context</a> associated with non-propagated <a>contexts</a>.</span>
         To begin, the <var>active property</var> is set to <code>null</code>,
         and <var>element</var> is set to the <a>JSON-LD input</a>.
         <span class="changed">If not passed, the both flags are set to <code>false</code></span>.</p>
@@ -1866,7 +1887,7 @@
         </li>
         <li>Otherwise <var>element</var> is a <a class="changed">map</a>.</li>
         <li class="changed">If <var>active context</var> has a <a>previous context</a>,
-          the <var>active context</var> is type-scoped.
+          the <var>active context</var> is not propagated.
           If <var>from map</var> is undefined or <code>false</code>,
           and <var>element</var> does not contain a <a>entry</a> expanding to <code>@value</code>,
           and <var>element</var> does not consist of a single entry expanding to <code>@id</code>,
@@ -2570,7 +2591,7 @@
         </li>
         <li>Otherwise <var>element</var> is a <a class="changed">map</a>.</li>
         <li class="changed">If <var>active context</var> has a <a>previous context</a>,
-          the <var>active context</var> is type-scoped.
+          the <var>active context</var> is not propagated.
           If <var>element</var> does not contain an <code>@value</code> <a>entry</a>,
           and <var>element</var> does not consist of a single <code>@id</code> entry,
           set <var>active context</var> to <a>previous context</a> from <var>active context</var>,
@@ -6215,6 +6236,9 @@
     <li>The <a href="#iri-compaction">IRI compaction algorithm</a> may generate an error if the result is an
       <a>absolute IRI</a> which could be confused with a compact IRI in the
       <a>active context</a>.</li>
+    <li>By default, all contexts are propagated when traversing <a>node objects</a>, other than
+      type-scoped contexts. This can be controlled using the <code>@preserve</code>
+      <a>member</a> in a <a>local context</a>.</li>
   </ul>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -6300,8 +6300,8 @@
       <a>active context</a>.</li>
     <li>By default, all contexts are propagated when traversing <a>node objects</a>, other than
       type-scoped contexts. This can be controlled using the <code>@propagate</code>
-      <a>member</a> in a <a>local context</a>.</li>
-    <li>A context may contain a <code>@source</code> member used to reference a remote context
+      <a>entry</a> in a <a>local context</a>.</li>
+    <li>A context may contain a <code>@source</code> <a>entry</a> used to reference a remote context
       within a context, allowing <code>JSON-LD 1.1</code> features to be added to contexts originally
       authored for <code>JSON-LD 1.0</code>.</li>
   </ul>

--- a/index.html
+++ b/index.html
@@ -6237,7 +6237,7 @@
       <a>absolute IRI</a> which could be confused with a compact IRI in the
       <a>active context</a>.</li>
     <li>By default, all contexts are propagated when traversing <a>node objects</a>, other than
-      type-scoped contexts. This can be controlled using the <code>@preserve</code>
+      type-scoped contexts. This can be controlled using the <code>@propagate</code>
       <a>member</a> in a <a>local context</a>.</li>
   </ul>
 </section>

--- a/index.html
+++ b/index.html
@@ -1066,8 +1066,10 @@
         <a>default language</a> by processing three specific keywords:
         <code>@base</code>, <code>@vocab</code>, <code>@version</code>, and <code>@language</code>.
         These are handled before any other <a>entries</a> in the <a>local context</a> because
-        they affect how the other <a>entries</a> are processed. Please note that <code>@base</code> is
-        ignored when processing remote contexts.</p>
+        they affect how the other <a>entries</a> are processed.
+        <span class="changed">If <a>context</a> contains <code>@source</code>, it is retrieved and is reverse-merged
+          into the containing context, allowing JSON-LD 1.0 contexts to be uplifed to JSON-LD 1.1.</span>
+        Please note that <code>@base</code> is ignored when processing remote contexts.</p>
 
       <p class="changed">If <a>context</a> is not to be propagated,
         a reference to the <var>previous context</var> is retained so that
@@ -1093,15 +1095,14 @@
 
       <p>This algorithm specifies how a new <a>active context</a> is updated
         with a <a>local context</a>. The algorithm takes two required
-        <span class="changed">and four optional</span> input variables.
+        <span class="changed">and three optional</span>
+        input variables.
         The required inputs are an <var>active context</var> and a <var>local context</var>.
         The optional inputs are an <a>array</a> <var>remote contexts</var>,
         defaulting to a new empty <a>array</a>, which is used to detect cyclical context inclusions,
         <span class="changed">
           <var>override protected</var>, defaulting to <code>false</code>,
           which is used to allow changes to protected terms,
-          <var>protected</var>, defaulting to <code>false</code>,
-          which provides a defeault value for <code>@protected</code>,
           and <var>propagate</var>, defaulting to <code>true</code>
           to mark <a>term definitions</a> associated with non-propagated <a>contexts</a>.</span>.
       </p>
@@ -1195,9 +1196,6 @@
                   to <code>json-ld-1.1</code>, if not already set.</li>
               </ol>
             </li>
-            <li class="changed">If <var>context</var> has a <code>@protected</code> <a>entry</a>,
-              set the value of <var>protected</var> from its value.</li>
-            </li>
             <li class="changed">If <var>context</var> has an <code>@source</code> <a>entry</a>:
               <ol>
                 <li>If <a>processing mode</a> is <code>json-ld-1.0</code>,
@@ -1206,12 +1204,39 @@
                 <li>Otherwise, if its value is not a <a>string</a>,
                   an <a data-link-for="JsonLdErrorCode">invalid @source value</a>
                   error has been detected and processing is aborted.</li>
-                <li>Otherwise, set <var>result</var> to the result of recursively calling this algorithm,
-                  passing <var>result</var> for <var>active context</var>,
-                  the value of <code>@source</code> for <var>local context</var>,
-                  a copy of <var>remote contexts</var>,
-                  and <var>protected</var>.
-                </li>
+                <li>Set <var>source</var> to the result of resolving the value of <code>@source</code> against
+                  the base IRI which is established as specified in
+                  <a data-cite="RFC3986#section-5.1">section 5.1 Establishing a Base URI</a>
+                  of [[RFC3986]]. Only the basic algorithm in
+                  <a data-cite="RFC3986#section-5.2">section 5.2</a>
+                  of [[RFC3986]] is used; neither
+                  <a data-cite="RFC3986#section-6.2.2">Syntax-Based Normalization</a> nor
+                  <a data-cite="RFC3986#section-6.2.3">Scheme-Based Normalization</a>
+                  are performed. Characters additionally allowed in IRI
+                  references are treated in the same way that unreserved
+                  characters are treated in URI references, per
+                  <a data-cite="RFC3987#section-6.5">section 6.5</a>
+                  of [[RFC3987]].</li>
+                <li>Otherwise, dereference <var>source</var> using
+                  the <a>LoadDocumentCallback</a>, passing <var>source</var>
+                  for <a data-link-for="LoadDocumentCallback">url</a>,
+                  and <code>http://www.w3.org/ns/json-ld#context</code> for <a data-link-for="LoadDocumentOptions">profile</a></li>
+                <li>If <var>source</var> cannot be dereferenced,
+                  <span>or cannot be transformed into the <a>internal representation</a></span>,
+                  a <a data-link-for="JsonLdErrorCode">loading remote context failed</a>
+                  error has been detected and processing is aborted.</li>
+                <li>If the dereferenced document has no
+                  top-level <a>map</a> with an <code>@context</code> <a>entry</a>,
+                  or if the value of <code>@context</code> is not an <a>map</a>,
+                  an <a data-link-for="JsonLdErrorCode">invalid remote context</a>
+                  has been detected and processing is aborted; otherwise,
+                  set <var>source context</var> to the value of that <a>entry</a>.</li>
+                <li>If <var>source context</var> has a <code>@source</code> <a>entry</a>,
+                  an <a data-link-for="JsonLdErrorCode">invalid context entry</a>
+                  error has been detected and processing is aborted.</li>
+                <li>Set <var>context</var> to the result of merging <var>context</var>
+                  into <var>source context</var>, replacing common entries
+                  with those from <var>context</var>.</li>
               </ol>
             </li>
             <li>If <var>context</var> has an <code>@base</code> <a>entry</a> and <var>remote contexts</var> is empty, i.e., the currently
@@ -1282,7 +1307,7 @@
                   and no further processing is necessary.</li>
               </ol>
             </li>
-            <li>Create a <a class="changed">dictionary</a> <var>defined</var> to use to keep
+            <li>Create a <a class="changed">map</a> <var>defined</var> to use to keep
               track of whether or not a <a>term</a> has already been defined
               or currently being defined during recursion.</li>
             <li>For each <var>key</var>-<var>value</var> pair in <var>context</var> where
@@ -1299,7 +1324,9 @@
               <var>context</var> for <var>local context</var>, <var>key</var>,
               <var>defined</var>,
               <span class="changed">
-                <var>protected</var>, <var>override protected</var>, and <var>propagate</var>
+                the value of the <code>@protected</code>
+                entry from <var>context</var>, if any, for <var>protected</var>,
+                and <var>propagate</var>
               </span>.
             </li>
           </ol>

--- a/index.html
+++ b/index.html
@@ -1093,15 +1093,16 @@
 
       <p>This algorithm specifies how a new <a>active context</a> is updated
         with a <a>local context</a>. The algorithm takes two required
-        <span class="changed">and three optional</span>
-        input variables.
+        <span class="changed">and four optional</span> input variables.
         The required inputs are an <var>active context</var> and a <var>local context</var>.
         The optional inputs are an <a>array</a> <var>remote contexts</var>,
         defaulting to a new empty <a>array</a>, which is used to detect cyclical context inclusions,
-        <span class="changed">, <var>from property</var>, defaulting to <code>false</code>,
+        <span class="changed">
+          <var>override protected</var>, defaulting to <code>false</code>,
           which is used to allow changes to protected terms,
-          and <var>from type</var>, defaulting to <code>false</code>,
-          which is used to set the default for <var>propagated</var>
+          <var>protected</var>, defaulting to <code>false</code>,
+          which provides a defeault value for <code>@protected</code>,
+          and <var>propagate</var>, defaulting to <code>true</code>
           to mark <a>term definitions</a> associated with non-propagated <a>contexts</a>.</span>.
       </p>
 
@@ -1111,7 +1112,6 @@
         <li class="changed">If <var>local context</var> is an object containing the member <code>@propagate</code>,
           its value MUST be <a>boolean</a> <code>true</code> or <code>false</code>,
           set <var>propagate</var> to that value.</li>
-        <li class="changed">Otherwise, set <var>propagate</var> to <var>from type</var>.</li>
         <li class="changed">If <var>propagate</var> is <code>false</code>, and <var>result</var>
           does not have a <a>previous context</a>, set <a>previous context</a>
           in <var>result</var> to <var>active context</var>.</li>
@@ -1123,14 +1123,14 @@
           <ol>
             <li>If <var>context</var> is <code>null</code>:
               <ol>
-                <li class="changed">If <var>from property</var> is <code>false</code> and <var>active context</var>
+                <li class="changed">If <var>override protected</var> is <code>false</code> and <var>active context</var>
                   contains any <a>protected</a> <a>term definitions</a>,
                   an <a data-link-for="JsonLdErrorCode">invalid context nullification</a>
                   has been detected and processing is aborted.</li>
                 <li>Otherwise, set <var>result</var> to a
                   newly-initialized <var>active context</var>,
                   <span class="changed">setting <a>previous context</a> in <var>result</var>
-                    to the previous value of <var>result</var> if <var>from type</var> is <code>true</code></span>.
+                    to the previous value of <var>result</var> if <var>propagate</var> is <code>false</code></span>.
                   Continue with the next <var>context</var>.
                   <span class="note">In [[[JSON-LD]]], the <a>base IRI</a> was given
                     a default value here; this is now described conditionally
@@ -1195,6 +1195,9 @@
                   to <code>json-ld-1.1</code>, if not already set.</li>
               </ol>
             </li>
+            <li class="changed">If <var>context</var> has a <code>@protected</code> <a>entry</a>,
+              set the value of <var>protected</var> from its value.</li>
+            </li>
             <li class="changed">If <var>context</var> has an <code>@source</code> <a>entry</a>:
               <ol>
                 <li>If <a>processing mode</a> is <code>json-ld-1.0</code>,
@@ -1206,7 +1209,8 @@
                 <li>Otherwise, set <var>result</var> to the result of recursively calling this algorithm,
                   passing <var>result</var> for <var>active context</var>,
                   the value of <code>@source</code> for <var>local context</var>,
-                  and a copy of <var>remote contexts</var>.
+                  a copy of <var>remote contexts</var>,
+                  and <var>protected</var>.
                 </li>
               </ol>
             </li>
@@ -1294,9 +1298,10 @@
               passing <var>result</var> for <var>active context</var>,
               <var>context</var> for <var>local context</var>, <var>key</var>,
               <var>defined</var>,
-              <span class="changed">the value of the <code>@protected</code>
-                entry from <var>context</var>, if any, for <var>protected</var></span>,
-                <var>from property</var>, and <var>from type</var>.</li>
+              <span class="changed">
+                <var>protected</var>, <var>override protected</var>, and <var>propagate</var>
+              </span>.
+            </li>
           </ol>
         </li>
         <li>Return <var>result</var>.</li>
@@ -1347,9 +1352,9 @@
         a <var>term</var>, and a map <var>defined</var>.
         <span class="changed">The optional inputs are
           <var>protected</var> which defaults to <code>false</code>,
-          <var>from property</var>, defaulting to <code>false</code>,
+          <var>override protected</var>, defaulting to <code>false</code>,
           which is used to allow changes to protected terms,
-          and <var>from type</var>, defaulting to <code>false</code>.</span>.
+          and <var>propagate</var>, defaulting to <code>true</code>.</span>.
         </p>
       <ol>
         <li>If <var>defined</var> contains the <a>entry</a> <var>term</var> and the associated
@@ -1565,7 +1570,7 @@
               <code>@context</code> <a>entry</a>, which is treated as a <var>local context</var>.</li>
             <li>Invoke the <a href="#context-processing-algorithm">Context Processing algorithm</a>
               using the <var>active context</var>, <var>context</var> as <var>local context</var>,
-              and <code>true</code> for <var>from property</var>.
+              and <code>true</code> for <var>override protected</var>.
               If any error is detected, an
               <a data-link-for="JsonLdErrorCode">invalid scoped context</a> error
               has been detected and processing is aborted.
@@ -1619,7 +1624,7 @@
           <code class="changed">@prefix</code>, or <code>@type</code>, an
           <a data-link-for="JsonLdErrorCode">invalid term definition</a> error has
           been detected and processing is aborted.</li>
-        <li class="changed">If <var>from property</var> is <code>false</code>
+        <li class="changed">If <var>override protected</var> is <code>false</code>
           and <var>previous definition</var> exists and is protected;
           <ol>
             <li>If <var>definition</var> is not the same as <var>previous definition</var>
@@ -1941,7 +1946,7 @@
               <a href="#context-processing-algorithm">Context Processing algorithm</a>,
               passing <var>active context</var>, the value of the
               <var>term</var>'s <a>local context</a> as <var>local context</var>,
-              <span class="changed">and <code>true</code> for <var>from type</var></span>.</li>
+              <span class="changed">and <code>true</code> for <var>propagate</var></span>.</li>
           </ol>
         </li>
         <li>Initialize two empty <a class="changed">maps</a>, <var>result</var>
@@ -2624,7 +2629,7 @@
               <a href="#context-processing-algorithm">Context Processing algorithm</a>,
               passing <var>active context</var>, the value of the
               <var>active property</var>'s <a>local context</a> as <var>local context</var>,
-              <span class="changed">and <code>true</code> for <var>from property</var></span>.</li>
+              <span class="changed">and <code>true</code> for <var>override protected</var></span>.</li>
             <li>Set <var>inverse context</var> using the
               <a href="#inverse-context-creation">Inverse Context Creation algorithm</a>
               using <var>active context</var>.</li>
@@ -2658,7 +2663,7 @@
           into it's compacted form using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
           passing <var>active context</var>, <var>inverse context</var>,
           <var>expanded type</var> for <var>var</var>, <code>true</code> for <var>vocab</var>,
-          and <code>true</code> for <var>from type</var>.
+          and <code>false</code> for <var>propagate</var>.
           Then, for each <var>term</var>
           in <var>compacted types</var> ordered lexicographically:
           <ol>

--- a/index.html
+++ b/index.html
@@ -1201,7 +1201,7 @@
             <li class="changed">If <var>context</var> has an <code>@source</code> <a>entry</a>:
               <ol>
                 <li>If <a>processing mode</a> is <code>json-ld-1.0</code>,
-                  an <a data-link-for="JsonLdErrorCode">invalid context member</a>
+                  an <a data-link-for="JsonLdErrorCode">invalid context entry</a>
                   error has been detected and processing is aborted.</li>
                 <li>Otherwise, if its value is not a <a>string</a>,
                   an <a data-link-for="JsonLdErrorCode">invalid @source value</a>
@@ -1273,7 +1273,7 @@
             <li class="changed">If <var>context</var> has an <code>@propagate</code> <a>entry</a>:
               <ol>
                 <li>If <a>processing mode</a> is <code>json-ld-1.0</code>,
-                  an <a data-link-for="JsonLdErrorCode">invalid context member</a>
+                  an <a data-link-for="JsonLdErrorCode">invalid context entry</a>
                   error has been detected and processing is aborted.</li>
                 <li>Otherwise, if its value is not <a>boolean</a> <code>true</code> or <code>false</code>,
                   an <a data-link-for="JsonLdErrorCode">invalid @propagate value</a>
@@ -5961,7 +5961,7 @@
             "invalid @version value",
             "invalid base IRI",
             "invalid container mapping",
-            "invalid context member",
+            "invalid context entry",
             "invalid context nullification",
             "invalid default language",
             "invalid IRI mapping",
@@ -6115,8 +6115,8 @@
           which is incompatible with the previous specified version.</dd>
         <dt><dfn>context overflow</dfn></dt>
         <dd>maximum number of <code>@context</code> URLs exceeded.</dd>
-        <dt class="changed"><dfn>invalid context member</dfn></dt>
-        <dd class="changed">A member of a context is invalid due to processing mode incompatibility.</dd>
+        <dt class="changed"><dfn>invalid context entry</dfn></dt>
+        <dd class="changed">An <a>entry</a> in a context is invalid due to processing mode incompatibility.</dd>
         <dt class="changed"><dfn>invalid context nullification</dfn></dt>
         <dd class="changed">An attempt was made to nullify a context
           containing <a>protected</a> <a>term definitions</a>.</dd>

--- a/index.html
+++ b/index.html
@@ -1182,6 +1182,34 @@
             <li>If <var>context</var> is not a <a class="changed">map</a>, an
               <a data-link-for="JsonLdErrorCode">invalid local context</a>
               error has been detected and processing is aborted.</li>
+            <li class="changed">If <var>context</var> has an <code>@version</code> <a>entry</a>:
+              <ol>
+                <li>If the associated value is not <code>1.1</code>,
+                  an <a data-link-for="JsonLdErrorCode">invalid @version value</a>
+                  has been detected, and processing is aborted.</li>
+                <li>If <a>processing mode</a>
+                  is set to <code>json-ld-1.0</code>,
+                  a <a data-link-for="JsonLdErrorCode">processing mode conflict</a>
+                  error has been detected and processing is aborted.</li>
+                <li>Set <a>processing mode</a>,
+                  to <code>json-ld-1.1</code>, if not already set.</li>
+              </ol>
+            </li>
+            <li class="changed">If <var>context</var> has an <code>@source</code> <a>entry</a>:
+              <ol>
+                <li>If <a>processing mode</a> is <code>json-ld-1.0</code>,
+                  an <a data-link-for="JsonLdErrorCode">invalid context member</a>
+                  error has been detected and processing is aborted.</li>
+                <li>Otherwise, if its value is not a <a>string</a>,
+                  an <a data-link-for="JsonLdErrorCode">invalid @source value</a>
+                  error has been detected and processing is aborted.</li>
+                <li>Otherwise, set <var>result</var> to the result of recursively calling this algorithm,
+                  passing <var>result</var> for <var>active context</var>,
+                  the value of <code>@source</code> for <var>local context</var>,
+                  and a copy of <var>remote contexts</var>.
+                </li>
+              </ol>
+            </li>
             <li>If <var>context</var> has an <code>@base</code> <a>entry</a> and <var>remote contexts</var> is empty, i.e., the currently
               being processed context is not a remote context:
               <ol>
@@ -1199,19 +1227,6 @@
                 <li>Otherwise, an
                   <a data-link-for="JsonLdErrorCode">invalid base IRI</a>
                   error has been detected and processing is aborted.</li>
-              </ol>
-            </li>
-            <li class="changed">If <var>context</var> has an <code>@version</code> <a>entry</a>:
-              <ol>
-                <li>If the associated value is not <code>1.1</code>,
-                  an <a data-link-for="JsonLdErrorCode">invalid @version value</a>
-                  has been detected, and processing is aborted.</li>
-                <li>If <a>processing mode</a>
-                  is set to <code>json-ld-1.0</code>,
-                  a <a data-link-for="JsonLdErrorCode">processing mode conflict</a>
-                  error has been detected and processing is aborted.</li>
-                <li>Set <a>processing mode</a>,
-                  to <code>json-ld-1.1</code>, if not already set.</li>
               </ol>
             </li>
             <li>If <var>context</var> has an <code>@vocab</code> <a>entry</a>:
@@ -1251,13 +1266,19 @@
                   error has been detected and processing is aborted.</li>
               </ol>
             </li>
-            <li>If <var>context</var> has an <code>@propagate</code> <a>entry</a>
-              and its value is not <a>boolean</a> <code>true</code> or <code>false</code>,
-              or <a>processing mode</a> is <code>json-ld-1.0</code>,
-              an <a data-link-for="JsonLdErrorCode">invalid local context</a>
-              error has been detected and processing is aborted.
-              <span class="note"><var>previous context</var> was determined before.</span></li>
-            <li>Create a <a class="changed">map</a> <var>defined</var> to use to keep
+            <li class="changed">If <var>context</var> has an <code>@propagate</code> <a>entry</a>:
+              <ol>
+                <li>If <a>processing mode</a> is <code>json-ld-1.0</code>,
+                  an <a data-link-for="JsonLdErrorCode">invalid context member</a>
+                  error has been detected and processing is aborted.</li>
+                <li>Otherwise, if its value is not <a>boolean</a> <code>true</code> or <code>false</code>,
+                  an <a data-link-for="JsonLdErrorCode">invalid @propagate value</a>
+                  error has been detected and processing is aborted.</li>
+                <li>Otherwise, <var>previous context</var> was determined before,
+                  and no further processing is necessary.</li>
+              </ol>
+            </li>
+            <li>Create a <a class="changed">dictionary</a> <var>defined</var> to use to keep
               track of whether or not a <a>term</a> has already been defined
               or currently being defined during recursion.</li>
             <li>For each <var>key</var>-<var>value</var> pair in <var>context</var> where
@@ -5929,10 +5950,13 @@
             "invalid @index value",
             "invalid @nest value",
             "invalid @prefix value",
+            "invalid @propagate value",
             "invalid @reverse value",
+            "invalid @source value",
             "invalid @version value",
             "invalid base IRI",
             "invalid container mapping",
+            "invalid context member",
             "invalid context nullification",
             "invalid default language",
             "invalid IRI mapping",
@@ -5985,9 +6009,13 @@
         <dd class="changed">An invalid value for <code>@nest</code> has been found.</dd>
         <dt class="changed"><dfn>invalid @prefix value</dfn></dt>
         <dd class="changed">An invalid value for <code>@prefix</code> has been found.</dd>
+        <dt class="changed"><dfn>invalid @propagate value</dfn></dt>
+        <dd class="changed">An invalid value for <code>@propagate</code> has been found.</dd>
         <dt><dfn>invalid @reverse value</dfn></dt>
         <dd>An invalid value for an <code>@reverse</code> <a>entry</a> has been detected,
           i.e., the value was not a <a class="changed">map</a>.</dd>
+        <dt class="changed"><dfn>invalid @source value</dfn></dt>
+        <dd class="changed">An invalid value for <code>@source</code> has been found.</dd>
         <dt><dfn>invalid @version value</dfn></dt>
         <dd>The <code>@version</code> <a>entry</a> was used in a <a>context</a>
           with an out of range value.</dd>
@@ -6082,6 +6110,8 @@
           which is incompatible with the previous specified version.</dd>
         <dt><dfn>context overflow</dfn></dt>
         <dd>maximum number of <code>@context</code> URLs exceeded.</dd>
+        <dt class="changed"><dfn>invalid context member</dfn></dt>
+        <dd class="changed">A member of a context is invalid due to processing mode incompatibility.</dd>
         <dt class="changed"><dfn>invalid context nullification</dfn></dt>
         <dd class="changed">An attempt was made to nullify a context
           containing <a>protected</a> <a>term definitions</a>.</dd>
@@ -6239,6 +6269,9 @@
     <li>By default, all contexts are propagated when traversing <a>node objects</a>, other than
       type-scoped contexts. This can be controlled using the <code>@propagate</code>
       <a>member</a> in a <a>local context</a>.</li>
+    <li>A context may contain a <code>@source</code> member used to reference a remote context
+      within a context, allowing <code>JSON-LD 1.1</code> features to be added to contexts originally
+      authored for <code>JSON-LD 1.0</code>.</li>
   </ul>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -1067,7 +1067,7 @@
         <code>@base</code>, <code>@vocab</code>, <code>@version</code>, and <code>@language</code>.
         These are handled before any other <a>entries</a> in the <a>local context</a> because
         they affect how the other <a>entries</a> are processed.
-        <span class="changed">If <a>context</a> contains <code>@source</code>, it is retrieved and is reverse-merged
+        <span class="changed">If <a>context</a> contains <code>@import</code>, it is retrieved and is reverse-merged
           into the containing context, allowing JSON-LD 1.0 contexts to be uplifed to JSON-LD 1.1.</span>
         Please note that <code>@base</code> is ignored when processing remote contexts.</p>
 
@@ -1196,15 +1196,15 @@
                   to <code>json-ld-1.1</code>, if not already set.</li>
               </ol>
             </li>
-            <li class="changed">If <var>context</var> has an <code>@source</code> <a>entry</a>:
+            <li class="changed">If <var>context</var> has an <code>@import</code> <a>entry</a>:
               <ol>
                 <li>If <a>processing mode</a> is <code>json-ld-1.0</code>,
                   an <a data-link-for="JsonLdErrorCode">invalid context entry</a>
                   error has been detected and processing is aborted.</li>
                 <li>Otherwise, if its value is not a <a>string</a>,
-                  an <a data-link-for="JsonLdErrorCode">invalid @source value</a>
+                  an <a data-link-for="JsonLdErrorCode">invalid @import value</a>
                   error has been detected and processing is aborted.</li>
-                <li>Set <var>source</var> to the result of resolving the value of <code>@source</code> against
+                <li>Set <var>import</var> to the result of resolving the value of <code>@import</code> against
                   the base IRI which is established as specified in
                   <a data-cite="RFC3986#section-5.1">section 5.1 Establishing a Base URI</a>
                   of [[RFC3986]]. Only the basic algorithm in
@@ -1217,11 +1217,11 @@
                   characters are treated in URI references, per
                   <a data-cite="RFC3987#section-6.5">section 6.5</a>
                   of [[RFC3987]].</li>
-                <li>Otherwise, dereference <var>source</var> using
-                  the <a>LoadDocumentCallback</a>, passing <var>source</var>
+                <li>Otherwise, dereference <var>import</var> using
+                  the <a>LoadDocumentCallback</a>, passing <var>import</var>
                   for <a data-link-for="LoadDocumentCallback">url</a>,
                   and <code>http://www.w3.org/ns/json-ld#context</code> for <a data-link-for="LoadDocumentOptions">profile</a></li>
-                <li>If <var>source</var> cannot be dereferenced,
+                <li>If <var>import</var> cannot be dereferenced,
                   <span>or cannot be transformed into the <a>internal representation</a></span>,
                   a <a data-link-for="JsonLdErrorCode">loading remote context failed</a>
                   error has been detected and processing is aborted.</li>
@@ -1230,12 +1230,12 @@
                   or if the value of <code>@context</code> is not an <a>map</a>,
                   an <a data-link-for="JsonLdErrorCode">invalid remote context</a>
                   has been detected and processing is aborted; otherwise,
-                  set <var>source context</var> to the value of that <a>entry</a>.</li>
-                <li>If <var>source context</var> has a <code>@source</code> <a>entry</a>,
+                  set <var>import context</var> to the value of that <a>entry</a>.</li>
+                <li>If <var>import context</var> has a <code>@import</code> <a>entry</a>,
                   an <a data-link-for="JsonLdErrorCode">invalid context entry</a>
                   error has been detected and processing is aborted.</li>
                 <li>Set <var>context</var> to the result of merging <var>context</var>
-                  into <var>source context</var>, replacing common entries
+                  into <var>import context</var>, replacing common entries
                   with those from <var>context</var>.</li>
               </ol>
             </li>
@@ -5984,7 +5984,7 @@
             "invalid @prefix value",
             "invalid @propagate value",
             "invalid @reverse value",
-            "invalid @source value",
+            "invalid @import value",
             "invalid @version value",
             "invalid base IRI",
             "invalid container mapping",
@@ -6046,8 +6046,8 @@
         <dt><dfn>invalid @reverse value</dfn></dt>
         <dd>An invalid value for an <code>@reverse</code> <a>entry</a> has been detected,
           i.e., the value was not a <a class="changed">map</a>.</dd>
-        <dt class="changed"><dfn>invalid @source value</dfn></dt>
-        <dd class="changed">An invalid value for <code>@source</code> has been found.</dd>
+        <dt class="changed"><dfn>invalid @import value</dfn></dt>
+        <dd class="changed">An invalid value for <code>@import</code> has been found.</dd>
         <dt><dfn>invalid @version value</dfn></dt>
         <dd>The <code>@version</code> <a>entry</a> was used in a <a>context</a>
           with an out of range value.</dd>
@@ -6301,7 +6301,7 @@
     <li>By default, all contexts are propagated when traversing <a>node objects</a>, other than
       type-scoped contexts. This can be controlled using the <code>@propagate</code>
       <a>entry</a> in a <a>local context</a>.</li>
-    <li>A context may contain a <code>@source</code> <a>entry</a> used to reference a remote context
+    <li>A context may contain a <code>@import</code> <a>entry</a> used to reference a remote context
       within a context, allowing <code>JSON-LD 1.1</code> features to be added to contexts originally
       authored for <code>JSON-LD 1.0</code>.</li>
   </ul>

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -1140,6 +1140,24 @@
       "expect": "compact/c025-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tc026",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "@propagate: true on type-scoped context",
+      "purpose": "type-scoped context with @propagate: true survive node-objects",
+      "input": "compact/c026-in.jsonld",
+      "context": "compact/c026-context.jsonld",
+      "expect": "compact/c026-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tc027",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "@propagate: false on property-scoped context",
+      "purpose": "property-scoped context with @propagate: false do not survive node-objects",
+      "input": "compact/c027-in.jsonld",
+      "context": "compact/c027-context.jsonld",
+      "expect": "compact/c027-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#te001",
       "@type": [ "jld:NegativeEvaluationTest", "jld:CompactTest" ],
       "name": "Compaction to list of lists",

--- a/tests/compact/c024-context.jsonld
+++ b/tests/compact/c024-context.jsonld
@@ -11,7 +11,6 @@
       "@id": "ex:Inner",
       "@context": {
         "@version": 1.1,
-        "val": "@value",
         "foo": {
           "@id": "ex:foo",
           "@container": "@set",

--- a/tests/compact/c024-out.jsonld
+++ b/tests/compact/c024-out.jsonld
@@ -11,7 +11,6 @@
       "@id": "ex:Inner",
       "@context": {
         "@version": 1.1,
-        "val": "@value",
         "foo": {
           "@id": "ex:foo",
           "@container": "@set",

--- a/tests/compact/c026-context.jsonld
+++ b/tests/compact/c026-context.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example/",
+    "Foo": {
+      "@context": {
+        "@propagate": true,
+        "baz": {"@type": "@vocab"}
+      }
+    }
+  }
+}

--- a/tests/compact/c026-in.jsonld
+++ b/tests/compact/c026-in.jsonld
@@ -1,0 +1,8 @@
+[
+  {
+    "@type": ["http://example/Foo"],
+    "http://example/bar": [{
+      "http://example/baz": [{"@id": "http://example/buzz"}]
+    }]
+  }
+]

--- a/tests/compact/c026-out.jsonld
+++ b/tests/compact/c026-out.jsonld
@@ -1,0 +1,14 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example/",
+    "Foo": {
+      "@context": {
+        "@propagate": true,
+        "baz": {"@type": "@vocab"}
+      }
+    }
+  },
+  "@type": "Foo",
+  "bar": {"baz": "buzz"}
+}

--- a/tests/compact/c027-context.jsonld
+++ b/tests/compact/c027-context.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example/",
+    "bar": {
+      "@context": {
+        "@propagate": false,
+        "baz": {"@type": "@id"}
+      }
+    }
+  }
+}

--- a/tests/compact/c027-in.jsonld
+++ b/tests/compact/c027-in.jsonld
@@ -1,0 +1,7 @@
+[{
+ "http://example/bar": [{
+   "http://example/baz": [{
+     "http://example/baz": [{"@value": "buzz"}]
+   }]
+ }]
+}]

--- a/tests/compact/c027-out.jsonld
+++ b/tests/compact/c027-out.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example/",
+    "bar": {
+      "@context": {
+        "@propagate": false,
+        "baz": {"@type": "@id"}
+      }
+    }
+  },
+  "bar": {"baz": {"baz": "buzz"}}
+}

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -2398,40 +2398,40 @@
     }, {
       "@id": "#tso01",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
-      "name": "@source is invalid in 1.0.",
-      "purpose": "@source is invalid in 1.0.",
+      "name": "@import is invalid in 1.0.",
+      "purpose": "@import is invalid in 1.0.",
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/so01-in.jsonld",
       "expect": "invalid context member"
     }, {
       "@id": "#tso02",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
-      "name": "@source must be a string",
-      "purpose": "@source must be a string.",
+      "name": "@import must be a string",
+      "purpose": "@import must be a string.",
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/so02-in.jsonld",
-      "expect": "invalid @source value"
+      "expect": "invalid @import value"
     }, {
       "@id": "#tso03",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
-      "name": "@source overflow",
-      "purpose": "Processors must detect source contexts that include @source.",
+      "name": "@import overflow",
+      "purpose": "Processors must detect source contexts that include @import.",
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/so03-in.jsonld",
       "expect": "invalid context member"
     }, {
       "@id": "#tso05",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "@propagate: true on type-scoped context with @source",
-      "purpose": "type-scoped context with @propagate: true survive node-objects (with @source)",
+      "name": "@propagate: true on type-scoped context with @import",
+      "purpose": "type-scoped context with @propagate: true survive node-objects (with @import)",
       "input": "expand/so05-in.jsonld",
       "expect": "expand/so05-out.jsonld",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tso06",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "@propagate: false on property-scoped context with @source",
-      "purpose": "property-scoped context with @propagate: false do not survive node-objects (with @source)",
+      "name": "@propagate: false on property-scoped context with @import",
+      "purpose": "property-scoped context with @propagate: false do not survive node-objects (with @import)",
       "input": "expand/so06-in.jsonld",
       "expect": "expand/so06-out.jsonld",
       "option": {"specVersion": "json-ld-1.1"}

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -1065,6 +1065,22 @@
       "expect": "expand/c028-out.jsonld",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tc029",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "@propagate is invalid in 1.0",
+      "purpose": "@propagate is invalid in 1.0",
+      "input": "expand/c029-in.jsonld",
+      "expect": "invalid context member",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tc029",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "@propagate must be boolean valued",
+      "purpose": "@propagate must be boolean valued",
+      "input": "expand/c030-in.jsonld",
+      "expect": "invalid @propagate value",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#te001",
       "@type": [ "jld:NegativeEvaluationTest", "jld:ExpandTest" ],
       "name": "Keywords cannot be aliased to other keywords",
@@ -2379,6 +2395,54 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr29-in.jsonld",
       "expect": "expand/pr29-out.jsonld"
+    }, {
+      "@id": "#tso01",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "@source is invalid in 1.0.",
+      "purpose": "@source is invalid in 1.0.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/so01-in.jsonld",
+      "expect": "invalid context member"
+    }, {
+      "@id": "#tso02",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "@source must be a string",
+      "purpose": "@source must be a string.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/so02-in.jsonld",
+      "expect": "invalid @source value"
+    }, {
+      "@id": "#tso03",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "@source overflow",
+      "purpose": "Processors must detect overflowing context loads through @source.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/so03-in.jsonld",
+      "expect": "maximum number of @context URLs exceeded"
+    }, {
+      "@id": "#tso04",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Embedded context with @source",
+      "purpose": "An embedded context may load another context using @source.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/so04-in.jsonld",
+      "expect": "expand/so04-out.jsonld"
+    }, {
+      "@id": "#tso05",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "@propagate: true on type-scoped context with @source",
+      "purpose": "type-scoped context with @propagate: true survive node-objects (with @source)",
+      "input": "expand/so05-in.jsonld",
+      "expect": "expand/so05-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tso06",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "@propagate: false on property-scoped context with @source",
+      "purpose": "property-scoped context with @propagate: false do not survive node-objects (with @source)",
+      "input": "expand/so06-in.jsonld",
+      "expect": "expand/so06-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
     }, {
       "@id": "#ttn01",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -1041,6 +1041,30 @@
       "expect": "expand/c025-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tc026",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "@propagate: true on type-scoped context",
+      "purpose": "type-scoped context with @propagate: true survive node-objects",
+      "input": "expand/c026-in.jsonld",
+      "expect": "expand/c026-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tc027",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "@propagate: false on property-scoped context",
+      "purpose": "property-scoped context with @propagate: false do not survive node-objects",
+      "input": "expand/c027-in.jsonld",
+      "expect": "expand/c027-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tc028",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "@propagate: false on embedded context",
+      "purpose": "embedded context with @propagate: false do not survive node-objects",
+      "input": "expand/c028-in.jsonld",
+      "expect": "expand/c028-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#te001",
       "@type": [ "jld:NegativeEvaluationTest", "jld:ExpandTest" ],
       "name": "Keywords cannot be aliased to other keywords",

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -2444,6 +2444,14 @@
       "expect": "expand/so06-out.jsonld",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tso07",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "Protect all terms in sourced context",
+      "purpose": "A protected context protects all term definitions.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/so07-in.jsonld",
+      "expect": "protected term redefinition"
+    }, {
       "@id": "#ttn01",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "@type: @none is illegal in 1.0.",

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -2415,18 +2415,10 @@
       "@id": "#tso03",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "@source overflow",
-      "purpose": "Processors must detect overflowing context loads through @source.",
+      "purpose": "Processors must detect source contexts that include @source.",
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/so03-in.jsonld",
-      "expect": "maximum number of @context URLs exceeded"
-    }, {
-      "@id": "#tso04",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "Embedded context with @source",
-      "purpose": "An embedded context may load another context using @source.",
-      "option": {"specVersion": "json-ld-1.1"},
-      "input": "expand/so04-in.jsonld",
-      "expect": "expand/so04-out.jsonld"
+      "expect": "invalid context member"
     }, {
       "@id": "#tso05",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -2451,6 +2443,38 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/so07-in.jsonld",
       "expect": "protected term redefinition"
+    }, {
+      "@id": "#tso08",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Override term defined in sourced context",
+      "purpose": "The containing context is merged into the source context.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/so08-in.jsonld",
+      "expect": "expand/so08-out.jsonld"
+    }, {
+      "@id": "#tso09",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Override @vocab defined in sourced context",
+      "purpose": "The containing context is merged into the source context.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/so09-in.jsonld",
+      "expect": "expand/so09-out.jsonld"
+    }, {
+      "@id": "#tso10",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "Protect terms in sourced context",
+      "purpose": "The containing context is merged into the source context.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/so10-in.jsonld",
+      "expect": "protected term redefinition"
+    }, {
+      "@id": "#tso11",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Override protected terms in sourced context",
+      "purpose": "The containing context is merged into the source context.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/so11-in.jsonld",
+      "expect": "expand/so11-out.jsonld"
     }, {
       "@id": "#ttn01",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],

--- a/tests/expand/c024-in.jsonld
+++ b/tests/expand/c024-in.jsonld
@@ -11,7 +11,6 @@
       "@id": "ex:Inner",
       "@context": {
         "@version": 1.1,
-        "val": "@value",
         "foo": {
           "@id": "ex:foo",
           "@container": "@set",

--- a/tests/expand/c026-in.jsonld
+++ b/tests/expand/c026-in.jsonld
@@ -1,0 +1,14 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example/",
+    "Foo": {
+      "@context": {
+        "@propagate": true,
+        "baz": {"@type": "@vocab"}
+      }
+    }
+  },
+  "@type": "Foo",
+  "bar": {"baz": "buzz"}
+}

--- a/tests/expand/c026-out.jsonld
+++ b/tests/expand/c026-out.jsonld
@@ -1,0 +1,8 @@
+[
+  {
+    "@type": ["http://example/Foo"],
+    "http://example/bar": [{
+      "http://example/baz": [{"@id": "http://example/buzz"}]
+    }]
+  }
+]

--- a/tests/expand/c027-in.jsonld
+++ b/tests/expand/c027-in.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example/",
+    "bar": {
+      "@context": {
+        "@propagate": false,
+        "baz": {"@type": "@id"}
+      }
+    }
+  },
+  "bar": {"baz": {"baz": "buzz"}}
+}

--- a/tests/expand/c027-out.jsonld
+++ b/tests/expand/c027-out.jsonld
@@ -1,0 +1,7 @@
+[{
+ "http://example/bar": [{
+   "http://example/baz": [{
+     "http://example/baz": [{"@value": "buzz"}]
+   }]
+ }]
+}]

--- a/tests/expand/c028-in.jsonld
+++ b/tests/expand/c028-in.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example/"
+  },
+  "bar": {
+    "@context": {
+      "@propagate": false,
+      "baz": {"@type": "@vocab"}
+    },
+    "baz": {
+      "baz": "buzz"
+    }
+  }
+}

--- a/tests/expand/c028-out.jsonld
+++ b/tests/expand/c028-out.jsonld
@@ -1,0 +1,7 @@
+[{
+ "http://example/bar": [{
+   "http://example/baz": [{
+     "http://example/baz": [{"@value": "buzz"}]
+   }]
+ }]
+}]

--- a/tests/expand/c029-in.jsonld
+++ b/tests/expand/c029-in.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "@propagate": true
+  }
+}

--- a/tests/expand/c030-in.jsonld
+++ b/tests/expand/c030-in.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@propagate": "not boolean"
+  }
+}

--- a/tests/expand/so01-in.jsonld
+++ b/tests/expand/so01-in.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "@source": "so01-in.jsonld"
+  }
+}

--- a/tests/expand/so01-in.jsonld
+++ b/tests/expand/so01-in.jsonld
@@ -1,5 +1,5 @@
 {
   "@context": {
-    "@source": "so01-in.jsonld"
+    "@import": "so01-in.jsonld"
   }
 }

--- a/tests/expand/so02-in.jsonld
+++ b/tests/expand/so02-in.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@source": {}
+  }
+}

--- a/tests/expand/so02-in.jsonld
+++ b/tests/expand/so02-in.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
     "@version": 1.1,
-    "@source": {}
+    "@import": {}
   }
 }

--- a/tests/expand/so03-in.jsonld
+++ b/tests/expand/so03-in.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@source": "so03-in.jsonld"
+  }
+}

--- a/tests/expand/so03-in.jsonld
+++ b/tests/expand/so03-in.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
     "@version": 1.1,
-    "@source": "so03-in.jsonld"
+    "@import": "so03-in.jsonld"
   }
 }

--- a/tests/expand/so04-context.jsonld
+++ b/tests/expand/so04-context.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "property": "http://example.org/property"
+  }
+}

--- a/tests/expand/so04-context.jsonld
+++ b/tests/expand/so04-context.jsonld
@@ -1,5 +1,0 @@
-{
-  "@context": {
-    "property": "http://example.org/property"
-  }
-}

--- a/tests/expand/so04-in.jsonld
+++ b/tests/expand/so04-in.jsonld
@@ -1,7 +1,0 @@
-{
-  "@context": {
-    "@version": 1.1,
-    "@source": "so04-context.jsonld"
-  },
-  "property": "value"
-}

--- a/tests/expand/so04-in.jsonld
+++ b/tests/expand/so04-in.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@source": "so04-context.jsonld"
+  },
+  "property": "value"
+}

--- a/tests/expand/so04-out.jsonld
+++ b/tests/expand/so04-out.jsonld
@@ -1,0 +1,3 @@
+[{
+  "http://example.org/property": [{"@value": "value"}]
+}]

--- a/tests/expand/so04-out.jsonld
+++ b/tests/expand/so04-out.jsonld
@@ -1,3 +1,0 @@
-[{
-  "http://example.org/property": [{"@value": "value"}]
-}]

--- a/tests/expand/so05-context.jsonld
+++ b/tests/expand/so05-context.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "baz": {"@id": "http://example.org/baz", "@type": "@vocab"}
+  }
+}

--- a/tests/expand/so05-in.jsonld
+++ b/tests/expand/so05-in.jsonld
@@ -1,0 +1,14 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example/",
+    "Foo": {
+      "@context": {
+        "@source": "so05-context.jsonld",
+        "@propagate": true
+      }
+    }
+  },
+  "@type": "Foo",
+  "bar": {"baz": "buzz"}
+}

--- a/tests/expand/so05-in.jsonld
+++ b/tests/expand/so05-in.jsonld
@@ -4,7 +4,7 @@
     "@vocab": "http://example/",
     "Foo": {
       "@context": {
-        "@source": "so05-context.jsonld",
+        "@import": "so05-context.jsonld",
         "@propagate": true
       }
     }

--- a/tests/expand/so05-out.jsonld
+++ b/tests/expand/so05-out.jsonld
@@ -1,0 +1,8 @@
+[
+  {
+    "@type": ["http://example/Foo"],
+    "http://example/bar": [{
+      "http://example.org/baz": [{"@id": "http://example/buzz"}]
+    }]
+  }
+]

--- a/tests/expand/so06-context.jsonld
+++ b/tests/expand/so06-context.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "baz": {"@id": "http://example.com/baz", "@type": "@id"}
+  }
+}

--- a/tests/expand/so06-in.jsonld
+++ b/tests/expand/so06-in.jsonld
@@ -4,7 +4,7 @@
     "@vocab": "http://example/",
     "bar": {
       "@context": {
-        "@source": "so06-context.jsonld",
+        "@import": "so06-context.jsonld",
         "@propagate": false
       }
     }

--- a/tests/expand/so06-in.jsonld
+++ b/tests/expand/so06-in.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example/",
+    "bar": {
+      "@context": {
+        "@source": "so06-context.jsonld",
+        "@propagate": false
+      }
+    }
+  },
+  "bar": {"baz": {"baz": "buzz"}}
+}

--- a/tests/expand/so06-out.jsonld
+++ b/tests/expand/so06-out.jsonld
@@ -1,0 +1,7 @@
+[{
+ "http://example/bar": [{
+   "http://example.com/baz": [{
+     "http://example/baz": [{"@value": "buzz"}]
+   }]
+ }]
+}]

--- a/tests/expand/so07-context.jsonld
+++ b/tests/expand/so07-context.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "protected1": {
+      "@id": "http://example.com/protected1"
+    },
+    "protected2": {
+      "@id": "http://example.com/protected2"
+    }
+  }
+}

--- a/tests/expand/so07-in.jsonld
+++ b/tests/expand/so07-in.jsonld
@@ -3,7 +3,7 @@
     "@vocab": "http://example.com/",
     "@version": 1.1,
     "@protected": true,
-    "@source": "so07-context.jsonld"
+    "@import": "so07-context.jsonld"
   },
   "protected1": {
     "@context": {

--- a/tests/expand/so07-in.jsonld
+++ b/tests/expand/so07-in.jsonld
@@ -1,0 +1,16 @@
+{
+  "@context": {
+    "@vocab": "http://example.com/",
+    "@version": 1.1,
+    "@protected": true,
+    "@source": "so07-context.jsonld"
+  },
+  "protected1": {
+    "@context": {
+      "protected1": "http://example.com/something-else",
+      "protected2": "http://example.com/something-else"
+    },
+    "protected1": "error / property http://example.com/protected1",
+    "protected2": "error / property http://example.com/protected2"
+  }
+}

--- a/tests/expand/so08-context.jsonld
+++ b/tests/expand/so08-context.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "term": "http://example.org/sourced"
+  }
+}

--- a/tests/expand/so08-in.jsonld
+++ b/tests/expand/so08-in.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@source": "so08-context.jsonld",
+    "term": "http://example.org/redefined"
+  },
+  "term": "value"
+}

--- a/tests/expand/so08-in.jsonld
+++ b/tests/expand/so08-in.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": {
     "@version": 1.1,
-    "@source": "so08-context.jsonld",
+    "@import": "so08-context.jsonld",
     "term": "http://example.org/redefined"
   },
   "term": "value"

--- a/tests/expand/so08-out.jsonld
+++ b/tests/expand/so08-out.jsonld
@@ -1,0 +1,3 @@
+[{
+  "http://example.org/redefined": [{"@value": "value"}]
+}]

--- a/tests/expand/so09-context.jsonld
+++ b/tests/expand/so09-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/source/",
+    "term": {"@id": "term"}
+  }
+}

--- a/tests/expand/so09-in.jsonld
+++ b/tests/expand/so09-in.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": {
     "@version": 1.1,
-    "@source": "so09-context.jsonld",
+    "@import": "so09-context.jsonld",
     "@vocab": "http://example.org/redefined/"
   },
   "term": "value"

--- a/tests/expand/so09-in.jsonld
+++ b/tests/expand/so09-in.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@source": "so09-context.jsonld",
+    "@vocab": "http://example.org/redefined/"
+  },
+  "term": "value"
+}

--- a/tests/expand/so09-out.jsonld
+++ b/tests/expand/so09-out.jsonld
@@ -1,0 +1,3 @@
+[{
+  "http://example.org/redefined/term": [{"@value": "value"}]
+}]

--- a/tests/expand/so10-context.jsonld
+++ b/tests/expand/so10-context.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "term": "http://example.org/protected"
+  }
+}

--- a/tests/expand/so10-in.jsonld
+++ b/tests/expand/so10-in.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": [{
+    "@version": 1.1,
+    "@protected": true,
+    "@source": "so10-context.jsonld"
+  }, {
+    "term": "http://example.org/unprotected"
+  }],
+  "term": "value"
+}
+  

--- a/tests/expand/so10-in.jsonld
+++ b/tests/expand/so10-in.jsonld
@@ -2,7 +2,7 @@
   "@context": [{
     "@version": 1.1,
     "@protected": true,
-    "@source": "so10-context.jsonld"
+    "@import": "so10-context.jsonld"
   }, {
     "term": "http://example.org/unprotected"
   }],

--- a/tests/expand/so11-context.jsonld
+++ b/tests/expand/so11-context.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "term": "http://example.org/sourced"
+  }
+}

--- a/tests/expand/so11-in.jsonld
+++ b/tests/expand/so11-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "@source": "so08-context.jsonld",
+    "term": "http://example.org/redefined"
+  },
+  "term": "value"
+}

--- a/tests/expand/so11-in.jsonld
+++ b/tests/expand/so11-in.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "@version": 1.1,
     "@protected": true,
-    "@source": "so08-context.jsonld",
+    "@import": "so08-context.jsonld",
     "term": "http://example.org/redefined"
   },
   "term": "value"

--- a/tests/expand/so11-out.jsonld
+++ b/tests/expand/so11-out.jsonld
@@ -1,0 +1,3 @@
+[{
+  "http://example.org/redefined": [{"@value": "value"}]
+}]


### PR DESCRIPTION
* Text and tests for `@propagate` and `@source`

For w3c/json-ld-syntax#174.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/112.html" title="Last updated on Jul 12, 2019, 9:10 PM UTC (08c9296)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/112/43c75e6...08c9296.html" title="Last updated on Jul 12, 2019, 9:10 PM UTC (08c9296)">Diff</a>