### PR TITLE
Update terms to use INFRA in place of WebIDL where reasonable.

### DIFF
--- a/common/algorithm-terms.html
+++ b/common/algorithm-terms.html
@@ -13,7 +13,7 @@
     A flag specifying that for <a>properties</a> to be included in the output,
     they MUST be explicitly declared in the matching <a>frame</a>.</dd>
   <dt><dfn>framing state</dfn></dt><dd>
-    A <a>dictionary</a> containing values for the
+    A <a>map</a> containing values for the
     <a>object embed flag</a>, the
     <a>require all flag</a>, the
     <a>explicit inclusion flag</a>, and the
@@ -35,15 +35,15 @@
     but present in the <a>input frame</a>,
     should be omitted from the output.</dd>
   <dt class="changed"><dfn>omit graph flag</dfn></dt><dd class="changed">
-    A flag that determines if framing output is always contained within a <code>@graph</code> member,
+    A flag that determines if framing output is always contained within a <code>@graph</code> <a>entry</a>,
     or only if required to represent multiple <a>node objects</a>.</dd>
   <dt><dfn>processor state</dfn></dt><dd>
     The <a>processor state</a>,
     which includes the <a>active context</a>, <a>active subject</a>, and <a>active property</a>.
     The <a>processor state</a> is managed as a stack with elements from the previous <a>processor state</a>
     copied into a new <a>processor state</a> when entering a new <a>JSON object</a>.</dd>
-  <dt><dfn>promise</dfn></dt><dd>
-    A <a data-cite="ECMASCRIPT#sec-promise-objects" class="externalDFN">promise</a> is an object that represents the eventual result of a single asynchronous operation.
+  <dt><dfn data-cite="ECMASCRIPT#sec-promise-objects">promise</dfn></dt><dd>
+    A <a>promise</a> is an object that represents the eventual result of a single asynchronous operation.
     Promises are defined in [[ECMASCRIPT]].</dd>
   <dt><dfn>require all flag</dfn></dt><dd>
     A flag specifying that all properties present in the <a>input frame</a>

--- a/common/terms.html
+++ b/common/terms.html
@@ -175,7 +175,7 @@
     A <a>JSON-LD document</a> is a serialization of
     a collection of <a>graphs</a>
     and comprises exactly one <a>default graph</a> and zero or more <a>named graphs</a>.</dd>
-  <dt><dfn>JSON-LD value</dfn></dt><dd>
+  <dt><dfn class="preserve">JSON-LD value</dfn></dt><dd>
     A <a>JSON-LD value</a> is a <a>string</a>,
     a <a>number</a>,
     <code>true</code> or <code>false</code>,
@@ -324,14 +324,14 @@
     JSON literals represent values which are valid JSON [[RFC8259]].
     See <dfn data-cite="JSON-LD11#dfn-json-datatype" class="preserve">JSON datatype</dfn> in [[JSON-LD11]].
   </dd>
-  <dt><dfn>typed value</dfn></dt><dd>
+  <dt><dfn class="preserve">typed value</dfn></dt><dd>
     A <a>typed value</a> consists of a value,
     which is a <a>string</a>,
     and a type,
     which is an <a>IRI</a>.</dd>
   <dt><dfn>value object</dfn></dt><dd>
     A <a>value object</a> is a <a>map</a> that has an <code>@value</code> <a>entry</a>.</dd>
-  <dt><dfn>vocabulary mapping</dfn></dt><dd>
+  <dt><dfn class="preserve">vocabulary mapping</dfn></dt><dd>
     The vocabulary mapping is set in the <a>context</a> using the <code>@vocab</code> key
     whose value MUST be an <a>IRI</a> or <code>null</code>.</dd>
 </dl>

--- a/common/terms.html
+++ b/common/terms.html
@@ -14,16 +14,17 @@
   <dt><dfn data-cite="RFC8259#section-4" class="preserve">JSON object</dfn></dt><dd>
     In the JSON serialization,
     an <a>object</a> structure
-    is represented as a pair of curly brackets surrounding zero or more <a>entries</a>
-    composed of name-value pairs.
+    is represented as a pair of curly brackets surrounding zero or more name/value pairs (or members).
     A name is a <a>string</a>.
     A single colon comes after each name,
     separating the name from the value.
     A single comma separates a value from a following name.
     In JSON-LD the names in an object MUST be unique.
-    In the <a>internal representation</a> a <a>JSON object</a> is described as a
-    <dfn data-cite="INFRA#ordered-map" class="preserve">map</dfn> (see [[INFRA]]),
-    composed of <dfn data-cite="INFRA#map-entry" data-lt="map entry|entry" data-ld-noDefault class="preserve">entries</dfn> with key-value pairs.</dd>
+    <p>In the <a>internal representation</a> a <a>JSON object</a> is described as a
+      <dfn data-cite="INFRA#ordered-map" class="preserve">map</dfn> (see [[INFRA]]),
+      composed of <dfn data-cite="INFRA#map-entry" data-lt="map entry|entry" data-ld-noDefault class="preserve">entries</dfn> with key/value pairs.</p>
+    <p>In the <a data-cite="JSON-LD11-API#the-application-programming-interface">Application Programming Interface</a>,
+      a <a>map</a> is described using a [[WEBIDL]] <a data-cite="WEBIDL#dfn-dictionary">dictionary</a>.</p></dd>
   <dt class="changed"><dfn data-lt="internal representation">JSON-LD internal representation</dfn></dt><dd class="changed">
     The JSON-LD internal representation
     is the result of transforming a JSON syntactic structure
@@ -266,12 +267,12 @@
     other processing modes can be accessed.
     This specification defines extensions for the <code>json-ld-1.1</code> <a>processing mode</a>.</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-property" class="preserve">property</dfn></dt><dd>
-    The name of a direct-arc in a <a>linked data graph</a>.
+    The name of a directed-arc in a <a>linked data graph</a>.
     Every <a>property</a> is directional
     and is labeled with an <a>IRI</a> or a <a>blank node identifier</a>.
     Whenever possible, a <a>property</a> should be labeled with an <a>IRI</a>.
     <div class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
-      and may be removed in a future version of JSON-LD.</div></dd>
+      and may be removed in a future version of JSON-LD.</div>
     See <dfn data-cite="RDF11-CONCEPTS#dfn-predicate" data-lt="predicate" class="preserve">RDF predicate</dfn> in [[RDF11-CONCEPTS]].</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-dataset" data-lt="dataset" class="preserve">RDF dataset</dfn></dt><dd>
     A <a>dataset</a>

--- a/common/terms.html
+++ b/common/terms.html
@@ -1,88 +1,88 @@
 <dl class="termlist" data-sort>
-  <dt><dfn>array</dfn></dt><dd>
+  <dt><dfn data-cite="INFRA#list" class="preserve">array</dfn></dt><dd>
     In the JSON serialization,
-    an array structure is represented as square brackets surrounding zero or more values.
+    an <a>array</a> structure is represented as square brackets surrounding zero or more values.
     Values are separated by commas.
     In the <a>internal representation</a>,
-    an array is an <em>ordered</em> collection of zero or more values.
+    a <a data-ld="array">list</a> (also called an <a>array</a>) is an <em>ordered</em> collection of zero or more values.
     While JSON-LD uses the same array representation as JSON,
     the collection is <em>unordered</em> by default.
     While order is preserved in regular JSON arrays,
     it is not in regular JSON-LD arrays unless specifically defined
-    (see <a data-cite="JSON-LD11#sets-and-lists" class="externalDFN">Sets and Lists</a>
+    (see <a data-cite="JSON-LD11#sets-and-lists">Sets and Lists</a>
     in the JSON-LD Syntax specification [[JSON-LD11]]).</dd>
-  <dt><dfn>JSON object</dfn></dt><dd>
+  <dt><dfn data-cite="RFC8259#section-4" class="preserve">JSON object</dfn></dt><dd>
     In the JSON serialization,
-    an <a data-cite="RFC8259#section-4" class="externalDFN">object</a> structure
-    is represented as a pair of curly brackets surrounding zero or more members
+    an <a>object</a> structure
+    is represented as a pair of curly brackets surrounding zero or more <a>entries</a>
     composed of name-value pairs.
     A name is a <a>string</a>.
     A single colon comes after each name,
     separating the name from the value.
     A single comma separates a value from a following name.
     In JSON-LD the names in an object MUST be unique.
-    In the <a>internal representation</a> a <a>JSON object</a> is equivalent to a
-    <dfn data-cite="WEBIDL#dfn-dictionary" class="preserve">dictionary</dfn> (see [[WEBIDL]]),
-    composed of <dfn data-cite="WEBIDL#dfn-dictionary-member" data-lt="dictionary member|member" class="preserve">dictionary members</dfn> with key-value pairs.</dd>
+    In the <a>internal representation</a> a <a>JSON object</a> is described as a
+    <dfn data-cite="INFRA#ordered-map" class="preserve">map</dfn> (see [[INFRA]]),
+    composed of <dfn data-cite="INFRA#map-entry" data-lt="map entry|entry" data-ld-noDefault class="preserve">entries</dfn> with key-value pairs.</dd>
   <dt class="changed"><dfn data-lt="internal representation">JSON-LD internal representation</dfn></dt><dd class="changed">
     The JSON-LD internal representation
     is the result of transforming a JSON syntactic structure
     into the core data structures suitable for direct processing:
-    <a>arrays</a>, <a>dictionaries</a>, <a>strings</a>, <a>numbers</a>, <a>booleans</a>, and <a>null</a>.</dd>
-  <dt><dfn>null</dfn></dt><dd>
-    The use of the <a data-cite="RFC8259#section-3" class="externalDFN">null</a> value within JSON-LD
+    <a>arrays</a>, <a>maps</a>, <a>strings</a>, <a>numbers</a>, <a>booleans</a>, and <a>null</a>.</dd>
+  <dt><dfn data-cite="INFRA#nulls" class="preserve">null</dfn></dt><dd>
+    The use of the <a>null</a> value within JSON-LD
     is used to ignore or reset values.
-    A <a>dictionary member</a> in the <code>@context</code> where the value,
+    A <a>map entry</a> in the <code>@context</code> where the value,
     or the <code>@id</code> of the value, is <code>null</code>,
     explicitly decouples a term's association with an IRI.
-    A <a>dictionary member</a> in the body of a <a>JSON-LD document</a>
+    A <a>map entry</a> in the body of a <a>JSON-LD document</a>
     whose value is <code>null</code>
-    has the same meaning as if the <a>dictionary member</a> was not defined.
+    has the same meaning as if the <a>map entry</a> was not defined.
     If <code>@value</code>, <code>@list</code>, or <code>@set</code> is set to <code>null</code> in expanded form,
     then the entire <a>JSON object</a> is ignored.</dd>
-  <dt><dfn data-lt="number|JSON number">number</dfn></dt><dd>
-    In the JSON serialization, a <a data-cite="RFC8259#section-6" class="externalDFN">number</a>
+  <dt><dfn data-cite="ECMASCRIPT#sec-terms-and-definitions-number-value" data-lt="number|JSON number" class="preserve">number</dfn></dt><dd>
+    In the JSON serialization, a <a>number</a>
     is similar to that used in most programming languages,
     except that the octal and hexadecimal formats are not used and that leading zeros are not allowed.
     In the <a>internal representation</a>,
     a <a>number</a> is equivalent to either a <dfn data-cite="WEBIDL#idl-long" class="preserve">long</dfn>
     or <dfn data-cite="WEBIDL#idl-double" class="preserve">double</dfn>,
     depending on if the number has a non-zero fractional part (see [[WEBIDL]]).</dd>
-  <dt><dfn>scalar</dfn></dt><dd>
-    A scalar is either a JSON <a>string</a>, <a>number</a>, <a>true</a>, or <a>false</a>.</dd>
-  <dt><dfn>string</dfn></dt><dd>
-    A <a data-cite="RFC8259#section-7" class="externalDFN">string</a>
+  <dt><dfn data-cite="INFRA#primitive-data-types" class="preserve">scalar</dfn></dt><dd>
+    A scalar is either a <a>string</a>, <a>number</a>, <code>true</code>, or <code>false</code>.</dd>
+  <dt><dfn data-cite="INFRA##javascript-string" class="preserve">string</dfn></dt><dd>
+    A <a>string</a>
     is a sequence of zero or more Unicode (UTF-8) characters,
     wrapped in double quotes, using backslash escapes (if necessary).
     A character is represented as a single character string.</dd>
-  <dt><dfn>true</dfn> and <dfn>false</dfn></dt><dd>
-    <a data-cite="RFC8259#section-3" class="externalDFN">Values</a> that are used
-    to express one of two possible <dfn data-cite="WEBIDL#idl-boolean" class="preserve">boolean</dfn> states.</dd>
+  <dt><dfn data-cite="INFRA#boolean" class="preserve">boolean</dfn></dt><dd>
+    The values <code>true</code> and <code>false</code> that are used
+    to express one of two possible states.</dd>
 </dl>
 
 <p>Furthermore, the following terminology is used throughout this document:</p>
 
 <dl class="termlist" data-sort>
-  <dt><dfn>absolute IRI</dfn></dt><dd>
-    An <a data-cite="RFC3987#section-1.3" class="externalDFN">absolute IRI</a>
+  <dt><dfn data-cite="RFC3987#section-1.3" class="preserve">absolute IRI</dfn></dt><dd>
+    An <a>absolute IRI</a>
     is defined in [[RFC3987]] containing a <em>scheme</em> along with a <em>path</em>
     and optional <em>query</em> and fragment segments.</dd>
   <dt><dfn>active context</dfn></dt><dd>
     A <a>context</a> that is used to resolve <a>terms</a>
     while the processing algorithm is running.</dd>
-  <dt><dfn>base IRI</dfn></dt><dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-base-iri" class="preserve">base IRI</dfn></dt><dd>
     The <a>base IRI</a> is an <a>absolute IRI</a> established in the <a>context</a>,
     or is based on the <a>JSON-LD document</a> location.
     The <a>base IRI</a> is used to turn <a>relative IRIs</a> into <a>absolute IRIs</a>.</dd>
-  <dt><dfn>blank node</dfn></dt><dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-blank-node" class="preserve">blank node</dfn></dt><dd>
     A <a>node</a> in a <a>graph</a> that is neither an <a>IRI</a>,
     nor a <a>JSON-LD value</a>, nor a <a>list</a>.
-    A <a data-cite="RDF11-CONCEPTS#dfn-blank-node" class="externalDFN">blank node</a> does not contain
+    A <a>blank node</a> does not contain
     a de-referenceable identifier because it is either ephemeral in nature
     or does not contain information that needs to be linked to from outside of the <a>linked data graph</a>.
     A blank node is assigned an identifier starting with the prefix <code>_:</code>.</dd>
-  <dt><dfn>blank node identifier</dfn></dt><dd>
-    A <a data-cite="RDF11-CONCEPTS#dfn-blank-node-identifier" class="externalDFN">blank node identifier</a>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-blank-node-identifier" class="preserve">blank node identifier</dfn></dt><dd>
+    A <a>blank node identifier</a>
     is a string that can be used as an identifier for a <a>blank node</a> within the scope of a JSON-LD document.
     Blank node identifiers begin with <code>_:</code>.</dd>
   <dt><dfn>compact IRI</dfn></dt><dd>
@@ -92,39 +92,30 @@
   <dt><dfn>context</dfn></dt><dd>
     A set of rules for interpreting a <a>JSON-LD document</a>
     as specified in the <a data-cite="JSON-LD11#the-context">The Context</a> section of the JSON-LD Syntax specification [[JSON-LD11]].</dd>
-  <dt><dfn>datatype IRI</dfn></dt><dd>
-    A <a data-cite="RDF11-CONCEPTS#dfn-datatype-iri" class="externalDFN">datatype IRI</a>
-    as specified by [[RDF11-CONCEPTS]].</dd>
-  <dt><dfn>default graph</dfn></dt><dd>
-    The <a data-cite="RDF11-CONCEPTS#dfn-default-graph" class="externalDFN">default graph</a>
-    is the only graph in a JSON-LD document which has no <a>graph name</a>.
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-datatype-iri" class="preserve">datatype IRI</dfn></dt><dd>
+    A <a>datatype IRI</a> as specified by [[RDF11-CONCEPTS]].</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-default-graph" class="preserve">default graph</dfn></dt><dd>
+    The <a>default graph</a> is the only graph in a JSON-LD document which has no <a>graph name</a>.
     When executing an algorithm,
     the graph where data should be placed if a <a>named graph</a> is not specified.</dd>
   <dt><dfn>default language</dfn></dt><dd>
     The default language is set in the <a>context</a> using the <code>@language</code> key
     whose value MUST be a <a>string</a> representing a [[BCP47]] language code or <code>null</code>.</dd>
   <dt><dfn>default object</dfn></dt><dd>
-    A <a>default object</a> is a <a>dictionary</a> that has a <code>@default</code> key.</dd>
-  <dt><dfn>edge</dfn></dt><dd>
-    Every <a>edge</a> has a direction associated with it
-    and is labeled with an <a>IRI</a> or a <a>blank node identifier</a>.
-    Within the JSON-LD syntax these edge labels are called <a>properties</a>.
-    Whenever possible, an <a>edge</a> should be labeled with an <a>IRI</a>.
-    <div class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
-      and may be removed in a future version of JSON-LD.</div></dd>
+    A <a>default object</a> is a <a>map</a> that has a <code>@default</code> key.</dd>
   <dt><dfn>embedded context</dfn></dt><dd>
-    An embedded <a>context</a> is a <a>dictionary</a> composed of a combintation of
+    An embedded <a>context</a> is a <a>map</a> composed of a combintation of
     <a>term definitions</a>, a <a>vocabulary mapping</a>, a <a>base IRI</a> and <a>default language</a>.
     An <a>embedded context</a> may appear as part of a <a>node object</a> or <a>value object</a> using the
-    <code>@context</code> <a>member</a>.
+    <code>@context</code> <a>entry</a>.
   </dd>
   <dt><dfn>scoped context</dfn></dt><dd>
     A <a>scoped context</a> is part of an <a>expanded term definition</a> using the
-    <code>@context</code> <a>member</a>. It has the same form as an <a>embedded context</a>.
+    <code>@context</code> <a>entry</a>. It has the same form as an <a>embedded context</a>.
   </dd>
   <dt><dfn>expanded term definition</dfn></dt><dd>
     An expanded term definition is a <a>term definition</a>
-    where the value is a <a>dictionary</a>
+    where the value is a <a>map</a>
     containing one or more <a>keyword</a> keys to define the associated <a>absolute IRI</a>,
     if this is a reverse property,
     the type associated with string values, and a container mapping.</dd>
@@ -132,19 +123,19 @@
     A <a>JSON-LD document</a>,
     which describes the form for transforming another <a>JSON-LD document</a>
     using matching and embedding rules.
-    A frame document allows additional keywords and certain <a>dictionary members</a>
+    A frame document allows additional keywords and certain <a>map entries</a>
     to describe the matching and transforming process.</dd>
   <dt><dfn data-lt="json-ld processor|Processors">JSON-LD Processor</dfn></dt><dd>
     A <a>JSON-LD Processor</a> is a system which can perform the algorithms defined in [[JSON-LD11-API]].</dd>
   <dt><dfn>frame object</dfn></dt><dd>
-    A frame object is a <a>dictionary</a> element within a <a>frame</a>
+    A frame object is a <a>map</a> element within a <a>frame</a>
     which represents a specific portion of the <a>frame</a> matching either
     a <a>node object</a> or a <a>value object</a>
     in the input.</dd>
-  <dt><dfn>graph name</dfn></dt><dd>
-    The <a>IRI</a> or <a>blank node</a> identifying a <a data-cite="RDF11-CONCEPTS#dfn-graph-name" class="externalDFN">named graph</a>.</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-graph-name" class="preserve">graph name</dfn></dt><dd>
+    The <a>IRI</a> or <a>blank node</a> identifying a <a>named graph</a>.</dd>
   <dt class="changed"><dfn>id map</dfn></dt><dd class="changed">
-    An <a>id map</a> is a <a>dictionary</a> value of a <a>term</a>
+    An <a>id map</a> is a <a>map</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@id</code>.
     The values of the <a>id map</a> MUST be <a>node objects</a>,
     and its keys are interpreted as <a>IRIs</a> representing
@@ -153,23 +144,23 @@
     it's value MUST be equivalent to the referencing key in the <a>id map</a>.</dd>
   <dt class="changed"><dfn>graph object</dfn></dt><dd class="changed">
     A <a>graph object</a> represents a <a>named graph</a>
-    as the value of a <a>dictionary member</a> within a <a>node object</a>.
-    When expanded, a graph object MUST have an <code>@graph</code> <a>member</a>,
-    and MAY also have <code>@id</code>, and <code>@index</code> <a>members</a>.
+    as the value of a <a>map entry</a> within a <a>node object</a>.
+    When expanded, a graph object MUST have an <code>@graph</code> <a>entry</a>,
+    and MAY also have <code>@id</code>, and <code>@index</code> <a>entries</a>.
     A <dfn class="preserve">simple graph object</dfn>
-    is a <a>graph object</a> which does not have an <code>@id</code> <a>member</a>.
-    Note that <a>node objects</a> may have a <code>@graph</code> member,
-    but are not considered <a>graph objects</a> if they include any other <a>members</a>.
+    is a <a>graph object</a> which does not have an <code>@id</code> <a>entry</a>.
+    Note that <a>node objects</a> may have a <code>@graph</code> <a>entry</a>,
+    but are not considered <a>graph objects</a> if they include any other <a>entries</a>.
     A top-level object consisting of <code>@graph</code> is also not a <a>graph object</a>.
     Note that a <a>node object</a> may also represent a <a>named graph</a> it it includes other properties.</dd>
   <dt><dfn>index map</dfn></dt><dd>
-    An <a>index map</a> is a <a>dictionary</a> value of a <a>term</a>
+    An <a>index map</a> is a <a>map</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@index</code>,
     whose values MUST be any of the following types:
     <a>string</a>,
     <a>number</a>,
-    <a>true</a>,
-    <a>false</a>,
+    <code>true</code>,
+    <code>false</code>,
     <a>null</a>,
     <a>node object</a>,
     <a>value object</a>,
@@ -177,7 +168,7 @@
     <a>set object</a>, or
     an <a>array</a> of zero or more of the above possibilities.
   </dd>
-  <dt><dfn data-lt="IRI|Internationalized Resource Identifier"><abbr title="Internationalized Resource Identifier">IRI</abbr></dfn></dt><dd>
+  <dt><dfn data-lt="IRI|Internationalized Resource Identifier" class="preserve"><abbr title="Internationalized Resource Identifier">IRI</abbr></dfn></dt><dd>
     An <a data-cite="RFC3987#section-1.3" class="externalDFN">Internationalized Resource Identifier</a>
     as described in [[RFC3987]].</dd>
   <dt><dfn>JSON-LD document</dfn></dt><dd>
@@ -187,7 +178,7 @@
   <dt><dfn>JSON-LD value</dfn></dt><dd>
     A <a>JSON-LD value</a> is a <a>string</a>,
     a <a>number</a>,
-    <a>true</a> or <a>false</a>,
+    <code>true</code> or <code>false</code>,
     a <a>typed value</a>,
     or a <a>language-tagged string</a>.
   </dd>
@@ -196,7 +187,7 @@
     specified in the JSON-LD Syntax specification [[JSON-LD11]]
     in the section titled <a data-cite="JSON-LD11#syntax-tokens-and-keywords">Syntax Tokens and Keywords</a>.</dd>
   <dt><dfn>language map</dfn></dt><dd>
-    An <a>language map</a> is a <a>dictionary</a> value of a <a>term</a>
+    An <a>language map</a> is a <a>map</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@language</code>,
     whose keys MUST be <a>strings</a> representing [[BCP47]] language codes
     and the values MUST be any of the following types:
@@ -204,46 +195,42 @@
     <a>string</a>, or
     an <a>array</a> of zero or more of the above possibilities.
   </dd>
-  <dt><dfn>language-tagged string</dfn></dt><dd>
-    A <a data-cite="RDF11-CONCEPTS#dfn-language-tagged-string" class="externalDFN">language-tagged string</a>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-language-tagged-string" class="preserve">language-tagged string</dfn></dt><dd>
+    A <a>language-tagged string</a>
     consists of a string and a non-empty language tag
     as defined by [[BCP47]].
-    The <dfn>language tag</dfn> MUST be well-formed
+    The <dfn data-cite="RDF11-CONCEPTS#dfn-language-tag">language tag</dfn> MUST be well-formed
     according to <a data-cite="BCP47#section-2.2.9">section 2.2.9 Classes of Conformance</a> of [[BCP47]],
     and is normalized to lowercase.</dd>
-  <dt><dfn>Linked Data</dfn></dt><dd>
+  <dt><dfn data-cite="LINKED-DATA" data-no-xref="" class="preserve">Linked Data</dfn></dt><dd>
     A set of documents, each containing a representation of a <a>linked data graph</a>.</dd>
-  <dt><dfn data-lt="graph">linked data graph</dfn></dt><dd>
-    A labeled directed <a data-cite="RDF11-CONCEPTS#dfn-rdf-graph" class="externalDFN">graph</a>,
-    i.e., a set of <a>nodes</a> connected by <a>edges</a>,
-    as specified in the <a data-cite="JSON-LD11#data-model">Data Model</a> section of the JSON-LD specification [[JSON-LD11]].
-    A <a>linked data graph</a> is a generalized representation of an <dfn class="preserve" data-cite="RDF11-CONCEPTS#dfn-rdf-graph">RDF graph</dfn>
-    as defined in [[RDF11-CONCEPTS]].</dd>
-  <dt><dfn>list</dfn></dt><dd>
-    A <a>list</a> is an ordered sequence of <a>IRIs</a>, <a>blank nodes</a>, and <a>JSON-LD values</a>.
-    See <dfn data-cite="RDF-SCHEMA#ch_collectionvocab" data-lt="collection" class="preserve">RDF collection</dfn> in [[RDF-SCHEMA]].</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-graph" data-lt="graph|RDF graph" class="preserve">linked data graph</dfn></dt><dd>
+    A labeled directed <a>graph</a>,
+    i.e., a set of <a>nodes</a> connected by directed-arcs.</dd>
+  <dt><dfn data-cite="RDF-SCHEMA#ch_collectionvocab" data-lt="collection|RDF collection" class="preserve">list</dfn></dt><dd>
+    A <a>list</a> is an ordered sequence of <a>IRIs</a>, <a>blank nodes</a>, and <a>JSON-LD values</a>.</dd>
   <dt><dfn>list object</dfn></dt><dd>
-    A <a>list object</a> is a <a>dictionary</a> that has a <code>@list</code> key.
-    It may also have an <code>@index</code> key, but no other members.</dd>
-  <dt><dfn>literal</dfn></dt><dd>
+    A <a>list object</a> is a <a>map</a> that has a <code>@list</code> key.
+    It may also have an <code>@index</code> key, but no other <a>entries</a>.</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-literal" data-lt="RDF literal" class="preserve">literal</dfn></dt><dd>
     An <a>object</a> expressed as a value such as a string or number, or in expanded form as a <a>value object</a>.</dd>
   <dt><dfn>local context</dfn></dt><dd>
-    A <a>context</a> that is specified with a <a>dictionary</a>,
+    A <a>context</a> that is specified with a <a>map</a>,
     specified via the <code>@context</code> <a>keyword</a>.</dd>
-  <dt><dfn>named graph</dfn></dt><dd>
-    A <a data-cite="RDF11-CONCEPTS#dfn-named-graph" class="externalDFN">named graph</a>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-named-graph" class="preserve">named graph</dfn></dt><dd>
+    A <a>named graph</a>
     is a <a>linked data graph</a> that is identified by an <a>IRI</a> or <a>blank node</a>.</dd>
   <dt><dfn>implicitly named graph</dfn></dt><dd>
-    A <a>named graph</a> created from the value of a <a>dictionary member</a>
+    A <a>named graph</a> created from the value of a <a>map entry</a>
     having an <a>expanded term definition</a>
     where <code>@container</code> is set to  <code>@graph</code>.</dd>
   <dt><dfn>nested property</dfn></dt><dd>
     A <a>nested property</a> is a key in a <a>node object</a>
-    whose value is a <a>dictionary</a> containing <a>members</a> which are treated as if they were values of the <a>node object</a>.
+    whose value is a <a>map</a> containing <a>entries</a> which are treated as if they were values of the <a>node object</a>.
     The <a>nested property</a> itself is semantically meaningless and used only to create a sub-structure within a <a>node object</a>.
   </dd>
-  <dt><dfn>node</dfn></dt><dd>
-    Every <a data-cite="RDF11-CONCEPTS#dfn-node" class="externalDFN">node</a> is an <a>IRI</a>,
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-node" class="preserve">node</dfn></dt><dd>
+    Every <a>node</a> is an <a>IRI</a>,
     a <a>blank node</a>,
     a <a>JSON-LD value</a>,
     or a <a>list</a>.
@@ -251,19 +238,19 @@
   <dt><dfn>node object</dfn></dt><dd>
     A <a>node object</a> represents zero or more <a>properties</a> of a <a>node</a> in the <a>graph</a>
     serialized by the <a>JSON-LD document</a>.
-    A <a>dictionary</a> is a <a>node object</a>
+    A <a>map</a> is a <a>node object</a>
     if it exists outside of the JSON-LD <a>context</a> and:
     <ul>
       <li>it does not contain the <code>@value</code>, <code>@list</code>, or <code>@set</code> keywords, or</li>
-      <li>it is not the top-most <a>dictionary</a> in the JSON-LD document
-        consisting of no other <a>members</a> than <code>@graph</code> and <code>@context</code>.</li>
+      <li>it is not the top-most <a>map</a> in the JSON-LD document
+        consisting of no other <a>entries</a> than <code>@graph</code> and <code>@context</code>.</li>
     </ul>
-    The <a>members</a> of a <a>node object</a> whose keys are not keywords are also called <a>properties</a> of the <a>node object</a>.
+    The <a>entries</a> of a <a>node object</a> whose keys are not keywords are also called <a>properties</a> of the <a>node object</a>.
   </dd>
   <dt><dfn>node reference</dfn></dt><dd>
     A <a>node object</a> used to reference a node having only the <code>@id</code> key.</dd>
-  <dt><dfn>object</dfn></dt><dd>
-    An <a data-cite="RDF11-CONCEPTS#dfn-object" class="externalDFN">object</a> is a <a>node</a> in a <a>linked data graph</a>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-object" class="preserve">object</dfn></dt><dd>
+    An <a>object</a> is a <a>node</a> in a <a>linked data graph</a>
     with at least one incoming edge.
     See <dfn data-cite="RDF11-CONCEPTS#dfn-object" class="preserve">RDF object</dfn> in [[RDF11-CONCEPTS]].</dd>
   <dt><dfn>prefix</dfn></dt><dd>
@@ -274,30 +261,27 @@
   <dt><dfn>processing mode</dfn></dt><dd>
     The processing mode defines how a JSON-LD document is processed.
     By default, all documents are assumed to be conformant with <a data-cite="JSON-LD" data-no-xref="">JSON-LD 1.0</a> [[JSON-LD]].
-    By defining a different version using the <code>@version</code> <a>member</a> in a <a>context</a>,
+    By defining a different version using the <code>@version</code> <a>entry</a> in a <a>context</a>,
     or via explicit API option,
     other processing modes can be accessed.
     This specification defines extensions for the <code>json-ld-1.1</code> <a>processing mode</a>.</dd>
-  <dt><dfn>property</dfn></dt><dd>
-    The <a>IRI</a> label of an edge in a <a>linked data graph</a>.
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-property" class="preserve">property</dfn></dt><dd>
+    The name of a direct-arc in a <a>linked data graph</a>.
+    Every <a>property</a> is directional
+    and is labeled with an <a>IRI</a> or a <a>blank node identifier</a>.
+    Whenever possible, a <a>property</a> should be labeled with an <a>IRI</a>.
+    <div class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
+      and may be removed in a future version of JSON-LD.</div></dd>
     See <dfn data-cite="RDF11-CONCEPTS#dfn-predicate" data-lt="predicate" class="preserve">RDF predicate</dfn> in [[RDF11-CONCEPTS]].</dd>
-  <dt><dfn>quad</dfn></dt><dd>
-    A piece of information that contains four items;
-    a <a>subject</a>,
-    a <a>property</a>,
-    an <a>object</a>,
-    and a <a>graph name</a>.</dd>
-  <dt><dfn data-lt="dataset">RDF dataset</dfn></dt><dd>
-    A <a data-cite="RDF11-CONCEPTS#dfn-rdf-dataset" class="externalDFN">dataset</a>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-dataset" data-lt="dataset" class="preserve">RDF dataset</dfn></dt><dd>
+    A <a>dataset</a>
     as specified by [[RDF11-CONCEPTS]]
     representing a collection of <a data-cite="RDF11-CONCEPTS#dfn-rdf-graph">RDF graphs</a>.</dd>
-  <dt><dfn data-lt="resource">RDF resource</dfn></dt><dd>
-    A <a data-cite="RDF11-CONCEPTS#dfn-resource" class="externalDFN">resource</a>
-    as specified by [[RDF11-CONCEPTS]].</dd>
-  <dt><dfn data-lt="triple">RDF triple</dfn></dt><dd>
-    A <a data-cite="RDF11-CONCEPTS#dfn-rdf-triple" class="externalDFN">triple</a>
-    as specified by [[RDF11-CONCEPTS]].</dd>
-  <dt><dfn>relative IRI</dfn></dt><dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-resource" data-lt="resource" class="preserve">RDF resource</dfn></dt><dd>
+    A <a >resource</a> as specified by [[RDF11-CONCEPTS]].</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-triple" data-lt="triple" class="preserve">RDF triple</dfn></dt><dd>
+    A <a>triple</a> as specified by [[RDF11-CONCEPTS]].</dd>
+  <dt><dfn data-cite="RFC3987#section-6.5" class="preserve">relative IRI</dfn></dt><dd>
     A relative IRI is an <a>IRI</a> that is relative to some other <a>absolute IRI</a>,
     typically the <a>base IRI</a> of the document.
     Note that <a>properties</a>,
@@ -306,11 +290,10 @@
     are resolved relative to the <a>vocabulary mapping</a>,
     not the <a>base IRI</a>.</dd>
   <dt><dfn>set object</dfn></dt><dd>
-    A <a>set object</a> is a <a>dictionary</a> that has an <code>@set</code> <a>member</a>.
-    It may also have an <code>@index</code> key, but no other members.</dd>
-  <dt><dfn>subject</dfn></dt><dd>
-    A <a data-cite="RDF11-CONCEPTS#dfn-subject" class="externalDFN">subject</a>
-    is a <a>node</a> in a <a>linked data graph</a>
+    A <a>set object</a> is a <a>map</a> that has an <code>@set</code> <a>entry</a>.
+    It may also have an <code>@index</code> key, but no other <a>entries</a>.</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-subject" class="preserve">subject</dfn></dt><dd>
+    A <a>subject</a> is a <a>node</a> in a <a>linked data graph</a>
     with at least one outgoing edge,
     related to an <a>object</a> node through a <a>property</a>.
     See <dfn data-cite="RDF11-CONCEPTS#dfn-subject" class="preserve">RDF subject</dfn> in [[RDF11-CONCEPTS]].</dd>
@@ -321,14 +304,14 @@
   <dt><dfn>term definition</dfn></dt><dd>
     A term definition is an entry in a <a>context</a>,
     where the key defines a <a>term</a>
-    which may be used within a <a>dictionary</a>
+    which may be used within a <a>map</a>
     as a key, type, or elsewhere that a string is interpreted as a vocabulary item.
     Its value is either a string (<dfn data-lt="simple term">simple term definition</dfn>),
     expanding to an absolute IRI,
     or an <a>expanded term definition</a>.
   </dd>
   <dt class="changed"><dfn>type map</dfn></dt><dd class="changed">
-    An <a>type map</a> is a <a>dictionary</a> value of a <a>term</a>
+    An <a>type map</a> is a <a>map</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@type</code>,
     whose keys are interpreted as <a>IRIs</a>
     representing the <code>@type</code> of the associated <a>node object</a>;
@@ -336,22 +319,18 @@
     If the value contains a <a>term</a> expanding to <code>@type</code>,
     it's values are merged with the map value when expanding.</dd>
   <dt><dfn>JSON literal</dfn></dt><dd>
-    A <a>JSON literal</a> is a <a>typed literal</a> where the associated <a>IRI</a> is <code>rdf:JSON</code>.
+    A <a>JSON literal</a> is a <a>literal</a> where the associated <a>IRI</a> is <code>rdf:JSON</code>.
     In the <a>value object</a> representation, the value of <code>@type</code> is <code>@json</code>.
     JSON literals represent values which are valid JSON [[RFC8259]].
     See <dfn data-cite="JSON-LD11#dfn-json-datatype" class="preserve">JSON datatype</dfn> in [[JSON-LD11]].
   </dd>
-  <dt><dfn>typed literal</dfn></dt><dd>
-    A <a>typed literal</a> is a <a>literal</a> with an associated <a>IRI</a>
-    which indicates the literal's datatype.
-    See <dfn data-cite="RDF11-CONCEPTS#dfn-literal" class="preserve">RDF literal</dfn> in [[RDF11-CONCEPTS]].</dd>
   <dt><dfn>typed value</dfn></dt><dd>
     A <a>typed value</a> consists of a value,
     which is a <a>string</a>,
     and a type,
     which is an <a>IRI</a>.</dd>
   <dt><dfn>value object</dfn></dt><dd>
-    A <a>value object</a> is a <a>dictionary</a> that has an <code>@value</code> <a>member</a>.</dd>
+    A <a>value object</a> is a <a>map</a> that has an <code>@value</code> <a>entry</a>.</dd>
   <dt><dfn>vocabulary mapping</dfn></dt><dd>
     The vocabulary mapping is set in the <a>context</a> using the <code>@vocab</code> key
     whose value MUST be an <a>IRI</a> or <code>null</code>.</dd>

--- a/index.html
+++ b/index.html
@@ -375,7 +375,7 @@
       is of necessity shown in serialized form as JSON. While the algorithms
       describe operations on the <a>JSON-LD internal representation</a>, when
       they as displayed as examples, the JSON serialization is used. In particular,
-      the internal representation use of <a>dictionaries</a> are represented using
+      the internal representation use of <a>maps</a> are represented using
       <a>JSON objects</a>.</p>
 
     <pre class="example nohighlight input" data-transform="updateExample"
@@ -397,10 +397,10 @@
     -->
     </pre>
     <p>In the <a>internal representation</a>, the example above would be of a
-      <a>dictionary</a> containing <code>@context</code>, <code>@id</code>, <code>name</code>, and <code>knows</code> <a>members</a>,
-      with either <a>dictionaries</a>, <a>strings</a>, or <a>arrays</a> of
-      dictionaries or strings values. In the JSON serialization, <a>JSON objects</a> are used
-      for dictionaries, while arrays and strings are serialized using a
+      <a>dictionary</a> containing <code>@context</code>, <code>@id</code>, <code>name</code>, and <code>knows</code> <a>entries</a>,
+      with either <a>maps</a>, <a>strings</a>, or <a>arrays</a> of
+      maps or strings values. In the JSON serialization, <a>JSON objects</a> are used
+      for maps, while arrays and strings are serialized using a
       convention common to many programming languages.</p>
   </section>
 
@@ -419,7 +419,7 @@
   <p class="changed">To allow these algorithms to be adapted for syntaxes
     other than JSON, the algorithms operate on the <a>JSON-LD internal representation</a>,
     which uses the generic
-    concepts of <a>arrays</a>, <a>dictionaries</a>,
+    concepts of <a>arrays</a>, <a>maps</a>,
     <a>strings</a>, <a>numbers</a>, <a>booleans</a>, and <a>null</a> to describe
     the data represented by a JSON document. Algorithms act on this
     <a>internal representation</a> with API entry points responsible for
@@ -448,7 +448,7 @@
     In order to detect this JSON-LD 1.1 requires that the <a>processing
     mode</a> be explicitly set to <code>json-ld-1.1</code>, either through the
     <a data-link-for="JsonLdOptions">processingMode</a> API option, or using the
-    <code>@version</code> <a>dictionary member</a> within a <a>context</a>.</p>
+    <code>@version</code> <a>map entry</a> within a <a>context</a>.</p>
 
   <p>There are four major types of transformation that are discussed in this
     document: expansion, compaction, flattening, and RDF serialization/deserialization.</p>
@@ -559,7 +559,7 @@
 
     <p><a>Expansion</a> has two important goals: removing any contextual
       information from the document, and ensuring all values are represented
-      in a regular form. These goals are accomplished by expanding all <a>member</a> keys
+      in a regular form. These goals are accomplished by expanding all <a>entry</a> keys
       to <a>absolute IRIs</a> and by expressing all
       values in <a>arrays</a> in
       <a>expanded form</a>. <a>Expanded form</a> is the most verbose
@@ -589,7 +589,7 @@
 
     <p class="changed">The example above is the JSON-LD serialization of the output of the
       <a href="#expansion-algorithm">expansion algorithm</a>,
-      where the algorithm's use of <a>dictionaries</a> are replaced with <a>JSON objects</a>.</p>
+      where the algorithm's use of <a>maps</a> are replaced with <a>JSON objects</a>.</p>
 
     <p>Note that in the output above all <a>context</a> definitions have
       been removed, all <a>terms</a> and
@@ -700,7 +700,7 @@
 
     <p class="changed">The example above is the JSON-LD serialization of the output of the
       <a href="#compaction-algorithm">compaction algorithm</a>,
-      where the algorithm's use of <a>dictionaries</a> are replaced with <a>JSON objects</a>.</p>
+      where the algorithm's use of <a>maps</a> are replaced with <a>JSON objects</a>.</p>
 
     <p>Note that all <a>IRIs</a> have been compacted to
       <a>terms</a> as specified in the <a>context</a>,
@@ -719,7 +719,7 @@
       <dfn data-lt="flattened">flattening</dfn> goes a step further to ensure that the shape of the data
       is deterministic. In expanded documents, the <a>properties</a> of a single
       <a>node</a> may be spread across a number of different
-      <a class="changed">dictionaries</a>. By flattening a
+      <a class="changed">maps</a>. By flattening a
       document, all <a>properties</a> of a <a>node</a> are collected in a single
       <a class="changed">dictionary</a> and all <a>blank nodes</a>
       are labeled with a <a>blank node identifier</a>. This may drastically
@@ -782,7 +782,7 @@
 
     <p class="changed">The example above is the JSON-LD serialization of the output of the
       <a href="#flattening-algorithm">flattening algorithm</a>,
-      where the algorithm's use of <a>dictionaries</a> are replaced with <a>JSON objects</a>.</p>
+      where the algorithm's use of <a>maps</a> are replaced with <a>JSON objects</a>.</p>
 
     <p>Note how in the output above all <a>properties</a> of a <a>node</a> are collected in a
       single <a class="changed">dictionary</a> and how the <a>blank node</a> representing
@@ -831,7 +831,7 @@
       is always a <a class="changed">dictionary</a>,
       <span class="changed">(represented as a <a>JSON object</a> when serialized)</span>,
       which contains an <code>@graph</code>
-      <a>member</a> that represents the <a>default graph</a>.</p>
+      <a>entry</a> that represents the <a>default graph</a>.</p>
   </section> <!-- end of Flattening -->
 
   <section class="informative">
@@ -877,7 +877,7 @@
 
     <p class="changed">The example above is the JSON-LD serialization of the output of the
       <a href="#serialize-rdf-as-json-ld-algorithm">Serialize RDF as JSON-LD Algorithm</a>,
-      where the algorithm's use of <a>dictionaries</a> are replaced with <a>JSON objects</a>.</p>
+      where the algorithm's use of <a>maps</a> are replaced with <a>JSON objects</a>.</p>
 
     <p>Note that the output above could easily be compacted using the technique outlined
       in the previous section. It is also possible to deserialize the JSON-LD document back
@@ -1044,19 +1044,19 @@
 
       <p class="changed">Unless specified using
         <a data-link-for="JsonLdOptions">processingMode</a> API option,
-        the <a>processing mode</a> is set using the <code>@version</code> <a>member</a>
+        the <a>processing mode</a> is set using the <code>@version</code> <a>entry</a>
         in a local <a>context</a> and
         affects the behavior of algorithms including <a>expansion</a> and <a>compaction</a>.</p>
 
       <p>If <a>context</a> is a <a>string</a>, it represents a reference to
         a remote context. We dereference the remote context and replace <a>context</a>
-        with the value of the <code>@context</code> <a>member</a> of the top-level object in the
+        with the value of the <code>@context</code> <a>entry</a> of the top-level object in the
         retrieved JSON-LD document.
         <span class="changed">If the result is an HTML document,
           we attempt to extract JSON-LD from the first <a data-cite="HTML/scripting.html#the-script-element">script element</a>
           of type <code>application/ld+json;profile=http://www.w3.org/ns/json-ld#context</code>
           or <code>application/ld+json</code>, if no context profile exists.</span>
-        If there's no such <a>member</a>, an
+        If there's no such <a>entry</a>, an
         <a data-link-for="JsonLdErrorCode">invalid remote context</a>
         has been detected. Otherwise, we process <a>context</a> by recursively using
         this algorithm ensuring that there is no cyclical reference.</p>
@@ -1065,11 +1065,11 @@
         <a>base IRI</a>, the <a>vocabulary mapping</a>, <a>processing mode</a>, and the
         <a>default language</a> by processing three specific keywords:
         <code>@base</code>, <code>@vocab</code>, <code>@version</code>, and <code>@language</code>.
-        These are handled before any other <a>members</a> in the <a>local context</a> because
-        they affect how the other <a>members</a> are processed. Please note that <code>@base</code> is
+        These are handled before any other <a>entries</a> in the <a>local context</a> because
+        they affect how the other <a>entries</a> are processed. Please note that <code>@base</code> is
         ignored when processing remote contexts.</p>
 
-      <p>Then, for every other <a>member</a> in <a>local context</a>, we update
+      <p>Then, for every other <a>entry</a> in <a>local context</a>, we update
         the <a>term definition</a> in <var>result</var>. Since
         <a>term definitions</a> in a <a>local context</a>
         may themselves contain <a>terms</a> or
@@ -1160,10 +1160,10 @@
                   <span class="changed">or cannot be transformed into the <a>internal representation</a></span>,
                   a <a data-link-for="JsonLdErrorCode">loading remote context failed</a>
                   error has been detected and processing is aborted. If the dereferenced document has no
-                  top-level <a class="changed">dictionary</a> with an <code>@context</code> <a>member</a>, an
+                  top-level <a class="changed">dictionary</a> with an <code>@context</code> <a>entry</a>, an
                   <a data-link-for="JsonLdErrorCode">invalid remote context</a>
                   has been detected and processing is aborted; otherwise,
-                  set <var>context</var> to the value of that <a>member</a>.</li>
+                  set <var>context</var> to the value of that <a>entry</a>.</li>
                 <li>Set <var>result</var> to the result of recursively calling this algorithm,
                   passing <var>result</var> for <var>active context</var>,
                   <var>context</var> for <var>local context</var>, and <span class="changed">a copy of</span> <var>remote contexts</var>.</li>
@@ -1173,11 +1173,11 @@
             <li>If <var>context</var> is not a <a class="changed">dictionary</a>, an
               <a data-link-for="JsonLdErrorCode">invalid local context</a>
               error has been detected and processing is aborted.</li>
-            <li>If <var>context</var> has an <code>@base</code> <a>member</a> and <var>remote contexts</var> is empty, i.e., the currently
+            <li>If <var>context</var> has an <code>@base</code> <a>entry</a> and <var>remote contexts</var> is empty, i.e., the currently
               being processed context is not a remote context:
               <ol>
                 <li>Initialize <var>value</var> to the value associated with the
-                  <code>@base</code> <a>member</a>.</li>
+                  <code>@base</code> <a>entry</a>.</li>
                 <li>If <var>value</var> is <code>null</code>, remove the
                   <a>base IRI</a> of <var>result</var>.</li>
                 <li>Otherwise, if <var>value</var> is an <a>absolute IRI</a>,
@@ -1192,7 +1192,7 @@
                   error has been detected and processing is aborted.</li>
               </ol>
             </li>
-            <li class="changed">If <var>context</var> has an <code>@version</code> <a>member</a>:
+            <li class="changed">If <var>context</var> has an <code>@version</code> <a>entry</a>:
               <ol>
                 <li>If the associated value is not <code>1.1</code>,
                   an <a data-link-for="JsonLdErrorCode">invalid @version value</a>
@@ -1205,10 +1205,10 @@
                   to <code>json-ld-1.1</code>, if not already set.</li>
               </ol>
             </li>
-            <li>If <var>context</var> has an <code>@vocab</code> <a>member</a>:
+            <li>If <var>context</var> has an <code>@vocab</code> <a>entry</a>:
               <ol>
                 <li>Initialize <var>value</var> to the value associated with the
-                  <code>@vocab</code> <a>member</a>.</li>
+                  <code>@vocab</code> <a>entry</a>.</li>
                 <li>If <var>value</var> is <a>null</a>, remove
                   any <a>vocabulary mapping</a> from <var>result</var>.</li>
                 <li>Otherwise, if <var>value</var> is
@@ -1229,10 +1229,10 @@
                     and may be removed in a future version of JSON-LD.</div></li>
               </ol>
             </li>
-            <li>If <var>context</var> has an <code>@language</code> <a>member</a>:
+            <li>If <var>context</var> has an <code>@language</code> <a>entry</a>:
               <ol>
                 <li>Initialize <var>value</var> to the value associated with the
-                  <code>@language</code> <a>member</a>.</li>
+                  <code>@language</code> <a>entry</a>.</li>
                 <li>If <var>value</var> is <code>null</code>, remove
                   any <a>default language</a> from <var>result</var>.</li>
                 <li>Otherwise, if <var>value</var> is <a>string</a>, the
@@ -1253,7 +1253,7 @@
               <var>context</var> for <var>local context</var>, <var>key</var>,
               <var>defined</var>,
               <span class="changed">the value of the <code>@protected</code>
-                member from <var>context</var>, if any, for <var>protected</var></span>,
+                entry from <var>context</var>, if any, for <var>protected</var></span>,
                 <var>from property</var>, and <var>from type</var>.</li>
           </ol>
         </li>
@@ -1279,7 +1279,7 @@
         <a>compact IRI</a>, it may omit an <a>IRI mapping</a> by
         depending on its <a>prefix</a> having its own
         <a>term definition</a>. If the <a>prefix</a> is
-        a <a>member</a> in the <a>local context</a>, then its <a>term definition</a>
+        an <a>entry</a> in the <a>local context</a>, then its <a>term definition</a>
         must first be created, through recursion, before continuing. Because a
         <a>term definition</a> can depend on other
         <a>term definitions</a>, a mechanism must
@@ -1310,21 +1310,21 @@
           and <var>from type</var>, defaulting to <code>false</code>.</span>.
         </p>
       <ol>
-        <li>If <var>defined</var> contains the <a>member</a> <var>term</var> and the associated
+        <li>If <var>defined</var> contains the <a>entry</a> <var>term</var> and the associated
           value is <code>true</code> (indicating that the
           <a>term definition</a> has already been created), return. Otherwise,
           if the value is <code>false</code>, a
           <a data-link-for="JsonLdErrorCode">cyclic IRI mapping</a>
           error has been detected and processing is aborted.</li>
-        <li>Set the value associated with <var>defined</var>'s <var>term</var> <a>member</a> to
+        <li>Set the value associated with <var>defined</var>'s <var>term</var> <a>entry</a> to
           <code>false</code>. This indicates that the <a>term definition</a>
           is now being created but is not yet complete.</li>
-        <li>Initialize <var>value</var> to a copy of the value associated with the <a>member</a>
+        <li>Initialize <var>value</var> to a copy of the value associated with the <a>entry</a>
           <var>term</var> in <var>local context</var>.</li>
         <li class="changed">If <a>processing mode</a>
           is <code>json-ld-1.1</code>
           and <var>term</var> is <code>@type</code>, <var>value</var>
-          MUST be a <a>dictionary</a> with the member <code>@container</code>
+          MUST be a <a>dictionary</a> with the entry <code>@container</code>
           and value <code>@set</code>. Any other value means that a
           <a data-link-for="JsonLdErrorCode">keyword redefinition</a> error has
           been detected and processing is aborted.</li>
@@ -1337,10 +1337,10 @@
         <li>Otherwise, remove any <var>previous definition</var> from
           <var>active context</var>.</li>
         <li class="changed">If <var>value</var> is <code>null</code>,
-          convert it to a <a class="changed">dictionary</a> consisting of a single <a>member</a> whose
+          convert it to a <a class="changed">dictionary</a> consisting of a single <a>entry</a> whose
           key is <code>@id</code> and whose value is <code>null</code>.</li>
         <li>Otherwise, if <var>value</var> is a <a>string</a>, convert it
-          to a <a class="changed">dictionary</a> consisting of a single <a>member</a> whose
+          to a <a class="changed">dictionary</a> consisting of a single <a>entry</a> whose
           key is <code>@id</code> and whose value is <var>value</var>.
           <span class="changed">Set <var>simple term</var> to <code>true</code></span>.</li>
         <li>Otherwise, <var>value</var> MUST be a <a class="changed">dictionary</a>, if not, an
@@ -1348,14 +1348,14 @@
           error has been detected and processing is aborted.
           <span class="changed">Set <var>simple term</var> to <code>false</code></span>.</li>
         <li>Create a new <a>term definition</a>, <var>definition</var>.</li>
-        <li class="changed">If the <code>@protected</code> member in <var>value</var>
-          is <code>true</code>, or there is no <code>@protected</code> member in <var>value</var>
+        <li class="changed">If the <code>@protected</code> entry in <var>value</var>
+          is <code>true</code>, or there is no <code>@protected</code> entry in <var>value</var>
           and the <var>protected</var> parameter is <code>true</code>,
           set the <a>protected</a> in <var>definition</var> to true.</li>
-        <li>If <var>value</var> contains the <a>member</a> <code>@type</code>:
+        <li>If <var>value</var> contains the <a>entry</a> <code>@type</code>:
           <ol>
             <li>Initialize <var>type</var> to the value associated with the
-              <code>@type</code> <a>member</a>, which MUST be a <a>string</a>. Otherwise, an
+              <code>@type</code> <a>entry</a>, which MUST be a <a>string</a>. Otherwise, an
               <a data-link-for="JsonLdErrorCode">invalid type mapping</a>
               error has been detected and processing is aborted.</li>
             <li>Set <var>type</var> to the result of using the
@@ -1371,26 +1371,26 @@
             <li>Set the <a>type mapping</a> for <var>definition</var> to <var>type</var>.</li>
           </ol>
         </li>
-        <li>If <var>value</var> contains the <a>member</a> <code>@reverse</code>:
+        <li>If <var>value</var> contains the <a>entry</a> <code>@reverse</code>:
           <ol>
-            <li>If <var>value</var> contains <code>@id</code> or <code>@nest</code>, <a>members</a>, an
+            <li>If <var>value</var> contains <code>@id</code> or <code>@nest</code>, <a>entries</a>, an
               <a data-link-for="JsonLdErrorCode">invalid reverse property</a>
               error has been detected and processing is aborted.</li>
-            <li>If the value associated with the <code>@reverse</code> <a>member</a>
+            <li>If the value associated with the <code>@reverse</code> <a>entry</a>
               is not a <a>string</a>, an
               <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
               error has been detected and processing is aborted.</li>
             <li>Otherwise, set the <a>IRI mapping</a> of <var>definition</var> to the
               result of using the <a href="#iri-expansion">IRI Expansion algorithm</a>,
               passing <var>active context</var>, the value associated with
-              the <code>@reverse</code> <a>member</a> for <var>value</var>, <code>true</code>
+              the <code>@reverse</code> <a>entry</a> for <var>value</var>, <code>true</code>
               for <var>vocab</var>,
               <var>local context</var>, and <var>defined</var>. If the result
               is neither an <a>absolute IRI</a> nor a <a>blank node identifier</a>,
               i.e., it contains no colon (<code>:</code>), an
               <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
               error has been detected and processing is aborted.</li>
-            <li>If <var>value</var> contains an <code>@container</code> <a>member</a>,
+            <li>If <var>value</var> contains an <code>@container</code> <a>entry</a>,
               set the <a>container mapping</a> of <var>definition</var>
               to its value; if its value is neither <code>@set</code>, nor
               <code>@index</code>, nor <code>null</code>, an
@@ -1401,24 +1401,24 @@
               to <code>true</code>.</li>
             <li>Set the <a>term definition</a> of <var>term</var> in
               <var>active context</var> to <var>definition</var> and the
-              value associated with <var>defined</var>'s <a>member</a> <var>term</var> to
+              value associated with <var>defined</var>'s <a>entry</a> <var>term</var> to
               <code>true</code> and return.</li>
           </ol>
         </li>
         <li>Set the <a>reverse property</a> flag of <var>definition</var>
           to <code>false</code>.</li>
-        <li>If <var>value</var> contains the <a>member</a> <code>@id</code> and its value
+        <li>If <var>value</var> contains the <a>entry</a> <code>@id</code> and its value
           does not equal <var>term</var>:
           <ol>
-            <li>If <var>value</var> contains the <code>@id</code> <a>member</a>
+            <li>If <var>value</var> contains the <code>@id</code> <a>entry</a>
               is <code>null</code>, the term is not used for IRI expansion, but is
               retained to be able to detect future redefinitions of this term.</li>
-            <li>Otherwise, if the value associated with the <code>@id</code> <a>member</a> is not a <a>string</a>, an
+            <li>Otherwise, if the value associated with the <code>@id</code> <a>entry</a> is not a <a>string</a>, an
               <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
               error has been detected and processing is aborted.</li>
             <li>Otherwise, set the <a>IRI mapping</a> of <var>definition</var> to the
               result of using the <a href="#iri-expansion">IRI Expansion algorithm</a>, passing
-              <var>active context</var>, the value associated with the <code>@id</code> <a>member</a> for
+              <var>active context</var>, the value associated with the <code>@id</code> <a>entry</a> for
               <var>value</var>, <code>true</code> for <var>vocab</var>,
               <var>local context</var>, and <var>defined</var>. If the resulting
               <a>IRI mapping</a> is neither a <a>keyword</a>, nor an
@@ -1445,7 +1445,7 @@
           Otherwise if the <var>term</var> contains a colon (<code>:</code>):
           <ol>
             <li>If <var>term</var> is a <a>compact IRI</a> with a
-              <a>prefix</a> that is a <a>member</a> in <var>local context</var>
+              <a>prefix</a> that is an <a>entry</a> in <var>local context</var>
               a dependency has been found. Use this algorithm recursively passing
               <var>active context</var>, <var>local context</var>, the
               <a>prefix</a> as <var>term</var>, and <var>defined</var>.</li>
@@ -1468,10 +1468,10 @@
           If it does not have a <a>vocabulary mapping</a>, an
           <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
           error been detected and processing is aborted.</li>
-        <li>If <var>value</var> contains the <a>member</a> <code>@container</code>:
+        <li>If <var>value</var> contains the <a>entry</a> <code>@container</code>:
           <ol>
             <li>Initialize <var>container</var> to the value associated with the
-              <code>@container</code> <a>member</a>, which MUST be either
+              <code>@container</code> <a>entry</a>, which MUST be either
               <code class="changed">@graph</code>,
               <code class="changed">@id</code>,
               <code>@index</code>,
@@ -1500,27 +1500,27 @@
               <var>container</var>.</li>
           </ol>
         </li>
-        <li class="changed">If <var>value</var> contains the <a>member</a> <code>@index</code>:
+        <li class="changed">If <var>value</var> contains the <a>entry</a> <code>@index</code>:
           <ol>
             <li>If <a>processing mode</a> is <code>json-ld-1.0</code> or
               <a>container mapping</a> does not include <code>@index</code>,
               an <a data-link-for="JsonLdErrorCode">invalid term definition</a>
               has been detected and processing is aborted.</li>
             <li>Initialize <var>index</var> to the value associated with the
-              <code>@index</code> <a>member</a>, which MUST a <a>string</a> expanding to an <a>absolute IRI</a>.
+              <code>@index</code> <a>entry</a>, which MUST a <a>string</a> expanding to an <a>absolute IRI</a>.
               Otherwise, an
               <a data-link-for="JsonLdErrorCode">invalid term definition</a>
               has been detected and processing is aborted.</li>
             <li>Set the <a>index mapping</a> of <var>definition</var> to <var>index</var></li>
           </ol>
         </li>
-        <li class="changed">If <var>value</var> contains the <a>member</a> <code>@context</code>:
+        <li class="changed">If <var>value</var> contains the <a>entry</a> <code>@context</code>:
           <ol>
             <li>If <a>processing mode</a> is <code>json-ld-1.0</code>, an
               <a data-link-for="JsonLdErrorCode">invalid term definition</a>
               has been detected and processing is aborted.</li>
             <li>Initialize <var>context</var> to the value associated with the
-              <code>@context</code> <a>member</a>, which is treated as a <var>local context</var>.</li>
+              <code>@context</code> <a>entry</a>, which is treated as a <var>local context</var>.</li>
             <li>Invoke the <a href="#context-processing-algorithm">Context Processing algorithm</a>
               using the <var>active context</var>, <var>context</var> as <var>local context</var>,
               and <code>true</code> for <var>from property</var>.
@@ -1534,11 +1534,11 @@
             <li>Set the <var>local context</var> of <var>definition</var> to <var>context</var>.</li>
           </ol>
         </li>
-        <li>If <var>value</var> contains the <a>member</a> <code>@language</code> and
-          does not contain the <a>member</a> <code>@type</code>:
+        <li>If <var>value</var> contains the <a>entry</a> <code>@language</code> and
+          does not contain the <a>entry</a> <code>@type</code>:
           <ol>
             <li>Initialize <var>language</var> to the value associated with the
-              <code>@language</code> <a>member</a>, which MUST be either <code>null</code>
+              <code>@language</code> <a>entry</a>, which MUST be either <code>null</code>
               or a <a>string</a>. Otherwise, an
               <a data-link-for="JsonLdErrorCode">invalid language mapping</a>
               error has been detected and processing is aborted.</li>
@@ -1547,31 +1547,31 @@
               of <var>definition</var> to <var>language</var>.</li>
           </ol>
         </li>
-        <li class="changed">If <var>value</var> contains the <a>member</a> <code>@nest</code>:
+        <li class="changed">If <var>value</var> contains the <a>entry</a> <code>@nest</code>:
           <ol>
             <li>If <a>processing mode</a> is <code>json-ld-1.0</code>, an
               <a data-link-for="JsonLdErrorCode">invalid term definition</a>
               has been detected and processing is aborted.</li>
             <li>Initialize <a>nest value</a> in <var>definition</var> to the value associated with the
-              <code>@nest</code> <a>member</a>, which MUST be a <a>string</a> and
+              <code>@nest</code> <a>entry</a>, which MUST be a <a>string</a> and
               MUST NOT be a keyword other than <code>@nest</code>. Otherwise, an
               <a data-link-for="JsonLdErrorCode">invalid @nest value</a>
               error has been detected and processing is aborted.</li>
           </ol>
         </li>
-        <li class="changed">If <var>value</var> contains the <a>member</a> <code>@prefix</code>:
+        <li class="changed">If <var>value</var> contains the <a>entry</a> <code>@prefix</code>:
           <ol>
             <li>If <a>processing mode</a> is <code>json-ld-1.0</code>, or if
               <var>term</var> contains a colon (<code>:</code>), an
               <a data-link-for="JsonLdErrorCode">invalid term definition</a>
               has been detected and processing is aborted.</li>
             <li>Initialize the <a>prefix flag</a> to the value associated with the
-              <code>@prefix</code> <a>member</a>, which MUST be a <a>boolean</a>. Otherwise, an
+              <code>@prefix</code> <a>entry</a>, which MUST be a <a>boolean</a>. Otherwise, an
               <a data-link-for="JsonLdErrorCode">invalid @prefix value</a>
               error has been detected and processing is aborted.</li>
           </ol>
         </li>
-        <li>If the value contains any <a>member</a> other than <code>@id</code>,
+        <li>If the value contains any <a>entry</a> other than <code>@id</code>,
           <code>@reverse</code>, <code>@container</code>,
           <code class="changed">@context</code>, <code>@language</code>, <code class="changed">@nest</code>,
           <code class="changed">@prefix</code>, or <code>@type</code>, an
@@ -1590,7 +1590,7 @@
         </li>
         <li>Set the <a>term definition</a> of <var>term</var> in
           <var>active context</var> to <var>definition</var> and set the value
-          associated with <var>defined</var>'s <a>member</a> <var>term</var> to
+          associated with <var>defined</var>'s <a>entry</a> <var>term</var> to
           <code>true</code>.</li>
       </ol>
     </section>
@@ -1630,8 +1630,8 @@
         checking <a>local context</a> against <code>null</code>.
         We know we need to create a <a>term definition</a> in the
         <a>active context</a> when <var>value</var> is
-        a <a>member</a> in the <a>local context</a> and the <var>defined</var> map
-        does not have a <a>member</a> for <var>value</var> with an associated value of
+        an <a>entry</a> in the <a>local context</a> and the <var>defined</var> map
+        does not have an <a>entry</a> for <var>value</var> with an associated value of
         <code>true</code>. The <var>defined</var> map is used during
         <a href="#context-processing-algorithm">Context Processing</a> to keep track of
         which <a>terms</a> have already been defined or are
@@ -1660,7 +1660,7 @@
         <li>If <var>value</var> is a <a>keyword</a> or <code>null</code>,
           return <var>value</var> as is.</li>
         <li>If <a>local context</a> is not <code>null</code>, it contains
-          a <a>member</a> with a key that equals <var>value</var>, and the value of the <a>member</a>
+          an <a>entry</a> with a key that equals <var>value</var>, and the value of the <a>entry</a>
           for <var>value</var> in <var>defined</var> is not <code>true</code>,
           invoke the <a href="#create-term-definition">Create Term Definition algorithm</a>,
           passing <var>active context</var>, <a>local context</a>,
@@ -1685,8 +1685,8 @@
               (<code>//</code>), return <var>value</var> as it is already an
               <a>absolute IRI</a> or a <a>blank node identifier</a>.</li>
             <li>If <a>local context</a> is not <code>null</code>, it
-              contains a <var>prefix</var> <a>member</a>, and the value
-              of the <var>prefix</var> <a>member</a> in <var>defined</var>
+              contains a <var>prefix</var> <a>entry</a>, and the value
+              of the <var>prefix</var> <a>entry</a> in <var>defined</var>
               is not <code>true</code>, invoke the
               <a href="#create-term-definition">Create Term Definition algorithm</a>,
               passing <var>active context</var>,
@@ -1764,8 +1764,8 @@
           each of its items recursively and return them in a new
           <a>array</a>.</li>
         <li>Otherwise, <var>element</var> is a <a class="changed">dictionary</a>. We expand
-          each of its <a>members</a>, adding them to our <var>result</var>, and then we expand
-          each value for each <a>member</a> recursively. Some of the <a>member</a> keys will be
+          each of its <a>entries</a>, adding them to our <var>result</var>, and then we expand
+          each value for each <a>entry</a> recursively. Some of the <a>entry</a> keys will be
           <a>terms</a> or
           <a>compact IRIs</a> and others will be
           <a>keywords</a> or simply ignored because
@@ -1789,7 +1789,7 @@
           <a data-link-for="JsonLdOptions">frameExpansion</a>
           flag allowing special forms of input used for <a data-cite="JSON-LD11-FRAMING#dfn-framing">frame expansion</a>,
           the <a data-link-for="JsonLdOptions">ordered</a> flag, used to order
-          <a>dictionary member</a> keys lexicographically, where noted,
+          <a>map entry</a> keys lexicographically, where noted,
           and the <var>from map</var> flag, used to control reverting
           previous <a>term definitions</a> in the <a>active context</a> associated with a type-scoped <a>context</a>.</span>
         To begin, the <var>active property</var> is set to <code>null</code>,
@@ -1798,10 +1798,10 @@
 
       <p class="changed">The algorithm also performs processing steps specific to expanding
         a <a>JSON-LD Frame</a>. For a <a>frame</a>, the <code>@id</code> and
-        <code>@type</code> <a>members</a> can accept an array of <a>IRIs</a> or
-        an empty <a>dictionary</a>. The <a>members</a> of a <a>value object</a> can also
+        <code>@type</code> <a>entries</a> can accept an array of <a>IRIs</a> or
+        an empty <a>dictionary</a>. The <a>entries</a> of a <a>value object</a> can also
         accept an <a>array</a> of <a>strings</a>, or an empty <a>dictionary</a>.
-        Framing also uses additional keyword <a>members</a>:
+        Framing also uses additional keyword <a>entries</a>:
         (<code>@explicit</code>, <code>@default</code>,
         <code>@embed</code>, <code>@explicit</code>, <code>@omitDefault</code>, or
         <code>@requireAll</code>) which are preserved through expansion.
@@ -1853,7 +1853,7 @@
                   of <var>active property</var> includes <code>@list</code>,
                   and <var>expanded item</var> is an
                   <a>array</a>, set <var>expanded item</var> to a new
-                  <a>dictionary</a> containing the <a>member</a>
+                  <a>dictionary</a> containing the <a>entry</a>
                   <code>@list</code> where the value is the original
                   <var>expanded item</var>.</li>
                 <li>If <var>expanded item</var> is an <a>array</a>, append each
@@ -1868,19 +1868,19 @@
         <li class="changed">If <var>active context</var> has a <a>previous context</a>,
           the <var>active context</var> is type-scoped.
           If <var>from map</var> is undefined or <code>false</code>,
-          and <var>element</var> does not contain a <a>member</a> expanding to <code>@value</code>,
-          and <var>element</var> does not consist of a single member expanding to <code>@id</code>,
+          and <var>element</var> does not contain a <a>entry</a> expanding to <code>@value</code>,
+          and <var>element</var> does not consist of a single entry expanding to <code>@id</code>,
           set <var>active context</var> to <a>previous context</a> from <var>active context</var>,
           as the scope of a term-scoped <a>context</a> does not apply when processing new <a>node objects</a>.</li>
         <li class="changed">If <var>property scoped context</var> is defined,
           set <var>active context</var> to the result of the
           <a href="#context-processing-algorithm">Context Processing algorithm</a>,
           passing <var>active context</var> and <var>property scoped context</var> as <var>local context</var>.</li>
-        <li>If <var>element</var> contains the <a>member</a> <code>@context</code>, set
+        <li>If <var>element</var> contains the <a>entry</a> <code>@context</code>, set
           <var>active context</var> to the result of the
           <a href="#context-processing-algorithm">Context Processing algorithm</a>,
           passing <var>active context</var> and the value of the
-          <code>@context</code> <a>member</a> as <var>local context</var>.</li>
+          <code>@context</code> <a>entry</a> as <var>local context</var>.</li>
         <li class="changed">Set <var>type scoped context</var> to <var>active context</var>.
           This is used for expanding values that may be relevant to any previous
           type-scoped <a>context</a>.</li>
@@ -1902,9 +1902,9 @@
               <span class="changed">and <code>true</code> for <var>from type</var></span>.</li>
           </ol>
         </li>
-        <li>Initialize two empty <a class="changed">dictionaries</a>, <var>result</var>
+        <li>Initialize two empty <a class="changed">maps</a>, <var>result</var>
           <span class="changed">and <var>nests</var>.
-            Set <var>input type</var> to the last value of any <a>member</a> of <var>element</var>
+            Set <var>input type</var> to the last value of any <a>entry</a> of <var>element</var>
             expanding to <code>@type</code></span>.
         </li>
         <li id="alg-expand-each-key-value">
@@ -1925,7 +1925,7 @@
                 <li>If <var>active property</var> equals <code>@reverse</code>, an
                   <a data-link-for="JsonLdErrorCode">invalid reverse property map</a>
                   error has been detected and processing is aborted.</li>
-                <li>If <var>result</var> has already an <var>expanded property</var> <a>member</a>, a
+                <li>If <var>result</var> has already an <var>expanded property</var> <a>entry</a>, a
                   <a data-link-for="JsonLdErrorCode">colliding keywords</a>
                   error has been detected and processing is aborted.</li>
                 <li>If <var>expanded property</var> is <code>@id</code> and
@@ -1971,7 +1971,7 @@
                   <span class="changed">and the <a data-link-for="JsonLdOptions">frameExpansion</a>
                     and <a data-link-for="JsonLdOptions">ordered</a> flags</span>,
                   <span class="changed">
-                    ensuring that <var>expanded value</var> is an <a>array</a> of one or more <a>dictionaries</a></span>.</li>
+                    ensuring that <var>expanded value</var> is an <a>array</a> of one or more <a>maps</a></span>.</li>
                 <li>Otherwise, if <var>expanded property</var> is <code>@value</code>,
                   <span class="changed"><a>processing mode</a> is <code>json-ld-1.1</code>, and
                     <var>input type</var> is <code>@json</code>,
@@ -1982,10 +1982,10 @@
                   error has been detected and processing is aborted. Otherwise,
                   set <var>expanded value</var> to <var>value</var>. If <var>expanded value</var>
                   is <code>null</code>, set the <code>@value</code>
-                  <a>member</a> of <var>result</var> to <code>null</code> and continue with the
+                  <a>entry</a> of <var>result</var> to <code>null</code> and continue with the
                   next <var>key</var> from <var>element</var>. Null values need to be preserved
-                  in this case as the meaning of an <code>@type</code> <a>member</a> depends
-                  on the existence of an <code>@value</code> <a>member</a>.
+                  in this case as the meaning of an <code>@type</code> <a>entry</a> depends
+                  on the existence of an <code>@value</code> <a>entry</a>.
                   <span class="changed">
                     When the <a data-link-for="JsonLdOptions">frameExpansion</a> flag is set, <var>value</var>
                     may also be an empty <a>dictionary</a> or an array of
@@ -2035,21 +2035,21 @@
                       <var>value</var> as <var>element</var>,
                       <span class="changed">and the <a data-link-for="JsonLdOptions">frameExpansion</a>
                         and <a data-link-for="JsonLdOptions">ordered</a> flags</span>.</li>
-                    <li>If <var>expanded value</var> contains an <code>@reverse</code> <a>member</a>,
+                    <li>If <var>expanded value</var> contains an <code>@reverse</code> <a>entry</a>,
                       i.e., <a>properties</a> that are reversed twice, execute for each of its
                       <var>property</var> and <var>item</var> the following steps:
                       <ol>
-                        <li>If <var>result</var> does not have a <var>property</var> <a>member</a>, create
+                        <li>If <var>result</var> does not have a <var>property</var> <a>entry</a>, create
                           one and set its value to an empty <a>array</a>.</li>
-                        <li>Append <var>item</var> to the value of the <var>property</var> <a>member</a>
+                        <li>Append <var>item</var> to the value of the <var>property</var> <a>entry</a>
                           of <var>result</var>.</li>
                       </ol>
                     </li>
-                    <li>If <var>expanded value</var> contains <a>member</a> other than <code>@reverse</code>:
+                    <li>If <var>expanded value</var> contains an <a>entry</a> other than <code>@reverse</code>:
                       <ol>
-                        <li>If <var>result</var> does not have an <code>@reverse</code> <a>member</a>, create
+                        <li>If <var>result</var> does not have an <code>@reverse</code> <a>entry</a>, create
                           one and set its value to an empty <a class="changed">dictionary</a>.</li>
-                        <li>Reference the value of the <code>@reverse</code> <a>member</a> in <var>result</var>
+                        <li>Reference the value of the <code>@reverse</code> <a>entry</a> in <var>result</var>
                           using the variable <var>reverse map</var>.</li>
                         <li>For each <var>property</var> and <var>items</var> in <var>expanded value</var>
                           other than <code>@reverse</code>:
@@ -2059,10 +2059,10 @@
                                 <li>If <var>item</var> is a <a>value object</a> or <a>list object</a>, an
                                   <a data-link-for="JsonLdErrorCode">invalid reverse property value</a>
                                   has been detected and processing is aborted.</li>
-                                <li>If <var>reverse map</var> has no <var>property</var> <a>member</a>, create one
+                                <li>If <var>reverse map</var> has no <var>property</var> <a>entry</a>, create one
                                   and initialize its value to an empty <a>array</a>.</li>
                                 <li>Append <var>item</var> to the value of the <var>property</var>
-                                  <a>member</a> in <var>reverse map</var>.</li>
+                                  <a>entry</a> in <var>reverse map</var>.</li>
                               </ol>
                             </li>
                           </ol>
@@ -2088,7 +2088,7 @@
                   <span class="changed">and the <a data-link-for="JsonLdOptions">frameExpansion</a>
                     and <a data-link-for="JsonLdOptions">ordered</a> flags</span>.</li>
                 <li>Unless <var>expanded value</var> is <code>null</code>, set
-                  the <var>expanded property</var> <a>member</a> of <var>result</var> to
+                  the <var>expanded property</var> <a>entry</a> of <var>result</var> to
                   <var>expanded value</var>.</li>
                 <li>Continue with the next <var>key</var> from <var>element</var>.</li>
               </ol>
@@ -2097,8 +2097,8 @@
               <var>active context</var>.</li>
             <li class="changed">If <var>key</var>'s <a>term definition</a> in <var>active context</var>
               has a <a>type mapping</a> of <code>@json</code>,
-              set <var>expanded value</var> to a new <a>dictionary</a>, set the <a>member</a>
-              <code>@value</code> to <var>value</var>, and set the member <code>@type</code> to <code>@json</code>.</li>
+              set <var>expanded value</var> to a new <a>dictionary</a>, set the <a>entry</a>
+              <code>@value</code> to <var>value</var>, and set the entry <code>@type</code> to <code>@json</code>.</li>
             <li>Otherwise, if <var>container mapping</var> <span class="changed">includes</span> <code>@language</code> and
               <var>value</var> is a <a class="changed">dictionary</a> then <var>value</var>
               is expanded from a <a>language map</a>
@@ -2126,7 +2126,7 @@
                           <var>language</var>),
                           <span class="changed">unless <var>item</var> is <code>null</code></span>.
                           <span class="changed">If <var>language</var> is <code>@none</code>,
-                            or expands to <code>@none</code>, do not set the <code>@language</code> <a>member</a>.</span></li>
+                            or expands to <code>@none</code>, do not set the <code>@language</code> <a>entry</a>.</span></li>
                       </ol>
                     </li>
                   </ol>
@@ -2184,7 +2184,7 @@
                           ensuring that the value is represented using an <a>array</a>.</li>
                         <li class="changed">If <var>container mapping</var> includes <code>@index</code>,
                           <var>index key</var> is not <code>@index</code>,
-                          <var>item</var> does not have a <a>member</a> <code>@index</code>
+                          <var>item</var> does not have an <a>entry</a> <code>@index</code>
                           and <var>expanded index</var> is not <code>@none</code>,
                           set <var>index property values</var> to the concatenation of
                           <var>expanded index</var> with any existing values of
@@ -2195,11 +2195,11 @@
                           an <a data-link-for="JsonLdErrorCode">invalid value object</a>
                           error has been detected and processing is aborted.</li>
                         <li>Otherwise, if <var>container mapping</var> includes <code>@index</code>,
-                          <var>item</var> does not have a <a>member</a> <code>@index</code>,
+                          <var>item</var> does not have an <a>entry</a> <code>@index</code>,
                           and <var>expanded index</var> is not <code>@none</code>,
                           add the key-value pair (<code>@index</code>-<var>index</var>) to <var>item</var>.</li>
                         <li>Otherwise, if <var>container mapping</var> includes <code>@id</code>
-                          and <var>item</var> does not have the <a>member</a> <code>@id</code>,
+                          and <var>item</var> does not have the <a>entry</a> <code>@id</code>,
                           add the key-value pair (<code>@id</code>-<var>expanded index</var>) to <var>item</var>,
                           where <var>expanded index</var> is set to the result of using the
                           <a href="#iri-expansion">IRI Expansion algorithm</a>,
@@ -2247,9 +2247,9 @@
             <li>If the <a>term definition</a> associated to
               <var>key</var> indicates that it is a <a>reverse property</a>
               <ol>
-                <li>If <var>result</var> has no <code>@reverse</code> <a>member</a>, create
+                <li>If <var>result</var> has no <code>@reverse</code> <a>entry</a>, create
                   one and initialize its value to an empty <a class="changed">dictionary</a>.</li>
-                <li>Reference the value of the <code>@reverse</code> <a>member</a> in <var>result</var>
+                <li>Reference the value of the <code>@reverse</code> <a>entry</a> in <var>result</var>
                   using the variable <var>reverse map</var>.</li>
                 <li>If <var>expanded value</var> is not an <a>array</a>, set
                   it to an <a>array</a> containing <var>expanded value</var>.</li>
@@ -2258,10 +2258,10 @@
                     <li>If <var>item</var> is a <a>value object</a> or <a>list object</a>, an
                       <a data-link-for="JsonLdErrorCode">invalid reverse property value</a>
                       has been detected and processing is aborted.</li>
-                    <li>If <var>reverse map</var> has no <var>expanded property</var> <a>member</a>,
+                    <li>If <var>reverse map</var> has no <var>expanded property</var> <a>entry</a>,
                       create one and initialize its value to an empty <a>array</a>.</li>
                     <li>Append <var>item</var> to the value of the <var>expanded property</var>
-                      <a>member</a> of <var>reverse map</var>.</li>
+                      <a>entry</a> of <var>reverse map</var>.</li>
                   </ol>
                 </li>
               </ol>
@@ -2269,10 +2269,10 @@
             <li>Otherwise, <var>key</var> is not a <a>reverse property</a>:
               <ol>
                 <li>If <var>result</var> does not have an <var>expanded property</var>
-                  <a>member</a>, create one and initialize its value to an empty
+                  <a>entry</a>, create one and initialize its value to an empty
                   <a>array</a>.</li>
                 <li>Append <var>expanded value</var> to value of the <var>expanded property</var>
-                  <a>member</a> of <var>result</var>.</li>
+                  <a>entry</a> of <var>result</var>.</li>
               </ol>
             </li>
             <li class="changed">For each key <var>nesting-key</var> in <var>nests</var>
@@ -2293,66 +2293,66 @@
             </li>
           </ol>
         </li>
-        <li>If <var>result</var> contains the <a>member</a> <code>@value</code>:
+        <li>If <var>result</var> contains the <a>entry</a> <code>@value</code>:
           <ol>
-            <li>The <var>result</var> must not contain any <a>members</a> other than
+            <li>The <var>result</var> must not contain any <a>entries</a> other than
               <code>@value</code>, <code>@language</code>, <code>@type</code>,
               and <code>@index</code>. It must not contain both a
-              <code>@language</code> <a>member</a> and a <code>@type</code> <a>member</a>.
+              <code>@language</code> <a>entry</a> and an <code>@type</code> <a>entry</a>.
               Otherwise, an
               <a data-link-for="JsonLdErrorCode">invalid value object</a>
               error has been detected and processing is aborted.</li>
-            <li>If the value of <var>result</var>'s <code>@value</code> <a>member</a> is
+            <li>If the value of <var>result</var>'s <code>@value</code> <a>entry</a> is
               <code>null</code>, then set <var>result</var> to <code>null</code>.</li>
-            <li class="changed">Otherwise, if the <var>result</var>'s <code>@type</code> <a>member</a>
-              is <code>@json</code>, then the <code>@value</code> <a>member</a> may
+            <li class="changed">Otherwise, if the <var>result</var>'s <code>@type</code> <a>entry</a>
+              is <code>@json</code>, then the <code>@value</code> <a>entry</a> may
               contain any value, and is treated as a <a>JSON literal</a>.</li>
-            <li>Otherwise, if the value of <var>result</var>'s <code>@value</code> <a>member</a>
-              is not a <a>string</a> and <var>result</var> contains the <a>member</a>
+            <li>Otherwise, if the value of <var>result</var>'s <code>@value</code> <a>entry</a>
+              is not a <a>string</a> and <var>result</var> contains the <a>entry</a>
               <code>@language</code>, an
               <a data-link-for="JsonLdErrorCode">invalid language-tagged value</a>
               error has been detected (only <a>strings</a>
               can be language-tagged) and processing is aborted.</li>
-            <li>Otherwise, if the <var>result</var> has an <code>@type</code> <a>member</a>
+            <li>Otherwise, if the <var>result</var> has an <code>@type</code> <a>entry</a>
               and its value is not an <a>IRI</a>, an
               <a data-link-for="JsonLdErrorCode">invalid typed value</a>
               error has been detected and processing is aborted.</li>
           </ol>
         </li>
-        <li>Otherwise, if <var>result</var> contains the <a>member</a> <code>@type</code>
+        <li>Otherwise, if <var>result</var> contains the <a>entry</a> <code>@type</code>
           and its associated value is not an <a>array</a>, set it to
           an <a>array</a> containing only the associated value.</li>
-        <li>Otherwise, if <var>result</var> contains the <a>member</a> <code>@set</code>
+        <li>Otherwise, if <var>result</var> contains the <a>entry</a> <code>@set</code>
           or <code>@list</code>:
           <ol>
-            <li>The <var>result</var> must contain at most one other <a>member</a>
+            <li>The <var>result</var> must contain at most one other <a>entry</a>
               which must be <code>@index</code>. Otherwise, an
               <a data-link-for="JsonLdErrorCode">invalid set or list object</a>
               error has been detected and processing is aborted.</li>
-            <li>If <var>result</var> contains the <a>member</a> <code>@set</code>, then
-              set <var>result</var> to the <a data-lt="member">member's</a> associated value.</li>
+            <li>If <var>result</var> contains the <a>entry</a> <code>@set</code>, then
+              set <var>result</var> to the <a data-lt="entry">entry's</a> associated value.</li>
           </ol>
         </li>
-        <li>If <var>result</var> contains only the <a>member</a>
+        <li>If <var>result</var> contains only the <a>entry</a>
           <code>@language</code>, set <var>result</var> to <code>null</code>.</li>
         <li>If <var>active property</var> is <code>null</code> or <code>@graph</code>,
           drop free-floating values as follows:
           <ol>
             <li>If <var>result</var> is an empty <a class="changed">dictionary</a> or contains
-              the <a>members</a> <code>@value</code> or <code>@list</code>, set <var>result</var> to
+              the <a>entries</a> <code>@value</code> or <code>@list</code>, set <var>result</var> to
               <code>null</code>.</li>
             <li>Otherwise, if <var>result</var> is a <a class="changed">dictionary</a> whose only
-              <a>member</a> is <code>@id</code>, set <var>result</var> to <code>null</code>.
+              <a>entry</a> is <code>@id</code>, set <var>result</var> to <code>null</code>.
               <span class="changed">
                 When the <a data-link-for="JsonLdOptions">frameExpansion</a> flag is set, a <a>dictionary</a>
-                containing only the <code>@id</code> <a>member</a> is retained.</span></li>
+                containing only the <code>@id</code> <a>entry</a> is retained.</span></li>
           </ol>
         </li>
         <li>Return <var>result</var>.</li>
       </ol>
 
       <p>If, after the above algorithm is run, the result is a
-        <a class="changed">dictionary</a> that contains only an <code>@graph</code> <a>member</a>, set the
+        <a class="changed">dictionary</a> that contains only an <code>@graph</code> <a>entry</a>, set the
         result to the value of <code>@graph</code>'s value. Otherwise, if the result
         is <code>null</code>, set it to an empty <a>array</a>. Finally, if
         the result is not an <a>array</a>, then set the result to an
@@ -2376,16 +2376,16 @@
       <p>If <a>active property</a> has a <a>type mapping</a> in the
         <a>active context</a> set to <code>@id</code> or <code>@vocab</code>,
         <span class="changed">and the value is a <a>string</a>,</span>
-        a <a class="changed">dictionary</a> with a single <a>member</a> <code>@id</code> whose
+        a <a class="changed">dictionary</a> with a single <a>entry</a> <code>@id</code> whose
         value is the result of using the
         <a href="#iri-expansion">IRI Expansion algorithm</a> on <var>value</var>
         is returned.</p>
 
       <p>Otherwise, the result will be a <a class="changed">dictionary</a> containing
-        an <code>@value</code> <a>member</a> whose value is the passed <var>value</var>.
-        Additionally, an <code>@type</code> <a>member</a> will be included if there is a
+        an <code>@value</code> <a>entry</a> whose value is the passed <var>value</var>.
+        Additionally, an <code>@type</code> <a>entry</a> will be included if there is a
         <a>type mapping</a> associated with the <a>active property</a>
-        or an <code>@language</code> <a>member</a> if <var>value</var> is a
+        or an <code>@language</code> <a>entry</a> if <var>value</var> is a
         <a>string</a> and there is <a>language mapping</a> associated
         with the <a>active property</a>.</p>
 
@@ -2411,7 +2411,7 @@
           in <var>active context</var> that is <code>@id</code>,
           <span class="changed">and the <var>value</var> is a <a>string</a>,</span>
           return a new
-          <a class="changed">dictionary</a> containing a single <a>member</a> where the
+          <a class="changed">dictionary</a> containing a single <a>entry</a> where the
           key is <code>@id</code> and the value is the result of using the
           <a href="#iri-expansion">IRI Expansion algorithm</a>, passing
           <var>active context</var>, <var>value</var>, and <code>true</code> for
@@ -2420,19 +2420,19 @@
           <var>active context</var> that is <code>@vocab</code>,
           <span class="changed">and the <var>value</var> is a <a>string</a>,</span>
           return a new
-          <a class="changed">dictionary</a> containing a single <a>member</a> where the
+          <a class="changed">dictionary</a> containing a single <a>entry</a> where the
           key is <code>@id</code> and the value is the result of using the
           <a href="#iri-expansion">IRI Expansion algorithm</a>, passing
           <var>active context</var>, <var>value</var>, <code>true</code> for
           <var>vocab</var>, and <code>true</code> for
           <var>document relative</var>.</li>
         <li>Otherwise, initialize <var>result</var> to a <a class="changed">dictionary</a>
-          with an <code>@value</code> <a>member</a> whose value is set to
+          with an <code>@value</code> <a>entry</a> whose value is set to
           <var>value</var>.</li>
         <li>If <var>active property</var> has a <a>type mapping</a> in
           <var>active context</var>,
           <span class="changed">other than <code>@id</code>, <code>@vocab</code>, or <code>@none</code>,</span>
-          add an <code>@type</code> <a>member</a> to
+          add an <code>@type</code> <a>entry</a> to
           <var>result</var> and set its value to the value associated with the
           <a>type mapping</a>.</li>
         <li>Otherwise, if <var>value</var> is a <a>string</a>:
@@ -2443,7 +2443,7 @@
               value to the language code associated with the
               <a>language mapping</a>; unless the
               <a>language mapping</a> is set to <code>null</code> in
-              which case no such <a>member</a> is added.</li>
+              which case no such <a>entry</a> is added.</li>
             <li>Otherwise, if the <var>active context</var> has a
               <a>default language</a>, add an <code>@language</code>
               to <var>result</var> and set its value to the
@@ -2493,7 +2493,7 @@
           each of its items recursively and return them in a new
           <a>array</a>.</li>
         <li>Otherwise <var>element</var> is a <a class="changed">dictionary</a>. The value
-          of each <a>member</a> in element is compacted recursively. Some of the <a>member</a> keys will be
+          of each <a>entry</a> in element is compacted recursively. Some of the <a>entry</a> keys will be
           compacted, using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
           to <a>terms</a> or <a>compact IRIs</a>
           and others will be compacted from <a>keywords</a> to
@@ -2507,9 +2507,9 @@
       </ol>
 
       <p>The final output is a <a class="changed">dictionary</a> with an <code>@context</code>
-        <a>member</a>, if a non-empty <a>context</a> was given, where the <a class="changed">dictionary</a>
+        <a>entry</a>, if a non-empty <a>context</a> was given, where the <a class="changed">dictionary</a>
         is either <var>result</var> or a wrapper for it where <var>result</var> appears
-        as the value of an (aliased) <code>@graph</code> <a>member</a> because <var>result</var>
+        as the value of an (aliased) <code>@graph</code> <a>entry</a> because <var>result</var>
         contained two or more items in an <a>array</a>.</p>
     </section>
 
@@ -2523,7 +2523,7 @@
         <span class="changed">The optional inputs are the
           <a data-link-for="JsonLdOptions">compactArrays</a> flag
           and the <a data-link-for="JsonLdOptions">ordered</a> flag, used to order
-          <a>dictionary member</a> keys lexicographically, where noted</span>.
+          <a>map entry</a> keys lexicographically, where noted</span>.
         To begin, the <var>active context</var> is set to the result of
         performing <a href="#context-processing-algorithm">Context Processing</a>
         on the passed <a>context</a>, the <var>inverse context</var> is
@@ -2571,8 +2571,8 @@
         <li>Otherwise <var>element</var> is a <a class="changed">dictionary</a>.</li>
         <li class="changed">If <var>active context</var> has a <a>previous context</a>,
           the <var>active context</var> is type-scoped.
-          If <var>element</var> does not contain an <code>@value</code> <a>member</a>,
-          and <var>element</var> does not consist of a single <code>@id</code> member,
+          If <var>element</var> does not contain an <code>@value</code> <a>entry</a>,
+          and <var>element</var> does not consist of a single <code>@id</code> entry,
           set <var>active context</var> to <a>previous context</a> from <var>active context</var>,
           as the scope of a term-scoped <a>context</a> does not apply when processing new <a>node objects</a>.</li>
         <li class="changed">If the <a>term definition</a> for <var>active property</var> has a
@@ -2589,7 +2589,7 @@
           </ol>
         </li>
         <li>If <var>element</var> has an <code>@value</code> or <code>@id</code>
-          <a>member</a> and the result of using the
+          <a>entry</a> and the result of using the
           <a href="#value-compaction">Value Compaction algorithm</a>,
           passing <var>active context</var>, <var>inverse context</var>,
           <var>active property</var>,and <var>element</var> as <var>value</var> is
@@ -2610,9 +2610,9 @@
           <var>active property</var> equals <code>@reverse</code>,
           otherwise to <code>false</code>.</li>
         <li>Initialize <var>result</var> to an empty <a class="changed">dictionary</a>.</li>
-        <li class="changed">If <var>element</var> has a <code>@type</code> <a>member</a>,
+        <li class="changed">If <var>element</var> has an <code>@type</code> <a>entry</a>,
           create a new array <var>compacted types</var> initialized
-          by transforming each <var>expanded type</var> of that <a>member</a>
+          by transforming each <var>expanded type</var> of that <a>entry</a>
           into it's compacted form using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
           passing <var>active context</var>, <var>inverse context</var>,
           <var>expanded type</var> for <var>var</var>, <code>true</code> for <var>vocab</var>,
@@ -2650,7 +2650,7 @@
                   passing <var>active context</var>, <var>inverse context</var>,
                   <var>expanded property</var> for <var>var</var>,
                   and <code>true</code> for <var>vocab</var>.</li>
-                <li>Add a <a>member</a> <var>alias</var> to <var>result</var> whose value is
+                <li>Add an <a>entry</a> <var>alias</var> to <var>result</var> whose value is
                   set to <var>compacted value</var> and continue to the next
                   <var>expanded property</var>.</li>
               </ol>
@@ -2693,7 +2693,7 @@
                   and the <a>term definition</a> for <var>alias</var> in the
                   <var>active context</var> has a <a>container mapping</a> including <code>@set</code>,
                   ensure that <var>compacted value</var> is an <a>array</a>.</li>
-                <li>Add a <a>member</a> <var>alias</var> to <var>result</var> whose value is
+                <li>Add an <a>entry</a> <var>alias</var> to <var>result</var> whose value is
                   set to <var>compacted value</var> and continue to the next
                   <var>expanded property</var>.</li>
               </ol>
@@ -2720,21 +2720,21 @@
                           is <code>false</code>, and <var>value</var> is not an
                           <a>array</a>, set <var>value</var> to a new
                           <a>array</a> containing only <var>value</var>.</li>
-                        <li>If <var>property</var> is not a <a>member</a> of
+                        <li>If <var>property</var> is not an <a>entry</a> of
                           <var>result</var>, add one and set its value to <var>value</var>.</li>
-                        <li>Otherwise, if the value of the <var>property</var> <a>member</a> of
+                        <li>Otherwise, if the value of the <var>property</var> <a>entry</a> of
                           <var>result</var> is not an <a>array</a>, set it to a new
                           <a>array</a> containing only the value. Then
                           append <var>value</var> to its value if <var>value</var>
                           is not an <a>array</a>, otherwise append each
                           of its items.</li>
-                        <li>Remove the <var>property</var> <a>member</a> from
+                        <li>Remove the <var>property</var> <a>entry</a> from
                           <var>compacted value</var>.</li>
                       </ol>
                     </li>
                   </ol>
                 </li>
-                <li>If <var>compacted value</var> has some remaining <a>dictionary members</a>, i.e.,
+                <li>If <var>compacted value</var> has some remaining <a>map entries</a>, i.e.,
                   it is not an empty <a class="changed">dictionary</a>:
                   <ol>
                     <li>Initialize <var>alias</var> to the result of using the
@@ -2742,7 +2742,7 @@
                       passing <var>active context</var>, <var>inverse context</var>,
                       <code>@reverse</code> for <var>var</var>,
                       and <code>true</code> for <var>vocab</var>.</li>
-                    <li>Set the value of the <var>alias</var> <a>member</a> of <var>result</var> to
+                    <li>Set the value of the <var>alias</var> <a>entry</a> of <var>result</var> to
                       <var>compacted value</var>.</li>
                   </ol>
                 </li>
@@ -2767,7 +2767,7 @@
               <var>active property</var> has a <a>container mapping</a>
               in <var>active context</var> that <span class="changed">includes</span> <code>@index</code>,
               then the compacted result will be inside of an <code>@index</code>
-              container, drop the <code>@index</code> <a>member</a> by continuing
+              container, drop the <code>@index</code> <a>entry</a> by continuing
               to the next <var>expanded property</var>.</li>
             <li>Otherwise, if <var>expanded property</var> is <code>@index</code>,
               <code>@value</code>, or <code>@language</code>:
@@ -2777,7 +2777,7 @@
                   passing <var>active context</var>, <var>inverse context</var>,
                   <var>expanded property</var> for <var>var</var>,
                   and <code>true</code> for <var>vocab</var>.</li>
-                <li>Add a <a>member</a> <var>alias</var> to <var>result</var> whose value is
+                <li>Add an <a>entry</a> <var>alias</var> to <var>result</var> whose value is
                   set to <var>expanded value</var> and continue with the next
                   <var>expanded property</var>.</li>
               </ol>
@@ -2797,17 +2797,17 @@
                   <var>active context</var> that expands to <code>@nest</code>,
                   otherwise an <a data-link-for="JsonLdErrorCode">invalid @nest
                   value</a> error has been detected, and processing is aborted.
-                  If <var>result</var> does not have a <var>nest term</var> <a>member</a>,
+                  If <var>result</var> does not have a <var>nest term</var> <a>entry</a>,
                   initialize it to an empty <a>dictionary</a> (<var>nest object</var>).
-                  If <var>nest object</var> does not have an <var>item active property</var> <a>member</a>,
-                  set this <a data-lt="member">member's</a>
+                  If <var>nest object</var> does not have an <var>item active property</var> <a>entry</a>,
+                  set this <a data-lt="entry">entry's</a>
                   value in <var>nest object</var> to an empty
-                  <a>array</a>.Otherwise, if the <a data-lt="member">member's</a> value is not an
+                  <a>array</a>.Otherwise, if the <a data-lt="entry">entry's</a> value is not an
                   <a>array</a>, then set it to one containing only the value.</li>
                 <li>Otherwise, if <var>result</var> does not have an
-                  <var>item active property</var> <a>member</a>, set this <a data-lt="member">member's</a> value in
+                  <var>item active property</var> <a>entry</a>, set this <a data-lt="entry">entry's</a> value in
                   <var>result</var> to an empty <a>array</a>. Otherwise, if
-                  the <a data-lt="member">member's</a> value is not an <a>array</a>, then set it
+                  the <a data-lt="entry">entry's</a> value is not an <a>array</a>, then set it
                   to one containing only the value.</li>
               </ol>
             </li>
@@ -2826,7 +2826,7 @@
                   <var>inside reverse</var>.</li>
                 <li class="changed">If the <a>term definition</a> for <var>item active property</var>
                   in the <var>active context</var> has a <a>nest value</a>
-                  <a>member</a>, that value (<var>nest term</var>) must be
+                  <a>entry</a>, that value (<var>nest term</var>) must be
                   <code>@nest</code>, or a <a>term</a> in the
                   <var>active context</var> that expands to <code>@nest</code>,
                   otherwise an <a data-link-for="JsonLdErrorCode">invalid @nest
@@ -2849,9 +2849,9 @@
                   <var>active context</var>, <var>inverse context</var>,
                   <var>item active property</var> for <var>active property</var>,
                   <var>expanded item</var> for <var>element</var> if it does
-                  not contain the <a>member</a> <code>@list</code>
+                  not contain the <a>entry</a> <code>@list</code>
                   <span class="changed">and is not a <a>graph object</a> containing <code>@list</code></span>,
-                  otherwise pass the value of the <a>member</a> for <var>element</var>.
+                  otherwise pass the value of the <a>entry</a> for <var>element</var>.
                   <span class="changed">Along with the <a data-link-for="JsonLdOptions">compactArrays</a>
                     and <a data-link-for="JsonLdOptions">ordered</a> flags</span></li>
                 <li>
@@ -2864,24 +2864,24 @@
                       <ol>
                         <li>Convert <var>compacted item</var> to a
                           <a>list object</a> by setting it to a
-                          <a class="changed">dictionary</a> containing a <a>member</a>
+                          <a class="changed">dictionary</a> containing an <a>entry</a>
                           where the key is the result of the
                           <a href="#iri-compaction">IRI Compaction algorithm</a>,
                           passing <var>active context</var>, <var>inverse context</var>,
                           <code>@list</code> for <var>var</var>, and <var>compacted item</var>
                           for <var>value</var> and the value is the original <var>compacted item</var>.</li>
-                        <li>If <var>expanded item</var> contains the <a>member</a>
-                          <code>@index</code>, then add a <a>member</a>
+                        <li>If <var>expanded item</var> contains the <a>entry</a>
+                          <code>@index</code>, then add an <a>entry</a>
                           to <var>compacted item</var> where the key is the
                           result of the <a href="#iri-compaction">IRI Compaction algorithm</a>,
                           passing <var>active context</var>, <var>inverse context</var>,
                           <code>@index</code> as <var>var</var>, and the value associated with the
-                          <code>@index</code> <a>member</a> in <var>expanded item</var> as <var>value</var>.</li>
+                          <code>@index</code> <a>entry</a> in <var>expanded item</var> as <var>value</var>.</li>
                       </ol>
                     </li>
                     <li class="changed">Otherwise, append <var>compacted item</var>
                       to the value associated with the
-                      <var>item active property</var> <a>member</a> in
+                      <var>item active property</var> <a>entry</a> in
                       <var>nest result</var>, initializing it to a new empty <a>array</a>, if
                       necessary.</li>
                   </ol>
@@ -2897,12 +2897,12 @@
                           <a href="#iri-compaction">IRI Compaction algorithm</a>
                           passing <var>active context</var> and the value of <code>@id</code> in <var>expanded item</var>
                           or <code>@none</code> if no such value exists as <var>var</var>, with <var>vocab</var> set to <code>true</code>
-                          if there is no <code>@id</code> <a>member</a> in <var>expanded item</var>.</li>
+                          if there is no <code>@id</code> <a>entry</a> in <var>expanded item</var>.</li>
                         <li class="changed">If <var>compacted item</var> is not an
                           <a>array</a> and <var>as array</var> is <code>true</code>,
                           set <var>compacted item</var> to an <a>array</a> containing that value.</li>
-                        <li>If <var>map key</var> is not a <a>member</a> in <var>map object</var>,
-                          then set this <a data-lt="member">member's</a> value in <var>map object</var>
+                        <li>If <var>map key</var> is not an <a>entry</a> in <var>map object</var>,
+                          then set this <a data-lt="entry">entry's</a> value in <var>map object</var>
                           to <var>compacted item</var>. Otherwise, if the value
                           is not an <a>array</a>, then set it to one
                           containing only the value and then append
@@ -2920,8 +2920,8 @@
                         <li class="changed">If <var>compacted item</var> is not an
                           <a>array</a> and <var>as array</var> is <code>true</code>,
                           set <var>compacted item</var> to an <a>array</a> containing that value.</li>
-                        <li>If <var>map key</var> is not a <a>member</a> in <var>map object</var>,
-                          then set this <a data-lt="member">member's</a> value in <var>map object</var>
+                        <li>If <var>map key</var> is not an <a>entry</a> in <var>map object</var>,
+                          then set this <a data-lt="entry">entry's</a> value in <var>map object</var>
                           to <var>compacted item</var>. Otherwise, if the value
                           is not an <a>array</a>, then set it to one
                           containing only the value and then append
@@ -2934,7 +2934,7 @@
                       object. If <var>compacted item</var> is not an <a>array</a>
                       and <var>as array</var> is <code>true</code>, set
                       <var>compacted item</var> to an <a>array</a> containing
-                      that value. If the value of an <var>item active property</var> <a>member</a> in
+                      that value. If the value of an <var>item active property</var> <a>entry</a> in
                       <var class="changed">nest result</var> is not an <a>array</a>,
                       set it to a new <a>array</a> containing only the value.
                       Then append <var>compacted item</var> to the value if
@@ -2951,7 +2951,7 @@
                           <var>var</var>, and <code>true</code> for
                           <var>vocab</var> using the original
                           <var>compacted item</var> as a value.</li>
-                        <li>If expanded item contains an <code>@id</code> <a>member</a>,
+                        <li>If expanded item contains an <code>@id</code> <a>entry</a>,
                           add the key resulting from calling the <a
                           href="#iri-compaction">IRI Compaction algorithm</a>
                           passing <var>active context</var>, <code>@id</code> as
@@ -2961,7 +2961,7 @@
                           passing <var>active context</var>, the value of <code>@id</code>
                           in <var>expanded item</var> as
                           <var>var</var>.</li>
-                        <li>If expanded item contains an <code>@index</code> <a>member</a>,
+                        <li>If expanded item contains an <code>@index</code> <a>entry</a>,
                           add the key resulting from calling the <a
                           href="#iri-compaction">IRI Compaction algorithm</a>
                           passing <var>active context</var>, <code>@index</code> as
@@ -2984,7 +2984,7 @@
                     or <code>@type</code></span>
                     <span class="changed">and <var>container</var> does not include <code>@graph</code></span>:
                   <ol>
-                    <li>If <var>item active property</var> is not a <a>member</a> in
+                    <li>If <var>item active property</var> is not an <a>entry</a> in
                       <var class="changed">nest result</var>, initialize it to an empty <a class="changed">dictionary</a>.
                       Initialize <var>map object</var> to the value of <var>item active property</var>
                       in <var class="changed">nest result</var>.</li>
@@ -2999,8 +2999,8 @@
                       or <code>@index</code>, if no such value exists.</li>
                     <li>If <var>container</var> includes <code>@language</code> and
                       <var>expanded item</var> contains a
-                      <code>@value</code> <a>member</a>, then set <var>compacted item</var>
-                      to the value associated with its <code>@value</code> <a>member</a>.
+                      <code>@value</code> <a>entry</a>, then set <var>compacted item</var>
+                      to the value associated with its <code>@value</code> <a>entry</a>.
                       Set <var>map key</var> to the value of <code>@language</code> in <var>expanded item</var>, if any.</li>
                     <li>Otherwise, if <var>container</var> includes <code>@index</code>
                       and <var>index key</var> is <code>@index</code>,
@@ -3013,7 +3013,7 @@
                       for <var>container key</var>, set the value of
                       <var>container key</var> in <var>compacted item</var>
                       to those remaining values. Otherwise, remove that
-                      <a>member</a> from <var>compacted item</var>.
+                      <a>entry</a> from <var>compacted item</var>.
                     </li>
                     <li class="changed">Otherwise, if <var>container</var> includes <code>@id</code>, set
                       <var>map key</var> to the value of <var>container key</var> in
@@ -3024,7 +3024,7 @@
                       for <var>container key</var>, set the value of
                       <var>container key</var> in <var>compacted item</var>
                       to those remaining values. Otherwise, remove that
-                      <a>member</a> from <var>compacted item</var>.</li>
+                      <a>entry</a> from <var>compacted item</var>.</li>
                     <li class="changed">If <var>compacted item</var> is not an
                       <a>array</a> and <var>as array</var> is <code>true</code>,
                       set <var>compacted item</var> to an <a>array</a> containing that value.</li>
@@ -3033,8 +3033,8 @@
                       passing <var>active context</var>, <code>@none</code> as
                       <var>var</var>, and <code>true</code> for
                       <var>vocab</var>.</li>
-                    <li>If <var>map key</var> is not a <a>member</a> of <var>map object</var>,
-                      then set this <a data-lt="member">member's</a> value in <var>map object</var>
+                    <li>If <var>map key</var> is not an <a>entry</a> of <var>map object</var>,
+                      then set this <a data-lt="entry">entry's</a> value in <var>map object</var>
                       to <var>compacted item</var>. Otherwise, if the value
                       is not an <a>array</a>, then set it to one
                       containing only the value and then append
@@ -3050,12 +3050,12 @@
                       <var>compacted item</var> is not an <a>array</a>,
                       set it to a new <a>array</a>
                       containing only <var>compacted item</var>.</li>
-                    <li>If <var>item active property</var> is not a <a>member</a> in
-                      <var>result</var> then add the <a>member</a>,
+                    <li>If <var>item active property</var> is not an <a>entry</a> in
+                      <var>result</var> then add the <a>entry</a>,
                       (<var>item active property</var>-<var>compacted item</var>),
                       to <var class="changed">nest result</var>.</li>
                     <li>Otherwise, if the value associated with the 
-                      <var>item active property</var> <a>member</a> in <var class="changed">nest result</var>
+                      <var>item active property</var> <a>entry</a> in <var class="changed">nest result</var>
                       is not an <a>array</a>, set it to a new
                       <a>array</a> containing only the value. Then
                       append <var>compacted item</var> to the value if
@@ -3073,13 +3073,13 @@
       <p>If, after the algorithm outlined above is run, <var>result</var>
         <span class="changed">is an empty <a>array</a>, replace it with a new <a>dictionary</a></span>.
         Otherwise, if <var>result</var> is an <a>array</a>, replace it with a new
-        <a class="changed">dictionary</a> with a single <a>member</a> whose key is the result
+        <a class="changed">dictionary</a> with a single <a>entry</a> whose key is the result
         of using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
         passing <var>active context</var>, <var>inverse context</var>, and
         <code>@graph</code> as <var>var</var> and whose value is the <a>array</a>
         <var>result</var>.</p>
       <p>Finally, if a non-empty <var>context</var> has been passed,
-        add an <code>@context</code> <a>member</a> to <var>result</var> and set its value
+        add an <code>@context</code> <a>entry</a> to <var>result</var> and set its value
         to the passed <var>context</var>.</p>
     </section>
   </section> <!-- end of Compaction -->
@@ -3161,30 +3161,30 @@
               </span>.</li>
             <li>Initialize <var>var</var> to the value of the <a>IRI mapping</a>
               for the <a>term definition</a>.</li>
-            <li>If <var>var</var> is not a <a>member</a> of <var>result</var>, add
-              a <a>member</a> where the key is <var>var</var> and the value
+            <li>If <var>var</var> is not an <a>entry</a> of <var>result</var>, add
+              a <a>entry</a> where the key is <var>var</var> and the value
               is an empty <a class="changed">dictionary</a> to <var>result</var>.</li>
-            <li>Reference the value associated with the <var>var</var> <a>member</a> in
+            <li>Reference the value associated with the <var>var</var> <a>entry</a> in
               <var>result</var> using the variable <var>container map</var>.</li>
-            <li>If <var>container map</var> has no <var>container</var> <a>member</a>,
+            <li>If <var>container map</var> has no <var>container</var> <a>entry</a>,
               create one and set its value to a new
-              <a class="changed">dictionary</a> with <span class="changed">three</span> <a>member</a>s.
-              The first <a>member</a> is <code>@language</code> and its value is a new empty
-              <a class="changed">dictionary</a>, the second <a>member</a> is <code>@type</code>
+              <a class="changed">dictionary</a> with <span class="changed">three</span> <a>entries</a>.
+              The first <a>entry</a> is <code>@language</code> and its value is a new empty
+              <a class="changed">dictionary</a>, the second <a>entry</a> is <code>@type</code>
               and its value is a new empty <a class="changed">dictionary</a>,
-              <span class="changed">and the third <a>member</a> is <code>@any</code>
-                and its value is a new <a>dictionary</a> with the <a>member</a>
+              <span class="changed">and the third <a>entry</a> is <code>@any</code>
+                and its value is a new <a>dictionary</a> with the <a>entry</a>
                 <code>@none</code> set to the <a>term</a> being processed</span>.</li>
-            <li>Reference the value associated with the <var>container</var> <a>member</a>
+            <li>Reference the value associated with the <var>container</var> <a>entry</a>
               in <var>container map</var> using the variable <var>type/language map</var>.</li>
             <li>If the <a>term definition</a> indicates that the <a>term</a>
               represents a <a>reverse property</a>:
               <ol>
                 <li>Reference the value associated with the <code>@type</code>
-                  <a>member</a> in <var>type/language map</var> using the variable
+                  <a>entry</a> in <var>type/language map</var> using the variable
                   <var>type map</var>.</li>
                 <li>If <var>type map</var> does not have an <code>@reverse</code>
-                  <a>member</a>, create one and set its value to the <a>term</a>
+                  <a>entry</a>, create one and set its value to the <a>term</a>
                   being processed.</li>
               </ol>
             </li>
@@ -3192,16 +3192,16 @@
               <a>type mapping</a> which is <code>@none</code>:
               <ol>
                 <li>Reference the value associated with the <code>@language</code>
-                  <a>member</a> in <var>type/language map</var> using the variable
+                  <a>entry</a> in <var>type/language map</var> using the variable
                   <var>language map</var>.</li>
                 <li>If <var>language map</var> does not have an <code>@any</code>
-                  <a>member</a>, create one and set its value to the <a>term</a>
+                  <a>entry</a>, create one and set its value to the <a>term</a>
                   being processed.</li>
                 <li>Reference the value associated with the <code>@type</code>
-                  <a>member</a> in <var>type/language map</var> using the variable
+                  <a>entry</a> in <var>type/language map</var> using the variable
                   <var>type map</var>.</li>
                 <li>If <var>type map</var> does not have an <code>@any</code>
-                  <a>member</a>, create one and set its value to the <a>term</a>
+                  <a>entry</a>, create one and set its value to the <a>term</a>
                   being processed.</li>
               </ol>
             </li>
@@ -3209,9 +3209,9 @@
               <a>type mapping</a>:
               <ol>
                 <li>Reference the value associated with the <code>@type</code>
-                  <a>member</a> in <var>type/language map</var> using the variable
+                  <a>entry</a> in <var>type/language map</var> using the variable
                   <var>type map</var>.</li>
-                <li>If <var>type map</var> does not have a <a>member</a> corresponding
+                <li>If <var>type map</var> does not have a <a>entry</a> corresponding
                   to the <a>type mapping</a> in <a>term definition</a>,
                   create one and set its value to the <a>term</a>
                   being processed.</li>
@@ -3221,12 +3221,12 @@
               <a>language mapping</a> (might be <code>null</code>):
               <ol>
                 <li>Reference the value associated with the <code>@language</code>
-                  <a>member</a> in <var>type/language map</var> using the variable
+                  <a>entry</a> in <var>type/language map</var> using the variable
                   <var>language map</var>.</li>
                 <li>If the <a>language mapping</a> equals <code>null</code>,
                   set <var>language</var> to <code>@null</code>; otherwise set it
                   to the language code in <a>language mapping</a>.</li>
-                <li>If <var>language map</var> does not have a <var>language</var> <a>member</a>,
+                <li>If <var>language map</var> does not have a <var>language</var> <a>entry</a>,
                   create one and set its value to the <a>term</a>
                   being processed.</li>
               </ol>
@@ -3234,19 +3234,19 @@
             <li>Otherwise:
               <ol>
                 <li>Reference the value associated with the <code>@language</code>
-                  <a>member</a> in <var>type/language map</var> using the variable
+                  <a>entry</a> in <var>type/language map</var> using the variable
                   <var>language map</var>.</li>
                 <li>If <var>language map</var> does not have a <var>default language</var>
-                  <a>member</a>, create one and set its value to the <a>term</a>
+                  <a>entry</a>, create one and set its value to the <a>term</a>
                   being processed.</li>
                 <li>If <var>language map</var> does not have an <code>@none</code>
-                  <a>member</a>, create one and set its value to the <a>term</a>
+                  <a>entry</a>, create one and set its value to the <a>term</a>
                   being processed.</li>
                 <li>Reference the value associated with the <code>@type</code>
-                  <a>member</a> in <var>type/language map</var> using the variable
+                  <a>entry</a> in <var>type/language map</var> using the variable
                   <var>type map</var>.</li>
                 <li>If <var>type map</var> does not have an <code>@none</code>
-                  <a>member</a>, create one and set its value to the <a>term</a>
+                  <a>entry</a>, create one and set its value to the <a>term</a>
                   being processed.</li>
               </ol>
             </li>
@@ -3324,8 +3324,8 @@
 
       <ol>
         <li>If <var>var</var> is <code>null</code>, return <code>null</code>.</li>
-        <li>If <var>vocab</var> is <code>true</code> and <var>var</var> is a
-          <a>member</a> of <var>inverse context</var>:
+        <li>If <var>vocab</var> is <code>true</code> and <var>var</var> is an
+          <a>entry</a> of <var>inverse context</var>:
           <ol>
             <li>Initialize <var>default language</var> to
               <a data-lt="active context">active context's</a>
@@ -3349,7 +3349,7 @@
               <a>type mapping</a> or <a>language mapping</a> for
               a <a>term</a>, based on what is compatible with <var>value</var>.</li>
             <li>If <var>value</var> is a <a class="changed">dictionary</a>,
-              that contains the an <code>@index</code> <a>member</a>,
+              that contains the an <code>@index</code> <a>entry</a>,
               <span class="changed">and <var>value</var> is not a <a>graph object</a></span>
               then append the values <code>@index</code> <span class="changed">and <code>@index@set</code></span> to <var>containers</var>.</li>
             <li>If <var>reverse</var> is <code>true</code>, set <var>type/language</var>
@@ -3360,10 +3360,10 @@
               to the most specific values that work for all items in
               the list as follows:
               <ol>
-                <li>If <code>@index</code> is a not <a>member</a> in <var>value</var>, then
+                <li>If <code>@index</code> is not an <a>entry</a> in <var>value</var>, then
                   append <code>@list</code> to <var>containers</var>.</li>
                 <li>Initialize <var>list</var> to the <a>array</a> associated
-                  with the <code>@list</code> <a>member</a> in <var>value</var>.</li>
+                  with the <code>@list</code> <a>entry</a> in <var>value</var>.</li>
                 <li>Initialize <var>common type</var> and <var>common language</var> to <code>null</code>. If
                   <var>list</var> is empty, set <var>common language</var> to
                   <var>default language</var>.</li>
@@ -3371,13 +3371,13 @@
                   <ol>
                     <li>Initialize <var>item language</var> to <code>@none</code> and
                       <var>item type</var> to <code>@none</code>.</li>
-                    <li>If <var>item</var> contains a <code>@value</code> <a>member</a>:
+                    <li>If <var>item</var> contains an <code>@value</code> <a>entry</a>:
                       <ol>
-                        <li>If <var>item</var> contains the a <code>@language</code> <a>member</a>,
+                        <li>If <var>item</var> contains the an <code>@language</code> <a>entry</a>,
                           then set <var>item language</var> to its associated
                           value.</li>
                         <li>Otherwise, if <var>item</var> contains the a
-                          <code>@type</code> <a>member</a>, set <var>item type</var> to its
+                          <code>@type</code> <a>entry</a>, set <var>item type</var> to its
                           associated value.</li>
                         <li>Otherwise, set <var>item language</var> to
                           <code>@null</code>.</li>
@@ -3388,7 +3388,7 @@
                       to <var>item language</var>.</li>
                     <li>Otherwise, if <var>item language</var> does not equal
                       <var>common language</var> and <var>item</var> contains a
-                      <code>@value</code> <a>member</a>, then set <var>common language</var>
+                      <code>@value</code> <a>entry</a>, then set <var>common language</var>
                       to <code>@none</code> because list items have conflicting
                       languages.</li>
                     <li>If <var>common type</var> is <code>null</code>, set it
@@ -3418,19 +3418,19 @@
             <li class="changed">Otherwise, if <var>value</var> is a <a>graph object</a>,
               prefer a mapping most appropriate for the particular value.
               <ol>
-                <li>If value contains an <code>@index</code> <a>member</a>,
+                <li>If value contains an <code>@index</code> <a>entry</a>,
                   append the values <code>@graph@index</code> and <code>@graph@index@set</code>
                   to <var>containers</var>.</li>
-                <li>If the value contains an <code>@id</code> <a>member</a>,
+                <li>If the value contains an <code>@id</code> <a>entry</a>,
                   append the values <code>@graph@id</code> and <code>@graph@id@set</code>
                   to <var>containers</var>.</li>
                 <li>Append the values <code>@graph</code> <code>@graph@set</code>,
                   and <code>@set</code>
                   to <var>containers</var>.</li>
-                <li>If value does not contain an <code>@index</code> <a>member</a>,
+                <li>If value does not contain an <code>@index</code> <a>entry</a>,
                   append the values <code>@graph@index</code> and <code>@graph@index@set</code>
                   to <var>containers</var>.</li>
-                <li>If the value does not contain an <code>@id</code> <a>member</a>,
+                <li>If the value does not contain an <code>@id</code> <a>entry</a>,
                   append the values <code>@graph@id</code> and <code>@graph@id@set</code>
                   to <var>containers</var>.</li>
                 <li>Append the values <code>@index</code> and <code>@index@set</code>
@@ -3443,14 +3443,14 @@
               <ol>
                 <li>If <var>value</var> is a <a>value object</a>:
                   <ol>
-                    <li>If <var>value</var> contains a <code>@language</code> <a>member</a>
-                      and does not contain an <code>@index</code> <a>member</a>,
+                    <li>If <var>value</var> contains an <code>@language</code> <a>entry</a>
+                      and does not contain an <code>@index</code> <a>entry</a>,
                       then set <var>type/language value</var> to its associated
                       value and, append <code>@language</code>
                       <span class="changed">and <code>@language@set</code></span> to
                       <var>containers</var>.</li>
                     <li>Otherwise, if <var>value</var> contains a
-                      <code>@type</code> <a>member</a>, then set <var>type/language value</var> to
+                      <code>@type</code> <a>entry</a>, then set <var>type/language value</var> to
                       its associated value and set <var>type/language</var> to
                       <code>@type</code>.</li>
                   </ol>
@@ -3468,11 +3468,11 @@
               be the last <a>container mapping</a> value to be checked as it
               is the most generic.</li>
             <li class="changed">
-              If <a>processing mode</a> is <code>json-ld-1.1</code> and value does not contain an <code>@index</code> <a>member</a>, append
+              If <a>processing mode</a> is <code>json-ld-1.1</code> and value does not contain an <code>@index</code> <a>entry</a>, append
               <code>@index</code> and <code>@index@set</code> to <var>containers</var>.
             </li>
             <li class="changed">
-              If <a>processing mode</a> is <code>json-ld-1.1</code> and value contains only a <code>@value</code> <a>member</a>, append
+              If <a>processing mode</a> is <code>json-ld-1.1</code> and value contains only an <code>@value</code> <a>entry</a>, append
               <code>@language</code> and <code>@language@set</code> to <var>containers</var>.
             </li>
             <li>If <var>type/language value</var> is <code>null</code>, set it to
@@ -3485,16 +3485,16 @@
             <li>If <var>type/language value</var> is <code>@reverse</code>, append
               <code>@reverse</code> to <var>preferred values</var>.</li>
             <li>If <var>type/language value</var> is <code>@id</code> or <code>@reverse</code>
-              and <var>value</var> has an <code>@id</code> <a>member</a>:
+              and <var>value</var> has an <code>@id</code> <a>entry</a>:
               <ol>
                 <li>If the result of using the
                   <a href="#iri-compaction">IRI compaction algorithm</a>,
                   passing <var>active context</var>, <var>inverse context</var>,
-                  the value associated with the <code>@id</code> <a>member</a> in <var>value</var> for
+                  the value associated with the <code>@id</code> <a>entry</a> in <var>value</var> for
                   <var>var</var>, and <code>true</code> for <var>vocab</var> has a
                   <a>term definition</a> in the <var>active context</var>
                   with an <a>IRI mapping</a> that equals the value associated
-                  with the <code>@id</code> <a>member</a> in <var>value</var>,
+                  with the <code>@id</code> <a>entry</a> in <var>value</var>,
                   then append <code>@vocab</code>, <code>@id</code>, and
                   <code>@none</code>, in that order, to <var>preferred values</var>.</li>
                 <li>Otherwise, append <code>@id</code>, <code>@vocab</code>, and
@@ -3627,22 +3627,22 @@
           <var>var</var> in the <var>inverse context</var>.</li>
         <li>For each item <var>container</var> in <var>containers</var>:
           <ol>
-            <li>If <var>container</var> is not a <a>member</a> of <var>container map</var>, then
+            <li>If <var>container</var> is not a <a>entry</a> of <var>container map</var>, then
               there is no <a>term</a> with a matching
               <a>container mapping</a> for it, so continue to the next
               <var>container</var>.</li>
             <li>Initialize <var>type/language map</var> to the value associated
-              with the <var>container</var> <a>member</a> in <var>container map</var>.</li>
+              with the <var>container</var> <a>entry</a> in <var>container map</var>.</li>
             <li>Initialize <var>value map</var> to the value associated
-              with <var>type/language</var> <a>member</a> in <var>type/language map</var>.</li>
+              with <var>type/language</var> <a>entry</a> in <var>type/language map</var>.</li>
             <li>For each <var>item</var> in <var>preferred values</var>:
               <ol>
-                <li>If <var>item</var> is not a <a>member</a> of <var>value map</var>,
+                <li>If <var>item</var> is not a <a>entry</a> of <var>value map</var>,
                   then there is no <a>term</a> with a matching
                   <a>type mapping</a> or <a>language mapping</a>,
                   so continue to the next <var>item</var>.</li>
                 <li>Otherwise, a matching term has been found, return the value
-                  associated with the <var>item</var> <a>member</a> in
+                  associated with the <var>item</var> <a>entry</a> in
                   <var>value map</var>.</li>
               </ol>
             </li>
@@ -3689,7 +3689,7 @@
         </aside>
 
         <aside class="example" data-ignore title="Language map term with language value">
-          <p>Given the <a>member</a> <code>{"http://example.org/t": {"@value": "foo", "@type": "http:/example.org/type"}}</code>,
+          <p>Given the <a>entry</a> <code>{"http://example.org/t": {"@value": "foo", "@type": "http:/example.org/type"}}</code>,
             The algorithm will be invoked as follows:</p>
           <dl>
             <dt><var>containers</var></dt>
@@ -3736,7 +3736,7 @@
         </aside>
 
         <aside class="example" data-ignore title="Datatyped term with datatyped value">
-          <p>Given the <a>member</a> <code>{"http://example.org/t": {"@value": "foo", "@type": "http:/example.org/type"}}</code>,
+          <p>Given the <a>entry</a> <code>{"http://example.org/t": {"@value": "foo", "@type": "http:/example.org/type"}}</code>,
             The algorithm will be invoked as follows:</p>
           <dl>
             <dt><var>containers</var></dt>
@@ -3752,7 +3752,7 @@
         </aside>
 
         <aside class="example" data-ignore title="Datatyped term with simple value">
-          <p>Given the <a>member</a> <code>{"http://example.org/t": {"@value": "foo"}}</code>,
+          <p>Given the <a>entry</a> <code>{"http://example.org/t": {"@value": "foo"}}</code>,
             The algorithm will be invoked as follows:</p>
           <dl>
             <dt><var>containers</var></dt>
@@ -3768,7 +3768,7 @@
         </aside>
 
         <aside class="example" data-ignore title="Datatyped term with object value">
-          <p>Given the <a>member</a> <code>{"http://example.org/t": {"@id": "http://example.org/id"}}</code>,
+          <p>Given the <a>entry</a> <code>{"http://example.org/t": {"@id": "http://example.org/id"}}</code>,
             The algorithm will be invoked as follows:</p>
           <dl>
             <dt><var>containers</var></dt>
@@ -3800,26 +3800,26 @@
       <h3>Overview</h3>
 
       <p>The <var>value</var> to compact has either an <code>@id</code> or an
-        <code>@value</code> <a>member</a>.</p>
+        <code>@value</code> <a>entry</a>.</p>
 
       <p>For the former case, if the <a>type mapping</a> of
         <a>active property</a> is set to <code>@id</code> or <code>@vocab</code>
-        and <var>value</var> consists of only an <code>@id</code> <a>member</a> and, if
+        and <var>value</var> consists of only an <code>@id</code> <a>entry</a> and, if
         the <a>container mapping</a> of <a>active property</a>
-        <span class="changed">includes</span> <code>@index</code>, an <code>@index</code> <a>member</a>, <var>value</var>
+        <span class="changed">includes</span> <code>@index</code>, an <code>@index</code> <a>entry</a>, <var>value</var>
         can be compacted to a <a>string</a> by returning the result of
         using the <a href="#iri-compaction">IRI Compaction algorithm</a>
-        to compact the value associated with the <code>@id</code> <a>member</a>.
+        to compact the value associated with the <code>@id</code> <a>entry</a>.
         Otherwise, <var>value</var> cannot be compacted and is returned as is.</p>
 
       <p>For the latter case, it might be possible to compact <var>value</var>
-        just into the value associated with the <code>@value</code> <a>member</a>.
+        just into the value associated with the <code>@value</code> <a>entry</a>.
         This can be done if the <a>active property</a> has a matching
         <a>type mapping</a> or <a>language mapping</a> and there
-        is either no <code>@index</code> <a>member</a> or the <a>container mapping</a>
+        is either no <code>@index</code> <a>entry</a> or the <a>container mapping</a>
         of <a>active property</a> <span class="changed">includes</span> <code>@index</code>. It can
-        also be done if <code>@value</code> is the only <a>member</a> in <var>value</var>
-        (apart an <code>@index</code> <a>member</a> in case the <a>container mapping</a>
+        also be done if <code>@value</code> is the only <a>entry</a> in <var>value</var>
+        (apart an <code>@index</code> <a>entry</a> in case the <a>container mapping</a>
         of <a>active property</a> <span class="changed">includes</span> <code>@index</code>) and
         either its associated value is not a <a>string</a>, there is
         no <a>default language</a>, or there is an explicit
@@ -3835,13 +3835,13 @@
         to be compacted.</p>
 
       <ol>
-        <li>Initialize <var>number members</var> to the number of <a>members</a>
+        <li>Initialize <var>number entries</var> to the number of <a>entries</a>
           <var>value</var> contains.</li>
-        <li>If <var>value</var> has an <code>@index</code> <a>member</a> and the
+        <li>If <var>value</var> has an <code>@index</code> <a>entry</a> and the
           <a>container mapping</a> associated to <var>active property</var>
-          <span class="changed">includes</span> <code>@index</code>, decrease <var>number members</var> by
+          <span class="changed">includes</span> <code>@index</code>, decrease <var>number entries</var> by
           <code>1</code>.</li>
-        <li>If <var>number members</var> is greater than <code>2</code>, return
+        <li>If <var>number entries</var> is greater than <code>2</code>, return
           <var>value</var> as it cannot be compacted.</li>
         <li class="changed">If the <a>type mapping</a> of <var>active property</var> is <code>@none</code>,
           leave <var>value</var> as is, as value compaction is disabled.
@@ -3849,7 +3849,7 @@
             <li>Replace any value of <code>@type</code> in <var>value</var> with the result of using the
               <a href="#iri-compaction">IRI compaction algorithm</a>,
               passing <var>active context</var>, <var>inverse context</var>,
-              the value of the <code>@type</code> <a>member</a> for <var>var</var>, and
+              the value of the <code>@type</code> <a>entry</a> for <var>var</var>, and
               <code>true</code> for <var>vocab</var>.</li>
             <li>Replace each key in <var>value</var> with the result of using the
               <a href="#iri-compaction">IRI compaction algorithm</a>,
@@ -3859,44 +3859,44 @@
             <li>Return <var>value</var>.</li>
           </ol>
         </li>
-        <li>If <var>value</var> has an <code>@id</code> <a>member</a>:
+        <li>If <var>value</var> has an <code>@id</code> <a>entry</a>:
           <ol>
-            <li>If <var>number members</var> is <code>1</code> and
+            <li>If <var>number entries</var> is <code>1</code> and
               the <a>type mapping</a> of <var>active property</var>
               is set to <code>@id</code>, return the result of using the
               <a href="#iri-compaction">IRI compaction algorithm</a>,
               passing <var>active context</var>, <var>inverse context</var>,
-              and the value of the <code>@id</code> <a>member</a> for <var>var</var>.</li>
-            <li>Otherwise, if <var>number members</var> is <code>1</code> and
+              and the value of the <code>@id</code> <a>entry</a> for <var>var</var>.</li>
+            <li>Otherwise, if <var>number entries</var> is <code>1</code> and
               the <a>type mapping</a> of <var>active property</var>
               is set to <code>@vocab</code>, return the result of using the
               <a href="#iri-compaction">IRI compaction algorithm</a>,
               passing <var>active context</var>, <var>inverse context</var>,
-              the value of the <code>@id</code> <a>member</a> for <var>var</var>, and
+              the value of the <code>@id</code> <a>entry</a> for <var>var</var>, and
               <code>true</code> for <var>vocab</var>.</li>
             <li>Otherwise, return <var>value</var> as is.</li>
           </ol>
         </li>
-        <li>Otherwise, if <var>value</var> has an <code>@type</code> <a>member</a> whose
+        <li>Otherwise, if <var>value</var> has an <code>@type</code> <a>entry</a> whose
           value matches the <a>type mapping</a> of <var>active property</var>,
-          return the value associated with the <code>@value</code> <a>member</a>
+          return the value associated with the <code>@value</code> <a>entry</a>
           of <var>value</var>.</li>
-        <li>Otherwise, if <var>value</var> has an <code>@language</code> <a>member</a> whose
+        <li>Otherwise, if <var>value</var> has an <code>@language</code> <a>entry</a> whose
           value matches the <a>language mapping</a> of
           <var>active property</var>, return the value associated with the
-          <code>@value</code> <a>member</a> of <var>value</var>.</li>
-        <li>Otherwise, if <var>number members</var> equals <code>1</code> and either
-          the value of the <code>@value</code> <a>member</a> is not a <a>string</a>,
+          <code>@value</code> <a>entry</a> of <var>value</var>.</li>
+        <li>Otherwise, if <var>number entries</var> equals <code>1</code> and either
+          the value of the <code>@value</code> <a>entry</a> is not a <a>string</a>,
           or the <var>active context</var> has no <a>default language</a>,
           or the <a>language mapping</a> of <var>active property</var>
           is set to <code>null</code>, return the value associated with the
-          <code>@value</code> <a>member</a>.</li>
+          <code>@value</code> <a>entry</a>.</li>
         <li>Otherwise:
           <ol class="changed">
             <li>Replace any value of <code>@type</code> in <var>value</var> with the result of using the
               <a href="#iri-compaction">IRI compaction algorithm</a>,
               passing <var>active context</var>, <var>inverse context</var>,
-              the value of the <code>@type</code> <a>member</a> for <var>var</var>, and
+              the value of the <code>@type</code> <a>entry</a> for <var>var</var>, and
               <code>true</code> for <var>vocab</var>.</li>
             <li>Replace each key in <var>value</var> with the result of using the
               <a href="#iri-compaction">IRI compaction algorithm</a>,
@@ -3946,7 +3946,7 @@
         The required input is an <var>element</var> to flatten.
         The optional inputs are the <var>context</var> used to compact the flattened document
         <span class="changed">and the <a data-link-for="JsonLdOptions">ordered</a> flag, used to order
-          <a>dictionary member</a> keys lexicographically, where noted</span>.
+          <a>map entry</a> keys lexicographically, where noted</span>.
         If not passed, <var>context</var> is set to <code>null</code>
         <span class="changed">and, the <a data-link-for="JsonLdOptions">ordered</a> flag is set to <code>false</code></span>.</p>
 
@@ -3963,12 +3963,12 @@
 
       <ol>
         <li>Initialize <var>node map</var> to a <a class="changed">dictionary</a> consisting of
-          a single <a>member</a> whose key is <code>@default</code> and whose value is
+          a single <a>entry</a> whose key is <code>@default</code> and whose value is
           an empty <a class="changed">dictionary</a>.</li>
         <li>Perform the <a href="#node-map-generation">Node Map Generation algorithm</a>, passing
           <var>element</var> and <var>node map</var>.</li>
         <li>Initialize <var>default graph</var> to the value of the <code>@default</code>
-          <a>member</a> of <var>node map</var>, which is a <a class="changed">dictionary</a> representing
+          <a>entry</a> of <var>node map</var>, which is a <a class="changed">dictionary</a> representing
           the <a>default graph</a>.</li>
         <li>For each key-value pair <var>graph name</var>-<var>graph</var> in <var>node map</var>
           where <var>graph name</var> is not <code>@default</code>,
@@ -3976,24 +3976,24 @@
           if <a data-link-for="JsonLdOptions">ordered</a> is <code>true</code></span>,
           perform the following steps:
           <ol>
-            <li>If <var>default graph</var> does not have a <var>graph name</var> <a>member</a>, create
+            <li>If <var>default graph</var> does not have a <var>graph name</var> <a>entry</a>, create
               one and initialize its value to a <a class="changed">dictionary</a> consisting of an
-              <code>@id</code> <a>member</a> whose value is set to <var>graph name</var>.</li>
-            <li>Reference the value associated with the <var>graph name</var> <a>member</a> in
+              <code>@id</code> <a>entry</a> whose value is set to <var>graph name</var>.</li>
+            <li>Reference the value associated with the <var>graph name</var> <a>entry</a> in
               <var>default graph</var> using the variable <var>entry</var>.</li>
-            <li>Add an <code>@graph</code> <a>member</a> to <var>entry</var> and set it to an
+            <li>Add an <code>@graph</code> <a>entry</a> to <var>entry</var> and set it to an
               empty <a>array</a>.</li>
             <li>For each <var>id</var>-<var>node</var> pair in <var>graph</var> ordered lexicographically by <var>id</var>
               <span class="changed">if <a data-link-for="JsonLdOptions">ordered</a> is <code>true</code></span>,
-              add <var>node</var> to the <code>@graph</code> <a>member</a> of <var>entry</var>,
-              unless the only <a>member</a> of <var>node</var> is <code>@id</code>.</li>
+              add <var>node</var> to the <code>@graph</code> <a>entry</a> of <var>entry</var>,
+              unless the only <a>entry</a> of <var>node</var> is <code>@id</code>.</li>
           </ol>
         </li>
         <li>Initialize an empty <a>array</a> <var>flattened</var>.</li>
         <li>For each <var>id</var>-<var>node</var> pair in <var>default graph</var> ordered lexicographically by <var>id</var>
           <span class="changed">if <a data-link-for="JsonLdOptions">ordered</a> is <code>true</code></span>,
           add <var>node</var> to <var>flattened</var>,
-          unless the only <a>member</a> of <var>node</var> is <code>@id</code>.</li>
+          unless the only <a>entry</a> of <var>node</var> is <code>@id</code>.</li>
         <li>If <var>context</var> is <code>null</code>, return <var>flattened</var>.</li>
         <li>Otherwise, return the result of <a>compacting</a> <var>flattened</var> according the
           <a href="#compaction-algorithm">Compaction algorithm</a> passing <var>context</var>
@@ -4013,27 +4013,27 @@
       representation of the <a>graphs</a> and <a>nodes</a>
       represented in the passed expanded document. All <a>nodes</a> that are not
       uniquely identified by an IRI get assigned a (new) <a>blank node identifier</a>.
-      The resulting <var>node map</var> will have a <a>dictionary member</a> for every graph in the document whose
-      value is another object with a <a>member</a> for every <a>node</a> represented in the document.
-      The default graph is stored under the <code>@default</code> <a>member</a>, all other graphs are
+      The resulting <var>node map</var> will have an <a>map entry</a> for every graph in the document whose
+      value is another object with a <a>entry</a> for every <a>node</a> represented in the document.
+      The default graph is stored under the <code>@default</code> <a>entry</a>, all other graphs are
       stored under their <a>graph name</a>.</p>
 
     <section class="informative">
       <h3>Overview</h3>
 
       <p>The algorithm recursively runs over an expanded JSON-LD document to
-        collect all <a>members</a> of a <a>node</a>
+        collect all <a>entries</a> of a <a>node</a>
         in a single <a class="changed">dictionary</a>. The algorithm updates a
         <a class="changed">dictionary</a> <var>node map</var> whose keys represent the
         <a>graph names</a> used in the document
-        (the <a>default graph</a> is stored under the <code>@default</code> <a>member</a>)
-        and whose associated values are <a class="changed">dictionaries</a>
+        (the <a>default graph</a> is stored under the <code>@default</code> <a>entry</a>)
+        and whose associated values are <a class="changed">maps</a>
         which index the <a>nodes</a> in the
         <a>graph</a>. If a
         <a data-lt="member">member's</a> value is a <a>node object</a>,
         it is replaced by a <a>node object</a> consisting of only an
-        <code>@id</code> <a>member</a>. If a <a>node object</a> has no <code>@id</code>
-        <a>member</a> or it is identified by a <a>blank node identifier</a>,
+        <code>@id</code> <a>entry</a>. If a <a>node object</a> has no <code>@id</code>
+        <a>entry</a> or it is identified by a <a>blank node identifier</a>,
         a new <a>blank node identifier</a> is generated. This relabeling
         of <a>blank node identifiers</a> is
         also done for <a>properties</a> and values of
@@ -4061,11 +4061,11 @@
         </li>
         <li>Otherwise <var>element</var> is a <a class="changed">dictionary</a>. Reference the
           <a class="changed">dictionary</a> which is the value of the <a>active graph</a>
-          <a>member</a> of <var>node map</var> using the variable <var>graph</var>. If the
+          <a>entry</a> of <var>node map</var> using the variable <var>graph</var>. If the
           <var>active subject</var> is <code>null</code>, set <var>node</var> to <code>null</code>
-          otherwise reference the <var>active subject</var> <a>member</a> of <var>graph</var> using the
+          otherwise reference the <var>active subject</var> <a>entry</a> of <var>graph</var> using the
           variable <var>subject node</var>.</li>
-        <li>If <var>element</var> has an <code>@type</code> <a>member</a>, perform for each
+        <li>If <var>element</var> has an <code>@type</code> <a>entry</a>, perform for each
           <var>item</var> the following steps:
           <ol>
             <li>If <var>item</var> is a <a>blank node identifier</a>, replace it with a newly
@@ -4073,105 +4073,105 @@
               passing <var>item</var> for <var>identifier</var>.</li>
           </ol>
         </li>
-        <li>If <var>element</var> has an <code>@value</code> <a>member</a>, perform the following steps:
+        <li>If <var>element</var> has an <code>@value</code> <a>entry</a>, perform the following steps:
           <ol>
             <li>If <var>list</var> is <code>null</code>:
               <ol>
-                <li>If <var>subject node</var> does not have an <var>active property</var> <a>member</a>,
+                <li>If <var>subject node</var> does not have an <var>active property</var> <a>entry</a>,
                   create one and initialize its value to an <a>array</a>
                   containing <var>element</var>.</li>
                 <li>Otherwise, compare <var>element</var> against every item in the
                   <a>array</a> associated with the <var>active property</var>
-                  <a>member</a> of <var>subject node</var>. If there is no item equivalent to <var>element</var>,
+                  <a>entry</a> of <var>subject node</var>. If there is no item equivalent to <var>element</var>,
                   append <var>element</var> to the <a>array</a>. Two
-                  <a class="changed">dictionaries</a> are considered
-                  equal if they have equivalent <a> dictionary members</a>.</li>
+                  <a class="changed">maps</a> are considered
+                  equal if they have equivalent <a> map entries</a>.</li>
               </ol>
             </li>
-            <li>Otherwise, append <var>element</var> to the <code>@list</code> <a>member</a> of <var>list</var>.</li>
+            <li>Otherwise, append <var>element</var> to the <code>@list</code> <a>entry</a> of <var>list</var>.</li>
           </ol>
         </li>
-        <li>Otherwise, if <var>element</var> has an <code>@list</code> <a>member</a>, perform
+        <li>Otherwise, if <var>element</var> has an <code>@list</code> <a>entry</a>, perform
           the following steps:
           <ol>
-            <li>Initialize a new <a class="changed">dictionary</a> <var>result</var> consisting of a single <a>member</a>
+            <li>Initialize a new <a class="changed">dictionary</a> <var>result</var> consisting of a single <a>entry</a>
               <code>@list</code> whose value is initialized to an empty <a>array</a>.</li>
             <li>Recursively call this algorithm passing the value of <var>element</var>'s
-              <code>@list</code> <a>member</a> for <var>element</var>, <var>node map</var>, <var>active graph</var>,
+              <code>@list</code> <a>entry</a> for <var>element</var>, <var>node map</var>, <var>active graph</var>,
               <var>active subject</var>, <var>active property</var>, and
               <var>result</var> for <var>list</var>.</li>
             <li class="changed">If <var>list</var> is <code>null</code>,
-              append <var>result</var> to the value of the <var>active property</var> <a>member</a>
+              append <var>result</var> to the value of the <var>active property</var> <a>entry</a>
               of <var>subject node</var>.</li>
-            <li class="changed">Otherwise, append <var>result</var> to the <code>@list</code> <a>member</a> of <var>list</var>.</li>
+            <li class="changed">Otherwise, append <var>result</var> to the <code>@list</code> <a>entry</a> of <var>list</var>.</li>
           </ol>
         </li>
         <li>Otherwise <var>element</var> is a <a>node object</a>, perform
           the following steps:
           <ol>
-            <li>If <var>element</var> has an <code>@id</code> <a>member</a>, set <var>id</var>
-              to its value and remove the <a>member</a> from <var>element</var>. If <var>id</var>
+            <li>If <var>element</var> has an <code>@id</code> <a>entry</a>, set <var>id</var>
+              to its value and remove the <a>entry</a> from <var>element</var>. If <var>id</var>
               is a <a>blank node identifier</a>, replace it with a newly
               <a href="#generate-blank-node-identifier">generated blank node identifier</a>
               passing <var>id</var> for <var>identifier</var>.</li>
             <li>Otherwise, set <var>id</var> to the result of the
               <a href="#generate-blank-node-identifier">Generate Blank Node Identifier algorithm</a>
               passing <code>null</code> for <var>identifier</var>.</li>
-            <li>If <var>graph</var> does not contain a <a>member</a> <var>id</var>, create one and initialize
-              its value to a <a class="changed">dictionary</a> consisting of a single <a>member</a> <code>@id</code> whose
+            <li>If <var>graph</var> does not contain a <a>entry</a> <var>id</var>, create one and initialize
+              its value to a <a class="changed">dictionary</a> consisting of a single <a>entry</a> <code>@id</code> whose
               value is <var>id</var>.</li>
-            <li>Reference the value of the <var>id</var> <a>member</a> of <var>graph</var> using the
+            <li>Reference the value of the <var>id</var> <a>entry</a> of <var>graph</var> using the
               variable <var>node</var>.</li>
             <li>If <var>active subject</var> is a <a class="changed">dictionary</a>, a reverse property relationship
               is being processed. Perform the following steps:
               <ol>
-                <li>If <var>node</var> does not have a <var>active property</var> <a>member</a>,
+                <li>If <var>node</var> does not have a <var>active property</var> <a>entry</a>,
                   create one and initialize its value to an <a>array</a>
                   containing <var>active subject</var>.</li>
                 <li>Otherwise, compare <var>active subject</var> against every item in the
                   <a>array</a> associated with the <var>active property</var>
-                  <a>member</a> of <var>node</var>. If there is no item equivalent to <var>active subject</var>,
+                  <a>entry</a> of <var>node</var>. If there is no item equivalent to <var>active subject</var>,
                   append <var>active subject</var> to the <a>array</a>. Two
-                  <a class="changed">dictionaries</a> are considered
-                  equal if they have equivalent <a>dictionary members</a>.</li>
+                  <a class="changed">maps</a> are considered
+                  equal if they have equivalent <a>map entries</a>.</li>
               </ol>
             </li>
             <li>Otherwise, if <var>active property</var> is not <code>null</code>, perform the following steps:
               <ol>
-                <li>Create a new <a class="changed">dictionary</a> <var>reference</var> consisting of a single <a>member</a>
+                <li>Create a new <a class="changed">dictionary</a> <var>reference</var> consisting of a single <a>entry</a>
                   <code>@id</code> whose value is <var>id</var>.</li>
                 <li>If <var>list</var> is <code>null</code>:
                   <ol>
-                    <li>If <var>subject node</var> does not have an <var>active property</var> <a>member</a>,
+                    <li>If <var>subject node</var> does not have an <var>active property</var> <a>entry</a>,
                       create one and initialize its value to an <a>array</a>
                       containing <var>reference</var>.</li>
                     <li>Otherwise, compare <var>reference</var> against every item in the
                       <a>array</a> associated with the <var>active property</var>
-                      <a>member</a> of <var>subject node</var>. If there is no item equivalent to <var>reference</var>,
+                      <a>entry</a> of <var>subject node</var>. If there is no item equivalent to <var>reference</var>,
                       append <var>reference</var> to the <a>array</a>. Two
-                      <a class="changed">dictionaries</a> are considered
-                      equal if they have equivalent <a>dictionary members</a>.</li>
+                      <a class="changed">maps</a> are considered
+                      equal if they have equivalent <a>map entries</a>.</li>
                   </ol>
                 </li>
-                <li>Otherwise, append <var class="changed">reference</var> to the <code>@list</code> <a>member</a> of <var>list</var>.</li>
+                <li>Otherwise, append <var class="changed">reference</var> to the <code>@list</code> <a>entry</a> of <var>list</var>.</li>
               </ol>
             </li>
-            <li>If <var>element</var> has a <code>@type</code> <a>member</a>, append
+            <li>If <var>element</var> has an <code>@type</code> <a>entry</a>, append
               each item of its associated <a>array</a> to the
-              <a>array</a> associated with the <code>@type</code> <a>member</a> of
+              <a>array</a> associated with the <code>@type</code> <a>entry</a> of
               <var>node</var> unless it is already in that <a>array</a>. Finally
-              remove the <code>@type</code> <a>member</a> from <var>element</var>.</li>
-            <li>If <var>element</var> has an <code>@index</code> <a>member</a>, set the <code>@index</code>
-              <a>member</a> of <var>node</var> to its value. If <a>node</a> has already an
-              <code>@index</code> <a>member</a> with a different value, a
+              remove the <code>@type</code> <a>entry</a> from <var>element</var>.</li>
+            <li>If <var>element</var> has an <code>@index</code> <a>entry</a>, set the <code>@index</code>
+              <a>entry</a> of <var>node</var> to its value. If <a>node</a> has already an
+              <code>@index</code> <a>entry</a> with a different value, a
               <a data-link-for="JsonLdErrorCode">conflicting indexes</a>
               error has been detected and processing is aborted. Otherwise, continue by
-              removing the <code>@index</code> <a>member</a> from <var>element</var>.</li>
-            <li>If <var>element</var> has an <code>@reverse</code> <a>member</a>:
+              removing the <code>@index</code> <a>entry</a> from <var>element</var>.</li>
+            <li>If <var>element</var> has an <code>@reverse</code> <a>entry</a>:
               <ol>
-                <li>Create a <a class="changed">dictionary</a> <var>referenced node</var> with a single <a>member</a> <code>@id</code> whose
+                <li>Create a <a class="changed">dictionary</a> <var>referenced node</var> with a single <a>entry</a> <code>@id</code> whose
                   value is <var>id</var>.</li>
-                <li>Set <var>reverse map</var> to the value of the <code>@reverse</code> <a>member</a> of
+                <li>Set <var>reverse map</var> to the value of the <code>@reverse</code> <a>entry</a> of
                   <var>element</var>.</li>
                 <li>For each key-value pair <var>property</var>-<var>values</var> in <var>reverse map</var>:
                   <ol>
@@ -4187,13 +4187,13 @@
                     </li>
                   </ol>
                 </li>
-                <li>Remove the <code>@reverse</code> <a>member</a> from <var>element</var>.</li>
+                <li>Remove the <code>@reverse</code> <a>entry</a> from <var>element</var>.</li>
               </ol>
             </li>
-            <li>If <var>element</var> has an <code>@graph</code> <a>member</a>, recursively invoke this
-              algorithm passing the value of the <code>@graph</code> <a>member</a> for <var>element</var>,
+            <li>If <var>element</var> has an <code>@graph</code> <a>entry</a>, recursively invoke this
+              algorithm passing the value of the <code>@graph</code> <a>entry</a> for <var>element</var>,
               <var>node map</var>, and <var>id</var> for <var>active graph</var> before removing
-              the <code>@graph</code> <a>member</a> from <var>element</var>.</li>
+              the <code>@graph</code> <a>entry</a> from <var>element</var>.</li>
             <li>Finally, for each key-value pair <var>property</var>-<var>value</var> in <var>element</var> ordered by
               <var>property</var> perform the following steps:
               <ol>
@@ -4202,7 +4202,7 @@
                   passing <var>property</var> for <var>identifier</var>.
                   <div class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
                     and may be removed in a future version of JSON-LD.</div></li>
-                <li>If <var>node</var> does not have a <var>property</var> <a>member</a>, create one and initialize
+                <li>If <var>node</var> does not have a <var>property</var> <a>entry</a>, create one and initialize
                   its value to an empty <a>array</a>.</li>
                 <li>Recursively invoke this algorithm passing <var>value</var> for <var>element</var>,
                   <var>node map</var>, <var>active graph</var>, <var>id</var> for <var>active subject</var>,
@@ -4274,7 +4274,7 @@
         and for each <var>id</var> and <var>node</var> in <var>node map</var>:
         <ol>
           <li>Set <var>merged node</var> to the value for <var>id</var> in <var>result</var>, initializing it
-            with a new <a>dictionary</a> consisting of a single <a>member</a> <code>@id</code> whose value is <var>id</var>, if it does not exist.</li>
+            with a new <a>dictionary</a> consisting of a single <a>entry</a> <code>@id</code> whose value is <var>id</var>, if it does not exist.</li>
           <li>For each <var>property</var> and <var>values</var> in <var>node</var>:
             <ol>
               <li>If <var>property</var> is a <a>keyword</a>, add <var>property</var> and values to <var>merged node</var>.</li>
@@ -4338,19 +4338,16 @@
         <a href="#node-map-generation">Node Map Generation algorithm</a>.
         This allows each graph represented within the document to be
         extracted and flattened, making it easier to process each
-        <a>node object</a>. Each graph from the <var>node map</var>
-        is processed to extract <a>RDF triple</a>,
-        to which any (non-default) graph name is applied to create an
-        <a>RDF dataset</a>. Each <a>node object</a> in the
-        <var>node map</var> has an <code>@id</code> <a>member</a> which corresponds to the
-        <a>RDF subject</a>, the other <a>members</a>
-        represent <a>RDF predicates</a>. Each
-        <a>member</a> value is either an <a>IRI</a> or
-        <a>blank node identifier</a> or can be transformed to an
-        <a>RDF literal</a>
-        to generate an <a>RDF triple</a>. <a>Lists</a>
-        are transformed into an
-        <a>RDF collection</a>
+        <a>node object</a>.
+        Each graph from the <var>node map</var> is processed to extract <a>RDF triple</a>,
+        to which any (non-default) graph name is applied to create an <a>RDF dataset</a>.
+        Each <a>node object</a> in the <var>node map</var> has an <code>@id</code> <a>entry</a>
+        which corresponds to the <a>RDF subject</a>,
+        the other <a>entries</a> represent <a>RDF predicates</a>.
+        Each <a>entry</a> value is either an <a>IRI</a> or <a>blank node identifier</a>
+        or can be transformed to an<a>RDF literal</a>
+        to generate an <a>RDF triple</a>.
+        <a>Lists</a> are transformed into an <a>RDF collection</a>
         using the <a href="#list-to-rdf-conversion">List to RDF Conversion algorithm.</a></p>
     </section>
 
@@ -4480,27 +4477,27 @@
 
       <ol>
         <li>If <var>item</var> is a <a>node object</a> and the value of
-          its <code>@id</code> <a>member</a> is
+          its <code>@id</code> <a>entry</a> is
           <span class="changed">not <a>well-formed</a></span>, return
           <code>null</code>.</li>
         <li>If <var>item</var> is a <a>node object</a>, return the
           <a>IRI</a> or <a>blank node identifier</a> associated
-          with its <code>@id</code> <a>member</a>.</li>
+          with its <code>@id</code> <a>entry</a>.</li>
         <li class="changed">If <var>item</var> is a <a>list object</a>
           return the result of the
           <a href="#list-to-rdf-conversion">List Conversion algorithm</a>, passing
-          the value associated with the <code>@list</code> <a>member</a> from
+          the value associated with the <code>@list</code> <a>entry</a> from
           <var>item</var> and <var>list triples</var>.
         </li>
         <li>Otherwise, <var>item</var> is a <a>value object</a>. Initialize
           <var>value</var> to the value associated with the <code>@value</code>
-          <a>member</a> in <var>item</var>.
+          <a>entry</a> in <var>item</var>.
         <li>Initialize <var>datatype</var> to the value associated with the
-          <code>@type</code> <a>member</a> of <var>item</var> or <code>null</code> if
-          <var>item</var> does not have such a <a>member</a>.</li>
+          <code>@type</code> <a>entry</a> of <var>item</var> or <code>null</code> if
+          <var>item</var> does not have such a <a>entry</a>.</li>
         <li class="changed">If <var>datatype</var> is not <a>well-formed</a>, return <code>null</code>.</li>
-        <li class="changed">If <var>item</var> has a <code>@language</code>
-          <a>member</a> which is not <a>well-formed</a>, return <code>null</code>.</li>
+        <li class="changed">If <var>item</var> has an <code>@language</code>
+          <a>entry</a> which is not <a>well-formed</a>, return <code>null</code>.</li>
         <li class="changed">If <var>datatype</var> is <code>@json</code>,
           convert <var>value</var> to the <a>canonical lexical form</a>
           using the result of transforming the <a>internal representation</a> of <var>value</var>
@@ -4541,11 +4538,11 @@
           <code>xsd:integer</code>.</li>
         <li>Otherwise, if <var>datatype</var> is <code>null</code>, set it to
           <code>xsd:string</code> or <code>rdf:langString</code>, depending on if
-          item has an <code>@language</code> <a>member</a>.</li>
+          item has an <code>@language</code> <a>entry</a>.</li>
         <li>Initialize <var>literal</var> as an <a>RDF literal</a> using
           <var>value</var> and <var>datatype</var>. If <var>item</var> has an
-          <code>@language</code> <a>member</a>, add the value associated with the
-          <code>@language</code> <a>member</a> as the <a>language tag</a> of <var>literal</var>.</li>
+          <code>@language</code> <a>entry</a>, add the value associated with the
+          <code>@language</code> <a>entry</a> as the <a>language tag</a> of <var>literal</var>.</li>
         <li>Return <var>literal</var>.</li>
       </ol>
     </section>
@@ -4647,7 +4644,7 @@
       <p>The algorithm takes one required and three optional inputs: an <a>RDF dataset</a>  <var>dataset</var>
         and the three flags <a data-link-for="JsonLdOptions">useNativeTypes</a>, <a data-link-for="JsonLdOptions">useRdfType</a>,
         <span class="changed">and the <a data-link-for="JsonLdOptions">ordered</a> flag, used to order
-          <a>dictionary member</a> keys lexicographically, where noted</span>
+          <a>map entry</a> keys lexicographically, where noted</span>
         that all default to <code>false</code>.</p>
 
       <p>The <var>dataset</var> is <a data-link-for="RdfDataset">iterable</a> to iterate over <a>graphs</a> and <a>graph names</a>
@@ -4657,7 +4654,7 @@
       <ol>
         <li>Initialize <var>default graph</var> to an empty <a class="changed">dictionary</a>.</li>
         <li>Initialize <var>graph map</var> to a <a class="changed">dictionary</a> consisting
-          of a single <a>member</a> <code>@default</code> whose value references
+          of a single <a>entry</a> <code>@default</code> whose value references
           <var>default graph</var>.</li>
         <li class="changed">Initialize <var>referenced once</var> to an empty <a>dictionary</a>.</li>
         <li>For each <var>graph</var> in  <var>dataset</var>:
@@ -4665,67 +4662,67 @@
             <li>If <var>graph</var> is the <a>default graph</a>,
               set <var>name</var> to <code>@default</code>, otherwise to the
               <a>graph name</a> associated with <var>graph</var>.</li>
-            <li>If <var>graph map</var> has no <var>name</var> <a>member</a>, create one and set
+            <li>If <var>graph map</var> has no <var>name</var> <a>entry</a>, create one and set
               its value to an empty <a class="changed">dictionary</a>.</li>
             <li>If <var>graph</var> is not the <a>default graph</a> and
-              <var>default graph</var> does not have a <var>name</var> <a>member</a>,
-              create such a <a>member</a> and initialize its value to a new
-              <a class="changed">dictionary</a> with a single <a>member</a> <code>@id</code>
+              <var>default graph</var> does not have a <var>name</var> <a>entry</a>,
+              create such a <a>entry</a> and initialize its value to a new
+              <a class="changed">dictionary</a> with a single <a>entry</a> <code>@id</code>
               whose value is <var>name</var>.</li>
-            <li>Reference the value of the <var>name</var> <a>member</a> in <var>graph map</var>
+            <li>Reference the value of the <var>name</var> <a>entry</a> in <var>graph map</var>
               using the variable <var>node map</var>.</li>
             <li>For each <a>RDF triple</a> in <var>graph</var>
               consisting of <var>subject</var>, <var>predicate</var>, and <var>object</var>:
               <ol>
-                <li>If <var>node map</var> does not have a <var>subject</var> <a>member</a>,
+                <li>If <var>node map</var> does not have a <var>subject</var> <a>entry</a>,
                   create one and initialize its value to a new <a class="changed">dictionary</a>
-                  consisting of a single <a>member</a> <code>@id</code> whose value is
+                  consisting of a single <a>entry</a> <code>@id</code> whose value is
                   set to <var>subject</var>.</li>
-                <li>Reference the value of the <var>subject</var> <a>member</a> in <var>node map</var>
+                <li>Reference the value of the <var>subject</var> <a>entry</a> in <var>node map</var>
                   using the variable <var>node</var>.</li>
                 <li>If <var>object</var> is an <a>IRI</a> or <a>blank node identifier</a>,
-                  and <var>node map</var> does not have an <var>object</var> <a>member</a>,
+                  and <var>node map</var> does not have an <var>object</var> <a>entry</a>,
                   create one and initialize its value to a new <a class="changed">dictionary</a>
-                  consisting of a single <a>member</a> <code>@id</code> whose value is
+                  consisting of a single <a>entry</a> <code>@id</code> whose value is
                   set to <var>object</var>.</li>
                 <li>If <var>predicate</var> equals <code>rdf:type</code>, the
                   <a data-link-for="JsonLdOptions">useRdfType</a> flag is not <code>true</code>, and <var>object</var>
                   is an <a>IRI</a> or <a>blank node identifier</a>,
                   append <var>object</var> to the value of the <code>@type</code>
-                  <a>member</a> of <var>node</var>; unless such an item already exists.
-                  If no such <a>member</a> exists, create one
+                  <a>entry</a> of <var>node</var>; unless such an item already exists.
+                  If no such <a>entry</a> exists, create one
                   and initialize it to an <a>array</a> whose only item is
                   <var>object</var>. Finally, continue to the next
                   <a>RDF triple</a>.</li>
                 <li>Set <var>value</var> to the result of using the
                   <a href="#rdf-to-object-conversion">RDF to Object Conversion algorithm</a>,
                   passing <var>object</var> and <a data-link-for="JsonLdOptions">useNativeTypes</a>.</li>
-                <li>If <var>node</var> does not have a <var>predicate</var> <a>member</a>, create one
+                <li>If <var>node</var> does not have a <var>predicate</var> <a>entry</a>, create one
                   and initialize its value to an empty <a>array</a>.</li>
                 <li>If there is no item equivalent to <var>value</var> in the <a>array</a>
-                  associated with the <var>predicate</var> <a>member</a> of <var>node</var>, append a
-                  reference to <var>value</var> to the <a>array</a>. Two <a>dictionaries</a>
-                  are considered equal if they have equivalent <a>dictionary members</a>.</li>
+                  associated with the <var>predicate</var> <a>entry</a> of <var>node</var>, append a
+                  reference to <var>value</var> to the <a>array</a>. Two <a>maps</a>
+                  are considered equal if they have equivalent <a>map entries</a>.</li>
                 <li class="changed">If <var>object</var> is <code>rdf:nil</code>, it represents
                   the termination of an <a>RDF collection</a>:
                   <ol>
-                    <li>Reference the <code>usages</code> <a>member</a> of the <var>object</var>
-                      <a>member</a> of <var>node map</var> using the variable <var>usages</var>.</li>
+                    <li>Reference the <code>usages</code> <a>entry</a> of the <var>object</var>
+                      <a>entry</a> of <var>node map</var> using the variable <var>usages</var>.</li>
                     <li>Append a new <a>dictionary</a> consisting of three
-                      <a>members</a>, <code>node</code>, <code>property</code>, and <code>value</code>
-                      to the <var>usages</var> <a>array</a>. The <code>node</code> <a>member</a>
+                      <a>entries</a>, <code>node</code>, <code>property</code>, and <code>value</code>
+                      to the <var>usages</var> <a>array</a>. The <code>node</code> <a>entry</a>
                       is set to a reference to <var>node</var>, <code>property</code> to <var>predicate</var>,
                       and <code>value</code> to a reference to <var>value</var>.</li>
                   </ol>
                 </li>
                 <li class="changed">Otherwise, if <var>referenced once</var> has an entry for <var>object</var>,
-                  set the <var>object</var> <a>member</a> of <var>referenced once</var> to <code>false</code>.</li>
+                  set the <var>object</var> <a>entry</a> of <var>referenced once</var> to <code>false</code>.</li>
                 <li class="changed">Otherwise, if <var>object</var> is a <a>blank node identifier</a>,
                   it might represent a list node:
                   <ol>
-                    <li>Set the <var>object</var> <a>member</a> of <var>referenced once</var> to a new <a>dictionary</a> consisting of three
-                      <a>member</a>s, <code>node</code>, <code>property</code>, and <code>value</code>
-                      to the <var>usages</var> <a>array</a>. The <code>node</code> <a>member</a>
+                    <li>Set the <var>object</var> <a>entry</a> of <var>referenced once</var> to a new <a>dictionary</a> consisting of three
+                      <a>entries</a>, <code>node</code>, <code>property</code>, and <code>value</code>
+                      to the <var>usages</var> <a>array</a>. The <code>node</code> <a>entry</a>
                       is set to a reference to <var>node</var>, <code>property</code> to <var>predicate</var>,
                       and <code>value</code> to a reference to <var>value</var>.</li>
                   </ol>
@@ -4736,56 +4733,56 @@
         </li>
         <li>For each <var>name</var> and <var>graph object</var> in <var>graph map</var>:
           <ol>
-            <li>If <var>graph object</var> has no <code>rdf:nil</code> <a>member</a>, continue
+            <li>If <var>graph object</var> has no <code>rdf:nil</code> <a>entry</a>, continue
               with the next <var>name</var>-<var>graph object</var> pair as the graph does
               not contain any lists that need to be converted.</li>
-            <li>Initialize <var>nil</var> to the value of the <code>rdf:nil</code> <a>member</a>
+            <li>Initialize <var>nil</var> to the value of the <code>rdf:nil</code> <a>entry</a>
               of <var>graph object</var>.</li>
-            <li>For each item <var>usage</var> in the <code>usages</code> <a>member</a> of
+            <li>For each item <var>usage</var> in the <code>usages</code> <a>entry</a> of
               <var>nil</var>, perform the following steps:
               <ol>
                 <li>Initialize <var>node</var> to the value of the value of the
-                  <code>node</code> <a>member</a> of <var>usage</var>, <var>property</var> to
-                  the value of the <code>property</code> <a>member</a> of <var>usage</var>,
-                  and <var>head</var> to the value of the <code>value</code> <a>member</a>
+                  <code>node</code> <a>entry</a> of <var>usage</var>, <var>property</var> to
+                  the value of the <code>property</code> <a>entry</a> of <var>usage</var>,
+                  and <var>head</var> to the value of the <code>value</code> <a>entry</a>
                   of <var>usage</var>.</li>
                 <li>Initialize two empty <a>arrays</a> <var>list</var>
                   and <var>list nodes</var>.</li>
                 <li>While <var>property</var> equals <code>rdf:rest</code>,
-                  <span class="changed">the value of the <code>@id</code> <a>member</a>
+                  <span class="changed">the value of the <code>@id</code> <a>entry</a>
                     of <var>node</var> is a <a>blank node identifier</a>,</span>
-                  the value of the <a>member</a> of <var>referenced once</var> associated with the <code>@id</code>
-                  <a>member</a> of <code>node</code> is a <a>dictionary</a>,
-                  <var>node</var> has <code>rdf:first</code> and <code>rdf:rest</code> <a>members</a>,
+                  the value of the <a>entry</a> of <var>referenced once</var> associated with the <code>@id</code>
+                  <a>entry</a> of <code>node</code> is a <a>dictionary</a>,
+                  <var>node</var> has <code>rdf:first</code> and <code>rdf:rest</code> <a>entries</a>,
                   both of which have as value an <a>array</a> consisting of a single element,
-                  and <var>node</var> has no other <a>members</a> apart from an optional <code>@type</code>
-                  <a>member</a> whose value is an array with a single item equal to
+                  and <var>node</var> has no other <a>entries</a> apart from an optional <code>@type</code>
+                  <a>entry</a> whose value is an array with a single item equal to
                   <code>rdf:List</code>,
                   <var>node</var> represents a <a>well-formed</a> list node.
                   Perform the following steps to traverse the list backwards towards its head:
                   <ol>
-                    <li>Append the only item of <code>rdf:first</code> <a>member</a> of
+                    <li>Append the only item of <code>rdf:first</code> <a>entry</a> of
                       <var>node</var> to the <var>list</var> <a>array</a>.</li>
-                    <li>Append the value of the <code>@id</code> <a>member</a> of
+                    <li>Append the value of the <code>@id</code> <a>entry</a> of
                       <var>node</var> to the <var>list nodes</var> <a>array</a>.</li>
-                    <li>Initialize <var>node usage</var> to the value of the <a>member</a> of <var>referenced once</var> associated with the <code>@id</code>
-                      <a>member</a> of <code>node</code>.</li>
-                    <li>Set <var>node</var> to the value of the <code>node</code> <a>member</a>
+                    <li>Initialize <var>node usage</var> to the value of the <a>entry</a> of <var>referenced once</var> associated with the <code>@id</code>
+                      <a>entry</a> of <code>node</code>.</li>
+                    <li>Set <var>node</var> to the value of the <code>node</code> <a>entry</a>
                       of <var>node usage</var>, <var>property</var> to the value of the
-                      <code>property</code> <a>member</a> of <var>node usage</var>, and
-                      <var>head</var> to the value of the <code>value</code> <a>member</a>
+                      <code>property</code> <a>entry</a> of <var>node usage</var>, and
+                      <var>head</var> to the value of the <code>value</code> <a>entry</a>
                       of <var>node usage</var>.</li>
-                    <li>If the <code>@id</code> <a>member</a> of <var>node</var> is an
+                    <li>If the <code>@id</code> <a>entry</a> of <var>node</var> is an
                       <a>IRI</a> instead of a <a>blank node identifier</a>,
                       exit the while loop.</li>
                   </ol>
                 </li>
-                <li>Remove the <code>@id</code> <a>member</a> from <var>head</var>.</li>
+                <li>Remove the <code>@id</code> <a>entry</a> from <var>head</var>.</li>
                 <li>Reverse the order of the <var>list</var> <a>array</a>.</li>
-                <li>Add an <code>@list</code> <a>member</a> to <var>head</var> and initialize
+                <li>Add an <code>@list</code> <a>entry</a> to <var>head</var> and initialize
                   its value to the <var>list</var> <a>array</a>.</li>
                 <li>For each item <var>node id</var> in <var>list nodes</var>, remove the
-                  <var>node id</var> <a>member</a> from <var>graph object</var>.</li>
+                  <var>node id</var> <a>entry</a> from <var>graph object</var>.</li>
               </ol>
             </li>
           </ol>
@@ -4795,20 +4792,20 @@
           ordered lexicographically by <var>subject</var>
           <span class="changed">if <a data-link-for="JsonLdOptions">ordered</a> is <code>true</code></span>:
           <ol>
-            <li>If <var>graph map</var> has a <var>subject</var> <a>member</a>:
+            <li>If <var>graph map</var> has a <var>subject</var> <a>entry</a>:
               <ol>
-                <li>Add an <code>@graph</code> <a>member</a> to <var>node</var> and initialize
+                <li>Add an <code>@graph</code> <a>entry</a> to <var>node</var> and initialize
                   its value to an empty <a>array</a>.</li>
                 <li>For each key-value pair <var>s</var>-<var>n</var> in the <var>subject</var>
-                  <a>member</a> of <var>graph map</var> ordered lexicographically by <var>s</var>
+                  <a>entry</a> of <var>graph map</var> ordered lexicographically by <var>s</var>
                   <span class="changed">if <a data-link-for="JsonLdOptions">ordered</a> is <code>true</code></span>,
-                  append <var>n</var> to the <code>@graph</code> <a>member</a> of <var>node</var> after
-                  removing its <code>usages</code> <a>member</a>, unless the only
-                  remaining <a>member</a> of <var>n</var> is <code>@id</code>.</li>
+                  append <var>n</var> to the <code>@graph</code> <a>entry</a> of <var>node</var> after
+                  removing its <code>usages</code> <a>entry</a>, unless the only
+                  remaining <a>entry</a> of <var>n</var> is <code>@id</code>.</li>
               </ol>
             </li>
             <li>Append <var>node</var> to <var>result</var> after removing its
-              <code>usages</code> <a>member</a>, unless the only remaining <a>member</a> of
+              <code>usages</code> <a>entry</a>, unless the only remaining <a>entry</a> of
               <var>node</var> is <code>@id</code>.</li>
           </ol>
         </li>
@@ -4857,7 +4854,7 @@
       <ol>
         <li>If <var>value</var> is an <a>IRI</a> or a
           <a>blank node identifier</a>, return a new <a class="changed">dictionary</a>
-          consisting of a single <a>member</a> <code>@id</code> whose value is set to
+          consisting of a single <a>entry</a> <code>@id</code> whose value is set to
           <var>value</var>.</li>
         <li>Otherwise <var>value</var> is an
           <a>RDF literal</a>:
@@ -4895,19 +4892,19 @@
             </li>
             <li class="changed">Otherwise, if <a>processing mode</a> is <code>json-ld-1.1</code>,
               and <var>value</var> is a <a>JSON literal</a>,
-              set the <code>@value</code> <a>member</a> to the result of
+              set the <code>@value</code> <a>entry</a> to the result of
               turning the lexical value of <var>value</var>
               into the <a>JSON-LD internal representation</a>, and set <var>type</var> to <code>@json</code>.</li>
             <li>Otherwise, if <var>value</var> is a
               <a>language-tagged string</a>
-              add a <a>member</a> <code>@language</code> to <var>result</var> and set its value to the
+              add a <a>entry</a> <code>@language</code> to <var>result</var> and set its value to the
               <a>language tag</a> of <var>value</var>.</li>
             <li>Otherwise, set <var>type</var> to the
               <a>datatype IRI</a>
               of <var>value</var>, unless it equals <code>xsd:string</code> which is ignored.</li>
-            <li>Add a <a>member</a> <code>@value</code> to <var>result</var> whose value
+            <li>Add a <a>entry</a> <code>@value</code> to <var>result</var> whose value
               is set to <var>converted value</var>.</li>
-            <li>If <var>type</var> is not <code>null</code>, add a <a>member</a> <code>@type</code>
+            <li>If <var>type</var> is not <code>null</code>, add a <a>entry</a> <code>@type</code>
               to <var>result</var> whose value is set to <var>type</var>.</li>
             <li>Return <var>result</var>.</li>
           </ol>
@@ -5037,7 +5034,7 @@
       <p>The example shows the value of "e" as a native JSON array including
         unnecessary whitespace, a number and an object. The result
         eliminates the whitespace, uses a canonical number representation,
-        and reorders the object members lexicographically:</p>
+        and reorders the <a>map entries</a> lexicographically:</p>
 
       <pre class="turtle result"
            data-content-type="text/turtle"
@@ -5096,7 +5093,7 @@
     <h3>Extract Script Content Algorithm</h3>
 
     <p>The algorithm extracts the text content a
-      <a>JSON-LD script element</a> into a <a>dictionary</a> or <a>array</a> of <a>dictionaries</a>.
+      <a>JSON-LD script element</a> into a <a>dictionary</a> or <a>array</a> of <a>maps</a>.
       A <dfn>JSON-LD script element</dfn> is a <a data-cite="HTML/scripting.html#the-script-element">script element</a>
       within an HTML [[HTML]] document with the <a data-cite="HTML/semantics.html#attr-link-type">type attribute</a> set to
       <code>application/ld+json</code>.</p>
@@ -5182,7 +5179,7 @@
             and <a data-lt="jsonldprocessor-compact-options">options</a>,
             <span class="changed">with <a data-link-for="JsonldOptions">ordered</a> set to <code>false</code></span>,
             <span class="changed">and <a data-link-for="JsonldOptions">extractAllScripts</a> defaulting to <code>false</code></span>.
-          <li>If <a data-lt="jsonldprocessor-compact-context">context</a> is a <a class="changed">dictionary</a> having an <code>@context</code> <a>member</a>,
+          <li>If <a data-lt="jsonldprocessor-compact-context">context</a> is a <a class="changed">dictionary</a> having an <code>@context</code> <a>entry</a>,
             set <var>context</var> to that <a data-lt="member">member's</a> value,
             otherwise to <a data-lt="jsonldprocessor-compact-context">context</a>.</li>
           <li class="changed">Initialize an <var>active context</var> using <var>context</var>;
@@ -5206,13 +5203,13 @@
         <dl class="parameters">
           <dt><dfn data-lt="jsonldprocessor-compact-input" data-lt-noDefault>input</dfn></dt>
            <dd>The <a class="changed">dictionary</a>,
-             array of <a class="changed">dictionaries</a> to perform the compaction upon,
+             array of <a class="changed">maps</a> to perform the compaction upon,
              or an <a>IRI</a> referencing the JSON-LD document to compact.</dd>
           <dt><dfn data-lt="jsonldprocessor-compact-context" data-lt-noDefault>context</dfn></dt>
           <dd>The context to use when <a>compacting</a> the <a data-lt="jsonldprocessor-compact-input">input</a>;
             it can be specified by using a <a class="changed">dictionary</a>,
             an <a>IRI</a>,
-            or an array consisting of <a class="changed">dictionaries</a> and <a>IRI</a>s.</dd>
+            or an array consisting of <a class="changed">maps</a> and <a>IRI</a>s.</dd>
           <dt><dfn data-lt="jsonldprocessor-compact-options" data-lt-noDefault>options</dfn></dt>
           <dd>A set of options to configure the algorithms.
             This allows, e.g., to set the input document's base <a>IRI</a>.</dd>
@@ -5245,7 +5242,7 @@
           <li>If an <a data-link-for="JsonldOptions">expandContext</a> option has been passed,
             update the <var>active context</var> using the <a href="#context-processing-algorithm">Context Processing algorithm</a>,
             passing the <a data-link-for="JsonldOptions">expandContext</a> as <var>local context</var>.
-            If <a data-link-for="JsonldOptions">expandContext</a> is a <a class="changed">dictionary</a> having an <code>@context</code> <a>member</a>,
+            If <a data-link-for="JsonldOptions">expandContext</a> is a <a class="changed">dictionary</a> having an <code>@context</code> <a>entry</a>,
             pass that <a data-lt="member">member's</a> value instead.</li>
           <li>If <var>remote document</var> has a <a data-link-for="RemoteDocument">contextUrl</a>,
             update the <var>active context</var> using the <a href="#context-processing-algorithm">Context Processing algorithm</a>,
@@ -5265,7 +5262,7 @@
         <dl class="parameters">
           <dt><dfn data-lt="jsonldprocessor-expand-input" data-lt-noDefault>input</dfn></dt>
           <dd>The <a class="changed">dictionary</a>,
-            or array of <a class="changed">dictionaries</a> to perform the expansion upon,
+            or array of <a class="changed">maps</a> to perform the expansion upon,
             or an <a>IRI</a> referencing the <a>JSON-LD document</a> to expand.</dd>
           <dt><dfn data-lt="jsonldprocessor-expand-options" data-lt-noDefault>options</dfn></dt>
           <dd>A set of options to configure the used algorithms.
@@ -5287,7 +5284,7 @@
             and <a data-lt="jsonldprocessor-flatten-options">options</a>
             <span class="changed">with <a data-link-for="JsonldOptions">ordered</a> set to <code>false</code></span>,
             <span class="changed">and <a data-link-for="JsonldOptions">extractAllScripts</a> defaulting to <code>true</code></span>.</li>
-          <li>If <a data-lt="jsonldprocessor-flatten-context">context</a> is a <a class="changed">dictionary</a> having an <code>@context</code> <a>member</a>,
+          <li>If <a data-lt="jsonldprocessor-flatten-context">context</a> is a <a class="changed">dictionary</a> having an <code>@context</code> <a>entry</a>,
             set <var>context</var> to that <a data-lt="member">member's</a> value,
             otherwise to <a data-lt="jsonldprocessor-flatten-context">context</a>.</li>
           <li class="changed">Initialize an <var>active context</var> using <var>context</var>;
@@ -5311,12 +5308,12 @@
         <dl class="parameters">
           <dt><dfn data-lt="jsonldprocessor-flatten-input" data-lt-noDefault>input</dfn></dt>
            <dd>The <a class="changed">dictionary</a>,
-             or array of <a class="changed">dictionaries</a>,
+             or array of <a class="changed">maps</a>,
              or an <a>IRI</a> referencing the JSON-LD document to flatten.</dd>
           <dt><dfn data-lt="jsonldprocessor-flatten-context" data-lt-noDefault>context</dfn></dt>
           <dd>The context to use when <a>compacting</a> the flattened <var>expanded input</var>;
             it can be specified by using a <a class="changed">dictionary</a>,
-            an <a>IRI</a>, or an array consisting of <a class="changed">dictionaries</a>
+            an <a>IRI</a>, or an array consisting of <a class="changed">maps</a>
             and <a>IRI</a>s.
             If not passed or <code>null</code> is passed,
             the result will not be compacted but kept in expanded form.</dd>
@@ -5350,7 +5347,7 @@
         <dl class="parameters">
           <dt><dfn data-lt="jsonldprocessor-fromRdf-input" data-lt-noDefault>input</dfn></dt>
            <dd>The <a class="changed">dictionary</a>,
-             or array of <a class="changed">dictionaries</a>,
+             or array of <a class="changed">maps</a>,
              or an <a>IRI</a> referencing the JSON-LD document to flatten.</dd>
           <dt><dfn data-lt="jsonldprocessor-fromRdf-options" data-lt-noDefault>options</dfn></dt>
           <dd>A set of options to configure the used algorithms.
@@ -5391,7 +5388,7 @@
         <dl class="parameters">
           <dt><dfn data-lt="jsonldprocessor-toRdf-input" data-lt-noDefault>input</dfn></dt>
            <dd>The <a class="changed">dictionary</a>,
-             or array of <a class="changed">dictionaries</a>,
+             or array of <a class="changed">maps</a>,
              or an <a>IRI</a> referencing the JSON-LD document to flatten.</dd>
           <dt><dfn data-lt="jsonldprocessor-toRdf-options" data-lt-noDefault>options</dfn></dt>
           <dd>A set of options to configure the used algorithms.
@@ -5404,7 +5401,7 @@
       dictionary JsonLdDictionary {};
     --></pre>
     <p class="changed">The <dfn>JsonLdDictionary</dfn> is the definition of a <a>dictionary</a>
-      used to contain arbitrary <a>dictionary members</a>
+      used to contain arbitrary <a>map entries</a>
       which are the result of parsing a <a>JSON Object</a>.
 
     <pre class="idl changed" data-transform="unComment"><!--
@@ -5413,7 +5410,7 @@
 
     <p class="changed">The <dfn>JsonLdInput</dfn> type is used to refer to an input value
       that that may be a <a>dictionary</a>,
-      an array of <a>dictionaries </a>,
+      an array of <a>maps </a>,
       or a <a>string</a> representing an <a>IRI</a>
       which can be dereferenced to retrieve a valid JSON document.</p>
 
@@ -5424,7 +5421,7 @@
     <p>The <dfn>JsonLdContext</dfn> type is used to refer to a value
       that may be a <a class="changed">dictionary</a>,
       a <a>string</a> representing an <a>IRI</a>,
-      or an array of <a class="changed">dictionaries</a> and <a>strings</a>.</p>
+      or an array of <a class="changed">maps</a> and <a>strings</a>.</p>
   </section>
 
   <section>
@@ -5960,24 +5957,24 @@
         <dt><dfn>cyclic IRI mapping</dfn></dt>
         <dd>A cycle in <a>IRI mappings</a> has been detected.</dd>
         <dt><dfn>invalid @id value</dfn></dt>
-        <dd>An <code>@id</code> <a>member</a> was encountered whose value was not a <a>string</a>.</dd>
+        <dd>An <code>@id</code> <a>entry</a> was encountered whose value was not a <a>string</a>.</dd>
         <dt><dfn>invalid @index value</dfn></dt>
-        <dd>An <code>@index</code> <a>member</a> was encountered whose value was not a <a>string</a>.</dd>
+        <dd>An <code>@index</code> <a>entry</a> was encountered whose value was not a <a>string</a>.</dd>
         <dt class="changed"><dfn>invalid @nest value</dfn></dt>
         <dd class="changed">An invalid value for <code>@nest</code> has been found.</dd>
         <dt class="changed"><dfn>invalid @prefix value</dfn></dt>
         <dd class="changed">An invalid value for <code>@prefix</code> has been found.</dd>
         <dt><dfn>invalid @reverse value</dfn></dt>
-        <dd>An invalid value for an <code>@reverse</code> <a>member</a> has been detected,
-          i.e., the value was not a <a class="changed">dictionary</a>.</dd>
+        <dd>An invalid value for an <code>@reverse</code> <a>entry</a> has been detected,
+          i.e., the value was not a <a class="changed">map</a>.</dd>
         <dt><dfn>invalid @version value</dfn></dt>
-        <dd>The <code>@version</code> <a>member</a> was used in a <a>context</a>
+        <dd>The <code>@version</code> <a>entry</a> was used in a <a>context</a>
           with an out of range value.</dd>
         <dt><dfn>invalid base IRI</dfn></dt>
         <dd>An invalid <a>base IRI</a> has been detected, i.e.,
           it is neither an <a>absolute IRI</a> nor <code>null</code>.</dd>
         <dt><dfn>invalid container mapping</dfn></dt>
-        <dd>An <code>@container</code> <a>member</a> was encountered
+        <dd>An <code>@container</code> <a>entry</a> was encountered
           whose value was not one of the following <a>strings</a>:
           <code>@list</code>,
           <code>@set</code>,
@@ -5994,7 +5991,7 @@
         <dd>An invalid value in a <a>language map</a> has been detected.
           It MUST be a <a>string</a> or an <a>array</a> of <a>strings</a>.</dd>
         <dt><dfn>invalid language mapping</dfn></dt>
-        <dd>An <code>@language</code> <a>member</a> in a <a>term definition</a>
+        <dd>An <code>@language</code> <a>entry</a> in a <a>term definition</a>
           was encountered whose value was neither a <a>string</a>
           nor <code>null</code> and thus invalid.</dd>
         <dt><dfn>invalid language-tagged string</dfn></dt>
@@ -6025,22 +6022,22 @@
           does not have an appropriate <a data-cite="HTML/semantics.html#attr-link-type">type attribute</a>.</dd>
         <dt><dfn>invalid set or list object</dfn></dt>
         <dd>A <a>set object</a> or <a>list object</a>
-          with disallowed <a>members</a>
+          with disallowed <a>entries</a>
           has been detected.</dd>
         <dt><dfn>invalid term definition</dfn></dt>
         <dd>An invalid <a>term definition</a> has been detected.</dd>
         <dt><dfn>invalid type mapping</dfn></dt>
-        <dd>An <code>@type</code> <a>member</a> in a <a>term definition</a>
+        <dd>An <code>@type</code> <a>entry</a> in a <a>term definition</a>
           was encountered whose value could not be expanded to an <a>absolute IRI</a>.</dd>
         <dt><dfn>invalid type value</dfn></dt>
-        <dd>An invalid value for an <code>@type</code> <a>member</a> has been detected,
+        <dd>An invalid value for an <code>@type</code> <a>entry</a> has been detected,
           i.e., the value was neither a <a>string</a> nor an <a>array</a> of <a>strings</a>.</dd>
         <dt><dfn>invalid typed value</dfn></dt>
         <dd>A <a>typed value</a> with an invalid type was detected.</dd>
         <dt><dfn>invalid value object</dfn></dt>
-        <dd>A <a>value object</a> with disallowed <a>members</a> has been detected.</dd>
+        <dd>A <a>value object</a> with disallowed <a>entries</a> has been detected.</dd>
         <dt><dfn>invalid value object value</dfn></dt>
-        <dd>An invalid value for the <code>@value</code> <a>member</a> of a <a>value object</a>
+        <dd>An invalid value for the <code>@value</code> <a>entry</a> of a <a>value object</a>
           has been detected,
           i.e., it is neither a <a>scalar</a> nor <code>null</code>.</dd>
         <dt><dfn>invalid vocab mapping</dfn></dt>
@@ -6106,7 +6103,7 @@
       the <a data-link-for="JsonLdOptions">frameExpansion</a> flag, to enable content associated with JSON-LD
       frames, which may not otherwise be valid <a>JSON-LD documents</a>.</li>
     <li>An <a>expanded term definition</a> can now have an
-      <code>@context</code> <a>member</a>, which defines a context used for values of
+      <code>@context</code> <a>entry</a>, which defines a context used for values of
       a <a>property</a> identified with such a <a>term</a>. This context is used
       in both the <a href="#expansion-algorithm">Expansion Algorithm</a> and
       <a href="#compaction-algorithm">Compaction Algorithm</a>.</li>
@@ -6114,9 +6111,9 @@
       for framing, to create a single graph from the <a data-lt="default graph">default</a>
       and <a>named graphs</a>.</li>
     <li>An <a>expanded term definition</a> can now have an
-      <code>@nest</code> <a>member</a>, which identifies a term expanding to
+      <code>@nest</code> <a>entry</a>, which identifies a term expanding to
       <code>@nest</code> which is used for containing <a>properties</a> using the same
-      <code>@nest</code> mapping. When expanding, the values of a <a>member</a>
+      <code>@nest</code> mapping. When expanding, the values of a <a>entry</a>
       expanding to <code>@nest</code> are treated as if they were contained
       within the enclosing <a>node object</a> directly.</li>
     <li><code>@container</code> values within an <a>expanded term definition</a> may now
@@ -6131,7 +6128,7 @@
     <li>The value for <code>@container</code> in an <a>expanded term definition</a>
       can also be an <a>array</a> containing any appropriate container
       keyword along with <code>@set</code> (other than <code>@list</code>).
-      This allows a way to ensure that such <a>member</a> values will always
+      This allows a way to ensure that such <a>entry</a> values will always
       be expressed in <a>array</a> form.</li>
     <li>Added support for the <a data-link-for="JsonLdOptions">compactToRelative</a> option to allow IRI compaction (<a href="#iri-compaction" class="sectionRef"></a>)
       to document relative IRIs to be disabled.</li>
@@ -6139,14 +6136,14 @@
       when compacting only if
       a <a>simple term definition</a> is used where the value ends with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
       or if their <a>expanded term definition</a> contains
-      a <code>@prefix</code> <a>member</a> with the value <code>true</code>. The 1.0 algorithm has
+      an <code>@prefix</code> <a>entry</a> with the value <code>true</code>. The 1.0 algorithm has
       been updated to only consider terms that map to a value that ends with a URI
       <a data-cite="RFC3986#section-2.2">gen-delim</a> character.</li>
     <li>Term definitions now allow <code>@container</code> to include <code>@graph</code>,
       along with <code>@id</code>, <code>@index</code> and <code>@set</code>.
       In the <a href="#expansion-algorithm">Expansion Algorithm</a>, this is
       used to create a <a>named graph</a> from either a <a>node object</a>, or
-      objects which are values of <a>members</a> in an <a>id map</a> or <a>index map</a>.
+      objects which are values of <a>entries</a> in an <a>id map</a> or <a>index map</a>.
       the <a href="#compaction-algorithm">Compaction Algorithm</a> allows
       specific forms of graph objects to be compacted back to a set of <a>node
       objects</a>, or maps of <a>node objects</a>.</li>
@@ -6161,7 +6158,7 @@
       transparently.</li>
     <li>The empty string (<code>&quot;&quot;</code>) has been added as a possible value for <code>@vocab</code> in
       a context. When this is set, vocabulary-relative IRIs, such as the
-      <a>members</a> of <a>node objects</a>, are expanded or compacted relative
+      <a>entries</a> of <a>node objects</a>, are expanded or compacted relative
       to the <a>base IRI</a> using string concatenation.</li>
   </ul>
   <p>Additionally, see <a href="#changes-from-cg" class="sectionRef"></a>.</p>
@@ -6170,21 +6167,21 @@
 <section class="appendix informative" id="changes-from-cg">
   <h2>Changes since JSON-LD Community Group Final Report</h2>
   <ul>
-    <li><a>Lists</a> may now have <a>members</a> which are themselves <a>lists</a>.</li>
+    <li><a>Lists</a> may now have items which are themselves <a>lists</a>.</li>
     <li>The <a href="#deserialize-json-ld-to-rdf-algorithm">Deserialize JSON-LD to RDF Algorithm</a>
       has been updated to ensure that only <a>well-formed</a> <a>triples</a>
       are emitted; previously, it only ensured that <a>triples</a> containing
       <a>relative IRIs</a> were excluded.</li>
     <li>The API now adds an <a data-link-for="JsonLdOptions">ordered</a>
        option, defaulting to <code>false</code> This is used in algorithms to
-       control interation of <a>dictionary member</a> keys. Previously, the
+       control interation of <a>map entry</a> keys. Previously, the
        algorithms always required such an order. The instructions for
        evaluating test results have been updated accordingly.</li>
     <li>The <a href="#generate-blank-node-identifier">Generate Blank Node Identifier algorithm</a>
       has been updated to remove the specifics of how new blank node
       identifiers are created.</li>
     <li>Values of <code>@type</code>, or an alais of <code>@type</code>, may now have their <code>@container</code> set to <code>@set</code>
-      to ensure that <code>@type</code> members are always represented as an array. This
+      to ensure that <code>@type</code> entries are always represented as an array. This
       also allows a term to be defined for <code>@type</code>, where the value MUST be a <a>dictionary</a>
       with <code>@container</code> set to <code>@set</code>.</li>
     <li>Updated the <a href="#iri-expansion">IRI Expansion algorithm</a> so that

--- a/index.html
+++ b/index.html
@@ -397,7 +397,7 @@
     -->
     </pre>
     <p>In the <a>internal representation</a>, the example above would be of a
-      <a>dictionary</a> containing <code>@context</code>, <code>@id</code>, <code>name</code>, and <code>knows</code> <a>entries</a>,
+      <a>map</a> containing <code>@context</code>, <code>@id</code>, <code>name</code>, and <code>knows</code> <a>entries</a>,
       with either <a>maps</a>, <a>strings</a>, or <a>arrays</a> of
       maps or strings values. In the JSON serialization, <a>JSON objects</a> are used
       for maps, while arrays and strings are serialized using a
@@ -721,7 +721,7 @@
       <a>node</a> may be spread across a number of different
       <a class="changed">maps</a>. By flattening a
       document, all <a>properties</a> of a <a>node</a> are collected in a single
-      <a class="changed">dictionary</a> and all <a>blank nodes</a>
+      <a class="changed">map</a> and all <a>blank nodes</a>
       are labeled with a <a>blank node identifier</a>. This may drastically
       simplify the code required to process JSON-LD data in certain applications.</p>
 
@@ -785,7 +785,7 @@
       where the algorithm's use of <a>maps</a> are replaced with <a>JSON objects</a>.</p>
 
     <p>Note how in the output above all <a>properties</a> of a <a>node</a> are collected in a
-      single <a class="changed">dictionary</a> and how the <a>blank node</a> representing
+      single <a class="changed">map</a> and how the <a>blank node</a> representing
       &quot;Dave Longley&quot; has been assigned the <a>blank node identifier</a>
       <code>_:b0</code>.</p>
 
@@ -828,7 +828,7 @@
     </aside>
 
     <p>Please note that the result of flattening and <a>compacting</a> a document
-      is always a <a class="changed">dictionary</a>,
+      is always a <a class="changed">map</a>,
       <span class="changed">(represented as a <a>JSON object</a> when serialized)</span>,
       which contains an <code>@graph</code>
       <a>entry</a> that represents the <a>default graph</a>.</p>
@@ -1038,7 +1038,7 @@
         the current <a>active context</a>. Then we normalize the form of the original
         <a>local context</a> to an <a>array</a>.
         <a>Local contexts</a> may be in the form of a
-        <a class="changed">dictionary</a>, a <a>string</a>, or an <a>array</a> containing
+        <a class="changed">map</a>, a <a>string</a>, or an <a>array</a> containing
         a combination of the two. Finally we process each <a>context</a> contained
         in the <a>local context</a> <a>array</a> as follows.</p>
 
@@ -1061,7 +1061,7 @@
         has been detected. Otherwise, we process <a>context</a> by recursively using
         this algorithm ensuring that there is no cyclical reference.</p>
 
-      <p>If <a>context</a> is a <a class="changed">dictionary</a>, we first update the
+      <p>If <a>context</a> is a <a class="changed">map</a>, we first update the
         <a>base IRI</a>, the <a>vocabulary mapping</a>, <a>processing mode</a>, and the
         <a>default language</a> by processing three specific keywords:
         <code>@base</code>, <code>@vocab</code>, <code>@version</code>, and <code>@language</code>.
@@ -1160,7 +1160,7 @@
                   <span class="changed">or cannot be transformed into the <a>internal representation</a></span>,
                   a <a data-link-for="JsonLdErrorCode">loading remote context failed</a>
                   error has been detected and processing is aborted. If the dereferenced document has no
-                  top-level <a class="changed">dictionary</a> with an <code>@context</code> <a>entry</a>, an
+                  top-level <a class="changed">map</a> with an <code>@context</code> <a>entry</a>, an
                   <a data-link-for="JsonLdErrorCode">invalid remote context</a>
                   has been detected and processing is aborted; otherwise,
                   set <var>context</var> to the value of that <a>entry</a>.</li>
@@ -1170,7 +1170,7 @@
                 <li>Continue with the next <var>context</var>.</li>
               </ol>
             </li>
-            <li>If <var>context</var> is not a <a class="changed">dictionary</a>, an
+            <li>If <var>context</var> is not a <a class="changed">map</a>, an
               <a data-link-for="JsonLdErrorCode">invalid local context</a>
               error has been detected and processing is aborted.</li>
             <li>If <var>context</var> has an <code>@base</code> <a>entry</a> and <var>remote contexts</var> is empty, i.e., the currently
@@ -1242,7 +1242,7 @@
                   error has been detected and processing is aborted.</li>
               </ol>
             </li>
-            <li>Create a <a class="changed">dictionary</a> <var>defined</var> to use to keep
+            <li>Create a <a class="changed">map</a> <var>defined</var> to use to keep
               track of whether or not a <a>term</a> has already been defined
               or currently being defined during recursion.</li>
             <li>For each <var>key</var>-<var>value</var> pair in <var>context</var> where
@@ -1324,7 +1324,7 @@
         <li class="changed">If <a>processing mode</a>
           is <code>json-ld-1.1</code>
           and <var>term</var> is <code>@type</code>, <var>value</var>
-          MUST be a <a>dictionary</a> with the entry <code>@container</code>
+          MUST be a <a>map</a> with the entry <code>@container</code>
           and value <code>@set</code>. Any other value means that a
           <a data-link-for="JsonLdErrorCode">keyword redefinition</a> error has
           been detected and processing is aborted.</li>
@@ -1337,13 +1337,13 @@
         <li>Otherwise, remove any <var>previous definition</var> from
           <var>active context</var>.</li>
         <li class="changed">If <var>value</var> is <code>null</code>,
-          convert it to a <a class="changed">dictionary</a> consisting of a single <a>entry</a> whose
+          convert it to a <a class="changed">map</a> consisting of a single <a>entry</a> whose
           key is <code>@id</code> and whose value is <code>null</code>.</li>
         <li>Otherwise, if <var>value</var> is a <a>string</a>, convert it
-          to a <a class="changed">dictionary</a> consisting of a single <a>entry</a> whose
+          to a <a class="changed">map</a> consisting of a single <a>entry</a> whose
           key is <code>@id</code> and whose value is <var>value</var>.
           <span class="changed">Set <var>simple term</var> to <code>true</code></span>.</li>
-        <li>Otherwise, <var>value</var> MUST be a <a class="changed">dictionary</a>, if not, an
+        <li>Otherwise, <var>value</var> MUST be a <a class="changed">map</a>, if not, an
           <a data-link-for="JsonLdErrorCode">invalid term definition</a>
           error has been detected and processing is aborted.
           <span class="changed">Set <var>simple term</var> to <code>false</code></span>.</li>
@@ -1763,7 +1763,7 @@
         <li>Otherwise, if the <var>element</var> is an <a>array</a>, then we expand
           each of its items recursively and return them in a new
           <a>array</a>.</li>
-        <li>Otherwise, <var>element</var> is a <a class="changed">dictionary</a>. We expand
+        <li>Otherwise, <var>element</var> is a <a class="changed">map</a>. We expand
           each of its <a>entries</a>, adding them to our <var>result</var>, and then we expand
           each value for each <a>entry</a> recursively. Some of the <a>entry</a> keys will be
           <a>terms</a> or
@@ -1799,8 +1799,8 @@
       <p class="changed">The algorithm also performs processing steps specific to expanding
         a <a>JSON-LD Frame</a>. For a <a>frame</a>, the <code>@id</code> and
         <code>@type</code> <a>entries</a> can accept an array of <a>IRIs</a> or
-        an empty <a>dictionary</a>. The <a>entries</a> of a <a>value object</a> can also
-        accept an <a>array</a> of <a>strings</a>, or an empty <a>dictionary</a>.
+        an empty <a>map</a>. The <a>entries</a> of a <a>value object</a> can also
+        accept an <a>array</a> of <a>strings</a>, or an empty <a>map</a>.
         Framing also uses additional keyword <a>entries</a>:
         (<code>@explicit</code>, <code>@default</code>,
         <code>@embed</code>, <code>@explicit</code>, <code>@omitDefault</code>, or
@@ -1853,7 +1853,7 @@
                   of <var>active property</var> includes <code>@list</code>,
                   and <var>expanded item</var> is an
                   <a>array</a>, set <var>expanded item</var> to a new
-                  <a>dictionary</a> containing the <a>entry</a>
+                  <a>map</a> containing the <a>entry</a>
                   <code>@list</code> where the value is the original
                   <var>expanded item</var>.</li>
                 <li>If <var>expanded item</var> is an <a>array</a>, append each
@@ -1864,7 +1864,7 @@
             <li>Return <var>result</var>.</li>
           </ol>
         </li>
-        <li>Otherwise <var>element</var> is a <a class="changed">dictionary</a>.</li>
+        <li>Otherwise <var>element</var> is a <a class="changed">map</a>.</li>
         <li class="changed">If <var>active context</var> has a <a>previous context</a>,
           the <var>active context</var> is type-scoped.
           If <var>from map</var> is undefined or <code>false</code>,
@@ -1938,7 +1938,7 @@
                   for <var>document relative</var>.
                   <span class="changed">
                     When the <a data-link-for="JsonLdOptions">frameExpansion</a> flag is set, <var>value</var>
-                    may be an empty <a>dictionary</a>, or an <a>array</a> of one
+                    may be an empty <a>map</a>, or an <a>array</a> of one
                     or more <a>strings</a>. <var>expanded value</var> will be
                     an <a>array</a> of one or more of these, with <a>string</a>
                     values expanded using the <a
@@ -1956,7 +1956,7 @@
                   or each of its items.
                   <span class="changed">
                     When the <a data-link-for="JsonLdOptions">frameExpansion</a> flag is set, <var>value</var>
-                    may also be an empty <a>dictionary</a>.
+                    may also be an empty <a>map</a>.
                   </span>
                   <div class="note">
                     No transformation from a <a>string</a> <var>value</var> to an <a>array</a>
@@ -1988,7 +1988,7 @@
                   on the existence of an <code>@value</code> <a>entry</a>.
                   <span class="changed">
                     When the <a data-link-for="JsonLdOptions">frameExpansion</a> flag is set, <var>value</var>
-                    may also be an empty <a>dictionary</a> or an array of
+                    may also be an empty <a>map</a> or an array of
                     <a>scalar</a> values. <var>expanded value</var> will be <a>null</a>, or an
                     <a>array</a> of one or more <a>scalar</a> values.</span></li>
                 <li>If <var>expanded property</var> is <code>@language</code> and
@@ -1998,7 +1998,7 @@
                   <span class="changed">
                     Otherwise, set <var>expanded value</var> to lowercased <var>value</var>.
                     When the <a data-link-for="JsonLdOptions">frameExpansion</a> flag is set, <var>value</var>
-                    may also be an empty <a>dictionary</a> or an array of zero or
+                    may also be an empty <a>map</a> or an array of zero or
                     <a>strings</a>. <var>expanded value</var> will be an
                     <a>array</a> of one or more <a>string</a> values converted to lower case.</span></li>
                 <li>If <var>expanded property</var> is <code>@index</code> and
@@ -2025,7 +2025,7 @@
                   <span class="changed">and the <a data-link-for="JsonLdOptions">frameExpansion</a>
                     and <a data-link-for="JsonLdOptions">ordered</a> flags</span>.</li>
                 <li>If <var>expanded property</var> is <code>@reverse</code> and
-                  <var>value</var> is not a <a class="changed">dictionary</a>, an
+                  <var>value</var> is not a <a class="changed">map</a>, an
                   <a data-link-for="JsonLdErrorCode">invalid @reverse value</a>
                   error has been detected and processing is aborted. Otherwise
                   <ol>
@@ -2048,7 +2048,7 @@
                     <li>If <var>expanded value</var> contains an <a>entry</a> other than <code>@reverse</code>:
                       <ol>
                         <li>If <var>result</var> does not have an <code>@reverse</code> <a>entry</a>, create
-                          one and set its value to an empty <a class="changed">dictionary</a>.</li>
+                          one and set its value to an empty <a class="changed">map</a>.</li>
                         <li>Reference the value of the <code>@reverse</code> <a>entry</a> in <var>result</var>
                           using the variable <var>reverse map</var>.</li>
                         <li>For each <var>property</var> and <var>items</var> in <var>expanded value</var>
@@ -2097,10 +2097,10 @@
               <var>active context</var>.</li>
             <li class="changed">If <var>key</var>'s <a>term definition</a> in <var>active context</var>
               has a <a>type mapping</a> of <code>@json</code>,
-              set <var>expanded value</var> to a new <a>dictionary</a>, set the <a>entry</a>
+              set <var>expanded value</var> to a new <a>map</a>, set the <a>entry</a>
               <code>@value</code> to <var>value</var>, and set the entry <code>@type</code> to <code>@json</code>.</li>
             <li>Otherwise, if <var>container mapping</var> <span class="changed">includes</span> <code>@language</code> and
-              <var>value</var> is a <a class="changed">dictionary</a> then <var>value</var>
+              <var>value</var> is a <a class="changed">map</a> then <var>value</var>
               is expanded from a <a>language map</a>
               as follows:
               <ol>
@@ -2119,7 +2119,7 @@
                           otherwise an
                           <a data-link-for="JsonLdErrorCode">invalid language map value</a>
                           error has been detected and processing is aborted.</li>
-                        <li>Append a <a class="changed">dictionary</a> to
+                        <li>Append a <a class="changed">map</a> to
                           <var>expanded value</var> that consists of two
                           key-value pairs: (<code>@value</code>-<var>item</var>)
                           and (<code>@language</code>-lowercased
@@ -2136,7 +2136,7 @@
             <li>Otherwise, if <var>container mapping</var>
               <span class="changed">includes</span> <code>@index</code>,
               <span class="changed"><code>@type</code>, or <code>@id</code></span> and
-              <var>value</var> is a <a class="changed">dictionary</a> then <var>value</var>
+              <var>value</var> is a <a class="changed">map</a> then <var>value</var>
               is expanded from an map as follows:
               <ol>
                 <li>Initialize <var>expanded value</var> to an empty <a>array</a>.</li>
@@ -2179,7 +2179,7 @@
                       <ol class="algorithm changed">
                         <li>If <var>container mapping</var> includes <code>@graph</code>
                           and if <var>item</var> is not a <a>graph object</a>,
-                          set <var>item</var> to a new <a>dictionary</a> containing the key-value pair
+                          set <var>item</var> to a new <a>map</a> containing the key-value pair
                           <code>@graph</code>-<var>item</var>,
                           ensuring that the value is represented using an <a>array</a>.</li>
                         <li class="changed">If <var>container mapping</var> includes <code>@index</code>,
@@ -2231,7 +2231,7 @@
               convert <var>expanded value</var> to a <a>list object</a>
               by first setting it to an <a>array</a> containing only
               <var>expanded value</var> if it is not already an <a>array</a>,
-              and then by setting it to a <a class="changed">dictionary</a> containing
+              and then by setting it to a <a class="changed">map</a> containing
               the key-value pair <code>@list</code>-<var>expanded value</var>.</li>
             <li class="changed">If <var>container mapping</var> <span>includes</span>
               <code>@graph</code>, convert <var>expanded value</var> into an <a>array</a>, if necessary,
@@ -2239,7 +2239,7 @@
               <a>graph object</a>:
               <ol>
                 <li>If <var>ev</var> is not a <a>graph object</a>, convert it into
-                  one by creating a <a>dictionary</a> containing the key-value
+                  one by creating a <a>map</a> containing the key-value
                   pair <code>@graph</code>-<var>ev</var>
                   where <var>ev</var> is represented as an <a>array</a>.</li>
               </ol>
@@ -2248,7 +2248,7 @@
               <var>key</var> indicates that it is a <a>reverse property</a>
               <ol>
                 <li>If <var>result</var> has no <code>@reverse</code> <a>entry</a>, create
-                  one and initialize its value to an empty <a class="changed">dictionary</a>.</li>
+                  one and initialize its value to an empty <a class="changed">map</a>.</li>
                 <li>Reference the value of the <code>@reverse</code> <a>entry</a> in <var>result</var>
                   using the variable <var>reverse map</var>.</li>
                 <li>If <var>expanded value</var> is not an <a>array</a>, set
@@ -2281,7 +2281,7 @@
                   in <var>element</var>, ensuring that it is an <a>array</a>.</li>
                 <li>For each <var>nested value</var> in <var>nested values</var>:
                   <ol>
-                    <li>If <var>nested value</var> is not a <a class="changed">dictionary</a>, or any key within
+                    <li>If <var>nested value</var> is not a <a class="changed">map</a>, or any key within
                       <var>nested value</var> expands to <code>@value</code>, an
                       <a data-link-for="JsonLdErrorCode">invalid @nest value</a> error
                       has been detected and processing is aborted.</li>
@@ -2338,13 +2338,13 @@
         <li>If <var>active property</var> is <code>null</code> or <code>@graph</code>,
           drop free-floating values as follows:
           <ol>
-            <li>If <var>result</var> is an empty <a class="changed">dictionary</a> or contains
+            <li>If <var>result</var> is an empty <a class="changed">map</a> or contains
               the <a>entries</a> <code>@value</code> or <code>@list</code>, set <var>result</var> to
               <code>null</code>.</li>
-            <li>Otherwise, if <var>result</var> is a <a class="changed">dictionary</a> whose only
+            <li>Otherwise, if <var>result</var> is a <a class="changed">map</a> whose only
               <a>entry</a> is <code>@id</code>, set <var>result</var> to <code>null</code>.
               <span class="changed">
-                When the <a data-link-for="JsonLdOptions">frameExpansion</a> flag is set, a <a>dictionary</a>
+                When the <a data-link-for="JsonLdOptions">frameExpansion</a> flag is set, a <a>map</a>
                 containing only the <code>@id</code> <a>entry</a> is retained.</span></li>
           </ol>
         </li>
@@ -2352,7 +2352,7 @@
       </ol>
 
       <p>If, after the above algorithm is run, the result is a
-        <a class="changed">dictionary</a> that contains only an <code>@graph</code> <a>entry</a>, set the
+        <a class="changed">map</a> that contains only an <code>@graph</code> <a>entry</a>, set the
         result to the value of <code>@graph</code>'s value. Otherwise, if the result
         is <code>null</code>, set it to an empty <a>array</a>. Finally, if
         the result is not an <a>array</a>, then set the result to an
@@ -2376,12 +2376,12 @@
       <p>If <a>active property</a> has a <a>type mapping</a> in the
         <a>active context</a> set to <code>@id</code> or <code>@vocab</code>,
         <span class="changed">and the value is a <a>string</a>,</span>
-        a <a class="changed">dictionary</a> with a single <a>entry</a> <code>@id</code> whose
+        a <a class="changed">map</a> with a single <a>entry</a> <code>@id</code> whose
         value is the result of using the
         <a href="#iri-expansion">IRI Expansion algorithm</a> on <var>value</var>
         is returned.</p>
 
-      <p>Otherwise, the result will be a <a class="changed">dictionary</a> containing
+      <p>Otherwise, the result will be a <a class="changed">map</a> containing
         an <code>@value</code> <a>entry</a> whose value is the passed <var>value</var>.
         Additionally, an <code>@type</code> <a>entry</a> will be included if there is a
         <a>type mapping</a> associated with the <a>active property</a>
@@ -2411,7 +2411,7 @@
           in <var>active context</var> that is <code>@id</code>,
           <span class="changed">and the <var>value</var> is a <a>string</a>,</span>
           return a new
-          <a class="changed">dictionary</a> containing a single <a>entry</a> where the
+          <a class="changed">map</a> containing a single <a>entry</a> where the
           key is <code>@id</code> and the value is the result of using the
           <a href="#iri-expansion">IRI Expansion algorithm</a>, passing
           <var>active context</var>, <var>value</var>, and <code>true</code> for
@@ -2420,13 +2420,13 @@
           <var>active context</var> that is <code>@vocab</code>,
           <span class="changed">and the <var>value</var> is a <a>string</a>,</span>
           return a new
-          <a class="changed">dictionary</a> containing a single <a>entry</a> where the
+          <a class="changed">map</a> containing a single <a>entry</a> where the
           key is <code>@id</code> and the value is the result of using the
           <a href="#iri-expansion">IRI Expansion algorithm</a>, passing
           <var>active context</var>, <var>value</var>, <code>true</code> for
           <var>vocab</var>, and <code>true</code> for
           <var>document relative</var>.</li>
-        <li>Otherwise, initialize <var>result</var> to a <a class="changed">dictionary</a>
+        <li>Otherwise, initialize <var>result</var> to a <a class="changed">map</a>
           with an <code>@value</code> <a>entry</a> whose value is set to
           <var>value</var>.</li>
         <li>If <var>active property</var> has a <a>type mapping</a> in
@@ -2492,7 +2492,7 @@
         <li>If the <var>element</var> is an <a>array</a>, we compact
           each of its items recursively and return them in a new
           <a>array</a>.</li>
-        <li>Otherwise <var>element</var> is a <a class="changed">dictionary</a>. The value
+        <li>Otherwise <var>element</var> is a <a class="changed">map</a>. The value
           of each <a>entry</a> in element is compacted recursively. Some of the <a>entry</a> keys will be
           compacted, using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
           to <a>terms</a> or <a>compact IRIs</a>
@@ -2506,8 +2506,8 @@
           maps.</li>
       </ol>
 
-      <p>The final output is a <a class="changed">dictionary</a> with an <code>@context</code>
-        <a>entry</a>, if a non-empty <a>context</a> was given, where the <a class="changed">dictionary</a>
+      <p>The final output is a <a class="changed">map</a> with an <code>@context</code>
+        <a>entry</a>, if a non-empty <a>context</a> was given, where the <a class="changed">map</a>
         is either <var>result</var> or a wrapper for it where <var>result</var> appears
         as the value of an (aliased) <code>@graph</code> <a>entry</a> because <var>result</var>
         contained two or more items in an <a>array</a>.</p>
@@ -2568,7 +2568,7 @@
             <li>Return <var>result</var>.</li>
           </ol>
         </li>
-        <li>Otherwise <var>element</var> is a <a class="changed">dictionary</a>.</li>
+        <li>Otherwise <var>element</var> is a <a class="changed">map</a>.</li>
         <li class="changed">If <var>active context</var> has a <a>previous context</a>,
           the <var>active context</var> is type-scoped.
           If <var>element</var> does not contain an <code>@value</code> <a>entry</a>,
@@ -2609,7 +2609,7 @@
         <li>Initialize <var>inside reverse</var> to <code>true</code> if
           <var>active property</var> equals <code>@reverse</code>,
           otherwise to <code>false</code>.</li>
-        <li>Initialize <var>result</var> to an empty <a class="changed">dictionary</a>.</li>
+        <li>Initialize <var>result</var> to an empty <a class="changed">map</a>.</li>
         <li class="changed">If <var>element</var> has an <code>@type</code> <a>entry</a>,
           create a new array <var>compacted types</var> initialized
           by transforming each <var>expanded type</var> of that <a>entry</a>
@@ -2735,7 +2735,7 @@
                   </ol>
                 </li>
                 <li>If <var>compacted value</var> has some remaining <a>map entries</a>, i.e.,
-                  it is not an empty <a class="changed">dictionary</a>:
+                  it is not an empty <a class="changed">map</a>:
                   <ol>
                     <li>Initialize <var>alias</var> to the result of using the
                       <a href="#iri-compaction">IRI Compaction algorithm</a>,
@@ -2798,7 +2798,7 @@
                   otherwise an <a data-link-for="JsonLdErrorCode">invalid @nest
                   value</a> error has been detected, and processing is aborted.
                   If <var>result</var> does not have a <var>nest term</var> <a>entry</a>,
-                  initialize it to an empty <a>dictionary</a> (<var>nest object</var>).
+                  initialize it to an empty <a>map</a> (<var>nest object</var>).
                   If <var>nest object</var> does not have an <var>item active property</var> <a>entry</a>,
                   set this <a data-lt="entry">entry's</a>
                   value in <var>nest object</var> to an empty
@@ -2832,7 +2832,7 @@
                   otherwise an <a data-link-for="JsonLdErrorCode">invalid @nest
                   value</a> error has been detected, and processing is aborted.
                   Set <var>nest result</var> to the value of <var>nest term</var> in <var>result</var>,
-                  initializing it to a new <a class="changed">dictionary</a>, if necessary; otherwise
+                  initializing it to a new <a class="changed">map</a>, if necessary; otherwise
                   set <var>nest result</var> to <var>result</var>.</li>
                 <li>Initialize <var>container</var> to <code>null</code>. If there
                   is a <a>container mapping</a> for
@@ -2864,7 +2864,7 @@
                       <ol>
                         <li>Convert <var>compacted item</var> to a
                           <a>list object</a> by setting it to a
-                          <a class="changed">dictionary</a> containing an <a>entry</a>
+                          <a class="changed">map</a> containing an <a>entry</a>
                           where the key is the result of the
                           <a href="#iri-compaction">IRI Compaction algorithm</a>,
                           passing <var>active context</var>, <var>inverse context</var>,
@@ -2944,7 +2944,7 @@
                     <li>Otherwise, <var>container</var> does not include <code>@graph</code>
                       or otherwise does not match one of the previous cases, redo <var>compacted item</var>.
                       <ol>
-                        <li>Set <var>compacted item</var> to a new dictionary containing
+                        <li>Set <var>compacted item</var> to a new map containing
                           the key resulting from calling the <a
                           href="#iri-compaction">IRI Compaction algorithm</a>
                           passing <var>active context</var>, <code>@graph</code> as
@@ -2985,7 +2985,7 @@
                     <span class="changed">and <var>container</var> does not include <code>@graph</code></span>:
                   <ol>
                     <li>If <var>item active property</var> is not an <a>entry</a> in
-                      <var class="changed">nest result</var>, initialize it to an empty <a class="changed">dictionary</a>.
+                      <var class="changed">nest result</var>, initialize it to an empty <a class="changed">map</a>.
                       Initialize <var>map object</var> to the value of <var>item active property</var>
                       in <var class="changed">nest result</var>.</li>
                     <li>Set <var>container key</var> to the result of calling the
@@ -3071,9 +3071,9 @@
       </ol>
 
       <p>If, after the algorithm outlined above is run, <var>result</var>
-        <span class="changed">is an empty <a>array</a>, replace it with a new <a>dictionary</a></span>.
+        <span class="changed">is an empty <a>array</a>, replace it with a new <a>map</a></span>.
         Otherwise, if <var>result</var> is an <a>array</a>, replace it with a new
-        <a class="changed">dictionary</a> with a single <a>entry</a> whose key is the result
+        <a class="changed">map</a> with a single <a>entry</a> whose key is the result
         of using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
         passing <var>active context</var>, <var>inverse context</var>, and
         <code>@graph</code> as <var>var</var> and whose value is the <a>array</a>
@@ -3141,7 +3141,7 @@
         the <a>inverse context</a> is being created for.</p>
 
       <ol>
-        <li>Initialize <var>result</var> to an empty <a class="changed">dictionary</a>.</li>
+        <li>Initialize <var>result</var> to an empty <a class="changed">map</a>.</li>
         <li>Initialize <var>default language</var> to <code>@none</code>. If the
           <var>active context</var> has a <a>default language</a>,
           set <var>default language</var> to it.</li>
@@ -3163,17 +3163,17 @@
               for the <a>term definition</a>.</li>
             <li>If <var>var</var> is not an <a>entry</a> of <var>result</var>, add
               a <a>entry</a> where the key is <var>var</var> and the value
-              is an empty <a class="changed">dictionary</a> to <var>result</var>.</li>
+              is an empty <a class="changed">map</a> to <var>result</var>.</li>
             <li>Reference the value associated with the <var>var</var> <a>entry</a> in
               <var>result</var> using the variable <var>container map</var>.</li>
             <li>If <var>container map</var> has no <var>container</var> <a>entry</a>,
               create one and set its value to a new
-              <a class="changed">dictionary</a> with <span class="changed">three</span> <a>entries</a>.
+              <a class="changed">map</a> with <span class="changed">three</span> <a>entries</a>.
               The first <a>entry</a> is <code>@language</code> and its value is a new empty
-              <a class="changed">dictionary</a>, the second <a>entry</a> is <code>@type</code>
-              and its value is a new empty <a class="changed">dictionary</a>,
+              <a class="changed">map</a>, the second <a>entry</a> is <code>@type</code>
+              and its value is a new empty <a class="changed">map</a>,
               <span class="changed">and the third <a>entry</a> is <code>@any</code>
-                and its value is a new <a>dictionary</a> with the <a>entry</a>
+                and its value is a new <a>map</a> with the <a>entry</a>
                 <code>@none</code> set to the <a>term</a> being processed</span>.</li>
             <li>Reference the value associated with the <var>container</var> <a>entry</a>
               in <var>container map</var> using the variable <var>type/language map</var>.</li>
@@ -3331,8 +3331,8 @@
               <a data-lt="active context">active context's</a>
               <a>default language</a>, if it has one, otherwise to
               <code>@none</code>.</li>
-            <li class="changed">If <var>value</var> is a <a>dictionary</a> containing
-              the member <code>@preserve</code>, use the first
+            <li class="changed">If <var>value</var> is a <a>map</a> containing
+              the <a>entry</a> <code>@preserve</code>, use the first
               element from the value of <code>@preserve</code> as <var>value</var>.</li>
             <li>Initialize <var>containers</var> to an empty <a>array</a>. This
               <a>array</a> will be used to keep track of an ordered list of
@@ -3348,7 +3348,7 @@
               variables will keep track of the preferred
               <a>type mapping</a> or <a>language mapping</a> for
               a <a>term</a>, based on what is compatible with <var>value</var>.</li>
-            <li>If <var>value</var> is a <a class="changed">dictionary</a>,
+            <li>If <var>value</var> is a <a class="changed">map</a>,
               that contains the an <code>@index</code> <a>entry</a>,
               <span class="changed">and <var>value</var> is not a <a>graph object</a></span>
               then append the values <code>@index</code> <span class="changed">and <code>@index@set</code></span> to <var>containers</var>.</li>
@@ -3919,7 +3919,7 @@
     <h2>Flattening Algorithm</h2>
 
     <p>This algorithm flattens an expanded JSON-LD document by collecting all
-      <a>properties</a> of a <a>node</a> in a single <a class="changed">dictionary</a>
+      <a>properties</a> of a <a>node</a> in a single <a class="changed">map</a>
       and labeling all <a>blank nodes</a> with
       <a>blank node identifiers</a>.
       This resulting uniform shape of the document, may drastically simplify
@@ -3931,7 +3931,7 @@
       <p>First, a <var>node map</var> is generated using the
         <a href="#node-map-generation">Node Map Generation algorithm</a>
         which collects all <a>properties</a> of a <a>node</a> in a single
-        <a class="changed">dictionary</a>. In the next step, the <var>node map</var> is
+        <a class="changed">map</a>. In the next step, the <var>node map</var> is
         converted to a JSON-LD document in
         <a data-cite="JSON-LD11#flattened-document-form">flattened document form</a>.
         Finally, if a <a>context</a> has been passed, the flattened document
@@ -3962,13 +3962,13 @@
         Thus, before this algorithm is run, the <var>identifier map</var> is reset.</p>
 
       <ol>
-        <li>Initialize <var>node map</var> to a <a class="changed">dictionary</a> consisting of
+        <li>Initialize <var>node map</var> to a <a class="changed">map</a> consisting of
           a single <a>entry</a> whose key is <code>@default</code> and whose value is
-          an empty <a class="changed">dictionary</a>.</li>
+          an empty <a class="changed">map</a>.</li>
         <li>Perform the <a href="#node-map-generation">Node Map Generation algorithm</a>, passing
           <var>element</var> and <var>node map</var>.</li>
         <li>Initialize <var>default graph</var> to the value of the <code>@default</code>
-          <a>entry</a> of <var>node map</var>, which is a <a class="changed">dictionary</a> representing
+          <a>entry</a> of <var>node map</var>, which is a <a class="changed">map</a> representing
           the <a>default graph</a>.</li>
         <li>For each key-value pair <var>graph name</var>-<var>graph</var> in <var>node map</var>
           where <var>graph name</var> is not <code>@default</code>,
@@ -3977,7 +3977,7 @@
           perform the following steps:
           <ol>
             <li>If <var>default graph</var> does not have a <var>graph name</var> <a>entry</a>, create
-              one and initialize its value to a <a class="changed">dictionary</a> consisting of an
+              one and initialize its value to a <a class="changed">map</a> consisting of an
               <code>@id</code> <a>entry</a> whose value is set to <var>graph name</var>.</li>
             <li>Reference the value associated with the <var>graph name</var> <a>entry</a> in
               <var>default graph</var> using the variable <var>entry</var>.</li>
@@ -4009,7 +4009,7 @@
   <section>
     <h2>Node Map Generation</h2>
 
-    <p>This algorithm creates a <a class="changed">dictionary</a> <var>node map</var> holding an indexed
+    <p>This algorithm creates a <a class="changed">map</a> <var>node map</var> holding an indexed
       representation of the <a>graphs</a> and <a>nodes</a>
       represented in the passed expanded document. All <a>nodes</a> that are not
       uniquely identified by an IRI get assigned a (new) <a>blank node identifier</a>.
@@ -4023,14 +4023,14 @@
 
       <p>The algorithm recursively runs over an expanded JSON-LD document to
         collect all <a>entries</a> of a <a>node</a>
-        in a single <a class="changed">dictionary</a>. The algorithm updates a
-        <a class="changed">dictionary</a> <var>node map</var> whose keys represent the
+        in a single <a class="changed">map</a>. The algorithm updates a
+        <a class="changed">map</a> <var>node map</var> whose keys represent the
         <a>graph names</a> used in the document
         (the <a>default graph</a> is stored under the <code>@default</code> <a>entry</a>)
         and whose associated values are <a class="changed">maps</a>
         which index the <a>nodes</a> in the
         <a>graph</a>. If a
-        <a data-lt="member">member's</a> value is a <a>node object</a>,
+        <a data-lt="entry">entry's</a> value is a <a>node object</a>,
         it is replaced by a <a>node object</a> consisting of only an
         <code>@id</code> <a>entry</a>. If a <a>node object</a> has no <code>@id</code>
         <a>entry</a> or it is identified by a <a>blank node identifier</a>,
@@ -4044,9 +4044,9 @@
       <h3>Algorithm</h3>
 
       <p>The algorithm takes as input an expanded JSON-LD document <var>element</var> and a reference to
-        a <a class="changed">dictionary</a> <var>node map</var>. Furthermore it has the optional parameters
+        a <a class="changed">map</a> <var>node map</var>. Furthermore it has the optional parameters
         <var>active graph</var> (which defaults to <code>@default</code>), an <var>active subject</var>,
-        <var>active property</var>, and a reference to a <a class="changed">dictionary</a> <var>list</var>. If
+        <var>active property</var>, and a reference to a <a class="changed">map</a> <var>list</var>. If
         not passed, <var>active subject</var>, <var>active property</var>, and <var>list</var> are
         set to <code>null</code>.</p>
 
@@ -4059,8 +4059,8 @@
               <var>active property</var>, and <var>list</var>.</li>
           </ol>
         </li>
-        <li>Otherwise <var>element</var> is a <a class="changed">dictionary</a>. Reference the
-          <a class="changed">dictionary</a> which is the value of the <a>active graph</a>
+        <li>Otherwise <var>element</var> is a <a class="changed">map</a>. Reference the
+          <a class="changed">map</a> which is the value of the <a>active graph</a>
           <a>entry</a> of <var>node map</var> using the variable <var>graph</var>. If the
           <var>active subject</var> is <code>null</code>, set <var>node</var> to <code>null</code>
           otherwise reference the <var>active subject</var> <a>entry</a> of <var>graph</var> using the
@@ -4094,7 +4094,7 @@
         <li>Otherwise, if <var>element</var> has an <code>@list</code> <a>entry</a>, perform
           the following steps:
           <ol>
-            <li>Initialize a new <a class="changed">dictionary</a> <var>result</var> consisting of a single <a>entry</a>
+            <li>Initialize a new <a class="changed">map</a> <var>result</var> consisting of a single <a>entry</a>
               <code>@list</code> whose value is initialized to an empty <a>array</a>.</li>
             <li>Recursively call this algorithm passing the value of <var>element</var>'s
               <code>@list</code> <a>entry</a> for <var>element</var>, <var>node map</var>, <var>active graph</var>,
@@ -4118,11 +4118,11 @@
               <a href="#generate-blank-node-identifier">Generate Blank Node Identifier algorithm</a>
               passing <code>null</code> for <var>identifier</var>.</li>
             <li>If <var>graph</var> does not contain a <a>entry</a> <var>id</var>, create one and initialize
-              its value to a <a class="changed">dictionary</a> consisting of a single <a>entry</a> <code>@id</code> whose
+              its value to a <a class="changed">map</a> consisting of a single <a>entry</a> <code>@id</code> whose
               value is <var>id</var>.</li>
             <li>Reference the value of the <var>id</var> <a>entry</a> of <var>graph</var> using the
               variable <var>node</var>.</li>
-            <li>If <var>active subject</var> is a <a class="changed">dictionary</a>, a reverse property relationship
+            <li>If <var>active subject</var> is a <a class="changed">map</a>, a reverse property relationship
               is being processed. Perform the following steps:
               <ol>
                 <li>If <var>node</var> does not have a <var>active property</var> <a>entry</a>,
@@ -4138,7 +4138,7 @@
             </li>
             <li>Otherwise, if <var>active property</var> is not <code>null</code>, perform the following steps:
               <ol>
-                <li>Create a new <a class="changed">dictionary</a> <var>reference</var> consisting of a single <a>entry</a>
+                <li>Create a new <a class="changed">map</a> <var>reference</var> consisting of a single <a>entry</a>
                   <code>@id</code> whose value is <var>id</var>.</li>
                 <li>If <var>list</var> is <code>null</code>:
                   <ol>
@@ -4169,7 +4169,7 @@
               removing the <code>@index</code> <a>entry</a> from <var>element</var>.</li>
             <li>If <var>element</var> has an <code>@reverse</code> <a>entry</a>:
               <ol>
-                <li>Create a <a class="changed">dictionary</a> <var>referenced node</var> with a single <a>entry</a> <code>@id</code> whose
+                <li>Create a <a class="changed">map</a> <var>referenced node</var> with a single <a>entry</a> <code>@id</code> whose
                   value is <var>id</var>.</li>
                 <li>Set <var>reverse map</var> to the value of the <code>@reverse</code> <a>entry</a> of
                   <var>element</var>.</li>
@@ -4181,7 +4181,7 @@
                           <var>element</var>, <var>node map</var>, <var>active graph</var>,
                           <var>referenced node</var> for <var>active subject</var>, and
                           <var>property</var> for <var>active property</var>. Passing a
-                          <a class="changed">dictionary</a> for <var>active subject</var> indicates to the
+                          <a class="changed">map</a> for <var>active subject</var> indicates to the
                           algorithm that a reverse property relationship is being processed.</li>
                       </ol>
                     </li>
@@ -4269,12 +4269,12 @@
       in each graph contained in the <var>node map</var>.</p>
 
     <ol>
-      <li>Create <var>result</var> as an empty <a>dictionary</a></li>
+      <li>Create <var>result</var> as an empty <a>map</a></li>
       <li>For each <var>graph name</var> and <var>node map</var> in <var>graph map</var>
         and for each <var>id</var> and <var>node</var> in <var>node map</var>:
         <ol>
           <li>Set <var>merged node</var> to the value for <var>id</var> in <var>result</var>, initializing it
-            with a new <a>dictionary</a> consisting of a single <a>entry</a> <code>@id</code> whose value is <var>id</var>, if it does not exist.</li>
+            with a new <a>map</a> consisting of a single <a>entry</a> <code>@id</code> whose value is <var>id</var>, if it does not exist.</li>
           <li>For each <var>property</var> and <var>values</var> in <var>node</var>:
             <ol>
               <li>If <var>property</var> is a <a>keyword</a>, add <var>property</var> and values to <var>merged node</var>.</li>
@@ -4296,7 +4296,7 @@
 
   <p>This section describes algorithms to deserialize a JSON-LD document to an
     <a>RDF dataset</a> and vice versa. The algorithms are designed for in-memory
-    implementations with random access to <a class="changed">dictionary</a> elements.</p>
+    implementations with random access to <a class="changed">map</a> elements.</p>
 
   <section>
     <h2>Deserialize JSON-LD to RDF Algorithm</h2>
@@ -4354,7 +4354,7 @@
     <section class="algorithm">
       <h3>Algorithm</h3>
 
-      <p>The algorithm takes a <a>dictionary</a> <var>node map</var>, which
+      <p>The algorithm takes a <a>map</a> <var>node map</var>, which
         is the result of the <a href="#node-map-generation">Node Map Generation algorithm</a> and
         an <a>RDF dataset</a> <var>dataset</var> into which new <a>graphs</a> and <a>triples</a> are added.
         Unless the <a data-link-for="JsonLdOptions">produceGeneralizedRdf</a> option
@@ -4652,22 +4652,22 @@
         for iterating over <a>triples</a> contained within the <a>RdfGraph</a>.</p>
 
       <ol>
-        <li>Initialize <var>default graph</var> to an empty <a class="changed">dictionary</a>.</li>
-        <li>Initialize <var>graph map</var> to a <a class="changed">dictionary</a> consisting
+        <li>Initialize <var>default graph</var> to an empty <a class="changed">map</a>.</li>
+        <li>Initialize <var>graph map</var> to a <a class="changed">map</a> consisting
           of a single <a>entry</a> <code>@default</code> whose value references
           <var>default graph</var>.</li>
-        <li class="changed">Initialize <var>referenced once</var> to an empty <a>dictionary</a>.</li>
+        <li class="changed">Initialize <var>referenced once</var> to an empty <a>map</a>.</li>
         <li>For each <var>graph</var> in  <var>dataset</var>:
           <ol>
             <li>If <var>graph</var> is the <a>default graph</a>,
               set <var>name</var> to <code>@default</code>, otherwise to the
               <a>graph name</a> associated with <var>graph</var>.</li>
             <li>If <var>graph map</var> has no <var>name</var> <a>entry</a>, create one and set
-              its value to an empty <a class="changed">dictionary</a>.</li>
+              its value to an empty <a class="changed">map</a>.</li>
             <li>If <var>graph</var> is not the <a>default graph</a> and
               <var>default graph</var> does not have a <var>name</var> <a>entry</a>,
               create such a <a>entry</a> and initialize its value to a new
-              <a class="changed">dictionary</a> with a single <a>entry</a> <code>@id</code>
+              <a class="changed">map</a> with a single <a>entry</a> <code>@id</code>
               whose value is <var>name</var>.</li>
             <li>Reference the value of the <var>name</var> <a>entry</a> in <var>graph map</var>
               using the variable <var>node map</var>.</li>
@@ -4675,14 +4675,14 @@
               consisting of <var>subject</var>, <var>predicate</var>, and <var>object</var>:
               <ol>
                 <li>If <var>node map</var> does not have a <var>subject</var> <a>entry</a>,
-                  create one and initialize its value to a new <a class="changed">dictionary</a>
+                  create one and initialize its value to a new <a class="changed">map</a>
                   consisting of a single <a>entry</a> <code>@id</code> whose value is
                   set to <var>subject</var>.</li>
                 <li>Reference the value of the <var>subject</var> <a>entry</a> in <var>node map</var>
                   using the variable <var>node</var>.</li>
                 <li>If <var>object</var> is an <a>IRI</a> or <a>blank node identifier</a>,
                   and <var>node map</var> does not have an <var>object</var> <a>entry</a>,
-                  create one and initialize its value to a new <a class="changed">dictionary</a>
+                  create one and initialize its value to a new <a class="changed">map</a>
                   consisting of a single <a>entry</a> <code>@id</code> whose value is
                   set to <var>object</var>.</li>
                 <li>If <var>predicate</var> equals <code>rdf:type</code>, the
@@ -4708,7 +4708,7 @@
                   <ol>
                     <li>Reference the <code>usages</code> <a>entry</a> of the <var>object</var>
                       <a>entry</a> of <var>node map</var> using the variable <var>usages</var>.</li>
-                    <li>Append a new <a>dictionary</a> consisting of three
+                    <li>Append a new <a>map</a> consisting of three
                       <a>entries</a>, <code>node</code>, <code>property</code>, and <code>value</code>
                       to the <var>usages</var> <a>array</a>. The <code>node</code> <a>entry</a>
                       is set to a reference to <var>node</var>, <code>property</code> to <var>predicate</var>,
@@ -4720,7 +4720,7 @@
                 <li class="changed">Otherwise, if <var>object</var> is a <a>blank node identifier</a>,
                   it might represent a list node:
                   <ol>
-                    <li>Set the <var>object</var> <a>entry</a> of <var>referenced once</var> to a new <a>dictionary</a> consisting of three
+                    <li>Set the <var>object</var> <a>entry</a> of <var>referenced once</var> to a new <a>map</a> consisting of three
                       <a>entries</a>, <code>node</code>, <code>property</code>, and <code>value</code>
                       to the <var>usages</var> <a>array</a>. The <code>node</code> <a>entry</a>
                       is set to a reference to <var>node</var>, <code>property</code> to <var>predicate</var>,
@@ -4752,7 +4752,7 @@
                   <span class="changed">the value of the <code>@id</code> <a>entry</a>
                     of <var>node</var> is a <a>blank node identifier</a>,</span>
                   the value of the <a>entry</a> of <var>referenced once</var> associated with the <code>@id</code>
-                  <a>entry</a> of <code>node</code> is a <a>dictionary</a>,
+                  <a>entry</a> of <code>node</code> is a <a>map</a>,
                   <var>node</var> has <code>rdf:first</code> and <code>rdf:rest</code> <a>entries</a>,
                   both of which have as value an <a>array</a> consisting of a single element,
                   and <var>node</var> has no other <a>entries</a> apart from an optional <code>@type</code>
@@ -4849,17 +4849,17 @@
       <h3>Algorithm</h3>
 
       <p>This algorithm takes two required inputs: a <var>value</var> to be converted
-        to a <a class="changed">dictionary</a> and a flag <a data-link-for="JsonLdOptions">useNativeTypes</a>.</p>
+        to a <a class="changed">map</a> and a flag <a data-link-for="JsonLdOptions">useNativeTypes</a>.</p>
 
       <ol>
         <li>If <var>value</var> is an <a>IRI</a> or a
-          <a>blank node identifier</a>, return a new <a class="changed">dictionary</a>
+          <a>blank node identifier</a>, return a new <a class="changed">map</a>
           consisting of a single <a>entry</a> <code>@id</code> whose value is set to
           <var>value</var>.</li>
         <li>Otherwise <var>value</var> is an
           <a>RDF literal</a>:
           <ol>
-            <li>Initialize a new empty <a class="changed">dictionary</a> result.</li>
+            <li>Initialize a new empty <a class="changed">map</a> result.</li>
             <li>Initialize <var>converted value</var> to <var>value</var>.</li>
             <li>Initialize <var>type</var> to <code>null</code></li>
             <li>If <a data-link-for="JsonLdOptions">useNativeTypes</a> is <code>true</code>
@@ -5093,7 +5093,7 @@
     <h3>Extract Script Content Algorithm</h3>
 
     <p>The algorithm extracts the text content a
-      <a>JSON-LD script element</a> into a <a>dictionary</a> or <a>array</a> of <a>maps</a>.
+      <a>JSON-LD script element</a> into a <a>map</a> or <a>array</a> of <a>maps</a>.
       A <dfn>JSON-LD script element</dfn> is a <a data-cite="HTML/scripting.html#the-script-element">script element</a>
       within an HTML [[HTML]] document with the <a data-cite="HTML/semantics.html#attr-link-type">type attribute</a> set to
       <code>application/ld+json</code>.</p>
@@ -5179,8 +5179,8 @@
             and <a data-lt="jsonldprocessor-compact-options">options</a>,
             <span class="changed">with <a data-link-for="JsonldOptions">ordered</a> set to <code>false</code></span>,
             <span class="changed">and <a data-link-for="JsonldOptions">extractAllScripts</a> defaulting to <code>false</code></span>.
-          <li>If <a data-lt="jsonldprocessor-compact-context">context</a> is a <a class="changed">dictionary</a> having an <code>@context</code> <a>entry</a>,
-            set <var>context</var> to that <a data-lt="member">member's</a> value,
+          <li>If <a data-lt="jsonldprocessor-compact-context">context</a> is a <a class="changed">map</a> having an <code>@context</code> <a>entry</a>,
+            set <var>context</var> to that <a data-lt="entry">entry's</a> value,
             otherwise to <a data-lt="jsonldprocessor-compact-context">context</a>.</li>
           <li class="changed">Initialize an <var>active context</var> using <var>context</var>;
             the <a>base IRI</a> is set to the <a data-link-for="JsonldOptions">base</a> option from <a data-lt="jsonldprocessor-compact-options">options</a>, if set;
@@ -5189,7 +5189,7 @@
             otherwise to <code>null</code>.</li>
           <li>Set <var>compacted output</var> to the result of using the <a href="#compaction-algorithm">Compaction algorithm</a>,
             using <a>active context</a>,
-            an empty <a>dictionary</a> as <var>inverse context</var>,
+            an empty <a>map</a> as <var>inverse context</var>,
             <code>null</code> as <var>property</var>,
             <var>expanded input</var> as <var>element</var>,
             and if passed, the <a data-link-for="JsonldOptions">compactArrays</a>
@@ -5202,12 +5202,12 @@
 
         <dl class="parameters">
           <dt><dfn data-lt="jsonldprocessor-compact-input" data-lt-noDefault>input</dfn></dt>
-           <dd>The <a class="changed">dictionary</a>,
+           <dd>The <a class="changed">map</a>,
              array of <a class="changed">maps</a> to perform the compaction upon,
              or an <a>IRI</a> referencing the JSON-LD document to compact.</dd>
           <dt><dfn data-lt="jsonldprocessor-compact-context" data-lt-noDefault>context</dfn></dt>
           <dd>The context to use when <a>compacting</a> the <a data-lt="jsonldprocessor-compact-input">input</a>;
-            it can be specified by using a <a class="changed">dictionary</a>,
+            it can be specified by using a <a class="changed">map</a>,
             an <a>IRI</a>,
             or an array consisting of <a class="changed">maps</a> and <a>IRI</a>s.</dd>
           <dt><dfn data-lt="jsonldprocessor-compact-options" data-lt-noDefault>options</dfn></dt>
@@ -5242,8 +5242,8 @@
           <li>If an <a data-link-for="JsonldOptions">expandContext</a> option has been passed,
             update the <var>active context</var> using the <a href="#context-processing-algorithm">Context Processing algorithm</a>,
             passing the <a data-link-for="JsonldOptions">expandContext</a> as <var>local context</var>.
-            If <a data-link-for="JsonldOptions">expandContext</a> is a <a class="changed">dictionary</a> having an <code>@context</code> <a>entry</a>,
-            pass that <a data-lt="member">member's</a> value instead.</li>
+            If <a data-link-for="JsonldOptions">expandContext</a> is a <a class="changed">map</a> having an <code>@context</code> <a>entry</a>,
+            pass that <a data-lt="entry">entry's</a> value instead.</li>
           <li>If <var>remote document</var> has a <a data-link-for="RemoteDocument">contextUrl</a>,
             update the <var>active context</var> using the <a href="#context-processing-algorithm">Context Processing algorithm</a>,
             passing the <a data-link-for="RemoteDocument">contextUrl</a> as <var>local context</var>.</li>
@@ -5261,7 +5261,7 @@
 
         <dl class="parameters">
           <dt><dfn data-lt="jsonldprocessor-expand-input" data-lt-noDefault>input</dfn></dt>
-          <dd>The <a class="changed">dictionary</a>,
+          <dd>The <a class="changed">map</a>,
             or array of <a class="changed">maps</a> to perform the expansion upon,
             or an <a>IRI</a> referencing the <a>JSON-LD document</a> to expand.</dd>
           <dt><dfn data-lt="jsonldprocessor-expand-options" data-lt-noDefault>options</dfn></dt>
@@ -5284,8 +5284,8 @@
             and <a data-lt="jsonldprocessor-flatten-options">options</a>
             <span class="changed">with <a data-link-for="JsonldOptions">ordered</a> set to <code>false</code></span>,
             <span class="changed">and <a data-link-for="JsonldOptions">extractAllScripts</a> defaulting to <code>true</code></span>.</li>
-          <li>If <a data-lt="jsonldprocessor-flatten-context">context</a> is a <a class="changed">dictionary</a> having an <code>@context</code> <a>entry</a>,
-            set <var>context</var> to that <a data-lt="member">member's</a> value,
+          <li>If <a data-lt="jsonldprocessor-flatten-context">context</a> is a <a class="changed">map</a> having an <code>@context</code> <a>entry</a>,
+            set <var>context</var> to that <a data-lt="entry">entry's</a> value,
             otherwise to <a data-lt="jsonldprocessor-flatten-context">context</a>.</li>
           <li class="changed">Initialize an <var>active context</var> using <var>context</var>;
             the <a>base IRI</a> is set to the <a data-link-for="JsonldOptions">base</a> option
@@ -5307,12 +5307,12 @@
 
         <dl class="parameters">
           <dt><dfn data-lt="jsonldprocessor-flatten-input" data-lt-noDefault>input</dfn></dt>
-           <dd>The <a class="changed">dictionary</a>,
+           <dd>The <a class="changed">map</a>,
              or array of <a class="changed">maps</a>,
              or an <a>IRI</a> referencing the JSON-LD document to flatten.</dd>
           <dt><dfn data-lt="jsonldprocessor-flatten-context" data-lt-noDefault>context</dfn></dt>
           <dd>The context to use when <a>compacting</a> the flattened <var>expanded input</var>;
-            it can be specified by using a <a class="changed">dictionary</a>,
+            it can be specified by using a <a class="changed">map</a>,
             an <a>IRI</a>, or an array consisting of <a class="changed">maps</a>
             and <a>IRI</a>s.
             If not passed or <code>null</code> is passed,
@@ -5346,7 +5346,7 @@
 
         <dl class="parameters">
           <dt><dfn data-lt="jsonldprocessor-fromRdf-input" data-lt-noDefault>input</dfn></dt>
-           <dd>The <a class="changed">dictionary</a>,
+           <dd>The <a class="changed">map</a>,
              or array of <a class="changed">maps</a>,
              or an <a>IRI</a> referencing the JSON-LD document to flatten.</dd>
           <dt><dfn data-lt="jsonldprocessor-fromRdf-options" data-lt-noDefault>options</dfn></dt>
@@ -5370,7 +5370,7 @@
             <span class="changed">with <a data-link-for="JsonldOptions">ordered</a> set to <code>false</code></span>,
             <span class="changed">and <a data-link-for="JsonldOptions">extractAllScripts</a> defaulting to <code>true</code></span>.</li>
           <li>Create a new <a>RdfDataset</a> <var>dataset</var>.</li>
-          <li>Create a new <a>dictionary</a> <var>node map</var>.</li>
+          <li>Create a new <a>map</a> <var>node map</var>.</li>
           <li>Invoke the <a href="#node-map-generation">Node Map Generation algorithm</a>,
             passing <var>expanded input</var> as <var>element</var>
             and <var>node map</var>.</li>
@@ -5387,7 +5387,7 @@
 
         <dl class="parameters">
           <dt><dfn data-lt="jsonldprocessor-toRdf-input" data-lt-noDefault>input</dfn></dt>
-           <dd>The <a class="changed">dictionary</a>,
+           <dd>The <a class="changed">map</a>,
              or array of <a class="changed">maps</a>,
              or an <a>IRI</a> referencing the JSON-LD document to flatten.</dd>
           <dt><dfn data-lt="jsonldprocessor-toRdf-options" data-lt-noDefault>options</dfn></dt>
@@ -5400,7 +5400,7 @@
     <pre class="idl changed" data-transform="unComment"><!--
       dictionary JsonLdDictionary {};
     --></pre>
-    <p class="changed">The <dfn>JsonLdDictionary</dfn> is the definition of a <a>dictionary</a>
+    <p class="changed">The <dfn>JsonLdDictionary</dfn> is the definition of a <a>map</a>
       used to contain arbitrary <a>map entries</a>
       which are the result of parsing a <a>JSON Object</a>.
 
@@ -5409,7 +5409,7 @@
     --></pre>
 
     <p class="changed">The <dfn>JsonLdInput</dfn> type is used to refer to an input value
-      that that may be a <a>dictionary</a>,
+      that that may be a <a>map</a>,
       an array of <a>maps </a>,
       or a <a>string</a> representing an <a>IRI</a>
       which can be dereferenced to retrieve a valid JSON document.</p>
@@ -5419,7 +5419,7 @@
     --></pre>
 
     <p>The <dfn>JsonLdContext</dfn> type is used to refer to a value
-      that may be a <a class="changed">dictionary</a>,
+      that may be a <a class="changed">map</a>,
       a <a>string</a> representing an <a>IRI</a>,
       or an array of <a class="changed">maps</a> and <a>strings</a>.</p>
   </section>
@@ -6182,7 +6182,7 @@
       identifiers are created.</li>
     <li>Values of <code>@type</code>, or an alais of <code>@type</code>, may now have their <code>@container</code> set to <code>@set</code>
       to ensure that <code>@type</code> entries are always represented as an array. This
-      also allows a term to be defined for <code>@type</code>, where the value MUST be a <a>dictionary</a>
+      also allows a term to be defined for <code>@type</code>, where the value MUST be a <a>map</a>
       with <code>@container</code> set to <code>@set</code>.</li>
     <li>Updated the <a href="#iri-expansion">IRI Expansion algorithm</a> so that
       if <var>value</var> contains a colon (<code>:</code>), but


### PR DESCRIPTION
For w3c/syntax#199.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/116.html" title="Last updated on Jul 10, 2019, 6:37 PM UTC (ecc116d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/116/a0a0893...ecc116d.html" title="Last updated on Jul 10, 2019, 6:37 PM UTC (ecc116d)">Diff</a>