### PR TITLE
`@container: @type` implies and requires that `@type` not be a literal.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1577,6 +1577,14 @@
               has been detected and processing is aborted.</li>
             <li>Set the <a>container mapping</a> of <var>definition</var> to
               <var>container</var>.</li>
+            <li class="changed">If <a>container mapping</a> is `@type`:
+              <ol>
+                <li>If <var>type mapping</var> in <var>definition</var> is undefined, set it to `@id`.</li>
+                <li>If <var>type mapping</var> in <var>definition</var> is neither `@id` nor `@vocab`,
+                  an <a data-link-for="JsonLdErrorCode">invalid type mapping</a>
+                  error has been detected and processing is aborted.</li>
+              </ol>
+            </li>
           </ol>
         </li>
         <li class="changed">If <var>value</var> contains the <a>entry</a> <code>@index</code>:
@@ -3097,13 +3105,26 @@
                     <li class="changed">Otherwise, if <var>container</var> includes <code>@id</code>, set
                       <var>map key</var> to the value of <var>container key</var> in
                       <var>compacted item</var> and remove <var>container key</var> from <var>compacted item</var>.</li>
-                    <li class="changed">Otherwise, if <var>container</var> is <code>@type</code>,
-                      set <var>map key</var> to the first value of <var>container key</var> in <var>compacted item</var>, if any.
-                      If there are remaining values in <var>compacted item</var>
-                      for <var>container key</var>, set the value of
-                      <var>container key</var> in <var>compacted item</var>
-                      to those remaining values. Otherwise, remove that
-                      <a>entry</a> from <var>compacted item</var>.</li>
+                    <li class="changed">Otherwise, if <var>container</var> is <code>@type</code>:
+                      <ol>
+                        <li>Set <var>map key</var> to the first value of <var>container key</var> in <var>compacted item</var>, if any.</li>
+                        <li>If there are remaining values in <var>compacted item</var>
+                          for <var>container key</var>, set the value of
+                          <var>container key</var> in <var>compacted item</var>
+                          to those remaining values.</li>
+                        <li>Otherwise, remove that <a>entry</a> from <var>compacted item</var>.</li>
+                        <li>If <var>compacted item</var> contains a single <a>entry</a> with a key expanding
+                          to `@id`, set <var>compacted item</var>
+                          to the result of using
+                          this algorithm recursively, passing
+                          <var>active context</var>, <var>inverse context</var>,
+                          <var>item active property</var> for <var>active property</var>,
+                          and a <a>map</a> composed of the single <a>entry</a> for `@id` from <var>expanded item</var> for <var>element</var>.
+                          <!-- Note: This will result in a string value, rather than a node object,
+                            because of either the implicit or explicit `@type` of `@id` or `@vocab` on <var>item active property</var>. -->
+                        </li>
+                      </ol>
+                    </li>
                     <li class="changed">If <var>compacted item</var> is not an
                       <a>array</a> and <var>as array</var> is <code>true</code>,
                       set <var>compacted item</var> to an <a>array</a> containing that value.</li>

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -1581,6 +1581,33 @@
       "expect": "compact/m019-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tm020",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "node reference compacts to string value of type map",
+      "purpose": "index on @type",
+      "input": "compact/m020-in.jsonld",
+      "context": "compact/m020-context.jsonld",
+      "expect": "compact/m020-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tm021",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "node reference compacts to string value of type map with @type: @id",
+      "purpose": "index on @type",
+      "input": "compact/m021-in.jsonld",
+      "context": "compact/m021-context.jsonld",
+      "expect": "compact/m021-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tm022",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "node reference compacts to string value of type map with @type: @vocab",
+      "purpose": "index on @type",
+      "input": "compact/m022-in.jsonld",
+      "context": "compact/m022-context.jsonld",
+      "expect": "compact/m022-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tn001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Indexes to @nest for property with @nest",

--- a/tests/compact/m020-context.jsonld
+++ b/tests/compact/m020-context.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/ns/",
+    "@base": "http://example.org/base/",
+    "foo": { "@container": "@type" }
+  }
+}

--- a/tests/compact/m020-in.jsonld
+++ b/tests/compact/m020-in.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example.org/ns/foo": [{
+    "@id": "http://example.org/base/baz",
+    "@type": [ "http://example.org/ns/bar" ]
+  }]
+}]

--- a/tests/compact/m020-out.jsonld
+++ b/tests/compact/m020-out.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/ns/",
+    "@base": "http://example.org/base/",
+    "foo": { "@container": "@type" }
+  },
+  "foo": {"bar": "baz"}
+}

--- a/tests/compact/m021-context.jsonld
+++ b/tests/compact/m021-context.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/ns/",
+    "@base": "http://example.org/base/",
+    "foo": { "@type": "@id", "@container": "@type" }
+  }
+}

--- a/tests/compact/m021-in.jsonld
+++ b/tests/compact/m021-in.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example.org/ns/foo": [{
+    "@id": "http://example.org/base/baz",
+    "@type": [ "http://example.org/ns/bar" ]
+  }]
+}]

--- a/tests/compact/m021-out.jsonld
+++ b/tests/compact/m021-out.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/ns/",
+    "@base": "http://example.org/base/",
+    "foo": { "@type": "@id", "@container": "@type" }
+  },
+  "foo": {"bar": "baz"}
+}

--- a/tests/compact/m022-context.jsonld
+++ b/tests/compact/m022-context.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/ns/",
+    "@base": "http://example.org/base/",
+    "foo": { "@type": "@vocab", "@container": "@type" }
+  }
+}

--- a/tests/compact/m022-in.jsonld
+++ b/tests/compact/m022-in.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example.org/ns/foo": [{
+    "@id": "http://example.org/ns/baz",
+    "@type": [ "http://example.org/ns/bar" ]
+  }]
+}]

--- a/tests/compact/m022-out.jsonld
+++ b/tests/compact/m022-out.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/ns/",
+    "@base": "http://example.org/base/",
+    "foo": { "@type": "@vocab", "@container": "@type" }
+  },
+  "foo": {"bar": "baz"}
+}

--- a/tests/compact/s001-out.jsonld
+++ b/tests/compact/s001-out.jsonld
@@ -11,7 +11,7 @@
   "mylist": ["foo"],
   "myset": ["foo"],
   "myid": {"http://example/id": {"@type": "http://example/type"}},
-  "mytype": {"http://example/type": {"@id": "http://example/id"}},
+  "mytype": {"http://example/type": "http://example/id"},
   "mylanguage": {"en": "foo"},
   "myindex": {"bar": "foo"}
 }

--- a/tests/compact/s002-out.jsonld
+++ b/tests/compact/s002-out.jsonld
@@ -7,7 +7,7 @@
   },
   "@id": "http://example.org/id",
   "myid": {"http://example/id": [{"@type": "http://example/type"}]},
-  "mytype": {"http://example/type": [{"@id": "http://example/id"}]},
+  "mytype": {"http://example/type": ["http://example/id"]},
   "mylanguage": {"en": ["foo"]},
   "myindex": {"bar": ["foo"]}
 }

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -1996,6 +1996,38 @@
       "expect": "expand/m016-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tm017",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "string value of type map expands to node reference",
+      "purpose": "index on @type",
+      "input": "expand/m017-in.jsonld",
+      "expect": "expand/m017-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tm018",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "string value of type map expands to node reference with @type: @id",
+      "purpose": "index on @type",
+      "input": "expand/m018-in.jsonld",
+      "expect": "expand/m018-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tm019",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "string value of type map expands to node reference with @type: @vocab",
+      "purpose": "index on @type",
+      "input": "expand/m019-in.jsonld",
+      "expect": "expand/m019-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tm020",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "string value of type map must not be a literal",
+      "purpose": "index on @type",
+      "input": "expand/m020-in.jsonld",
+      "expect": "invalid type mapping",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tn001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "Expands input using @nest",

--- a/tests/expand/m017-in.jsonld
+++ b/tests/expand/m017-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/ns/",
+    "@base": "http://example.org/base/",
+    "foo": { "@container": "@type" }
+  },
+  "foo": {"bar": "baz"}
+}

--- a/tests/expand/m017-out.jsonld
+++ b/tests/expand/m017-out.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example.org/ns/foo": [{
+    "@id": "http://example.org/base/baz",
+    "@type": [ "http://example.org/ns/bar" ]
+  }]
+}]

--- a/tests/expand/m018-in.jsonld
+++ b/tests/expand/m018-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/ns/",
+    "@base": "http://example.org/base/",
+    "foo": { "@type": "@id", "@container": "@type" }
+  },
+  "foo": {"bar": "baz"}
+}

--- a/tests/expand/m018-out.jsonld
+++ b/tests/expand/m018-out.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example.org/ns/foo": [{
+    "@id": "http://example.org/base/baz",
+    "@type": [ "http://example.org/ns/bar" ]
+  }]
+}]

--- a/tests/expand/m019-in.jsonld
+++ b/tests/expand/m019-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/ns/",
+    "@base": "http://example.org/base/",
+    "foo": { "@type": "@vocab", "@container": "@type" }
+  },
+  "foo": {"bar": "baz"}
+}

--- a/tests/expand/m019-out.jsonld
+++ b/tests/expand/m019-out.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example.org/ns/foo": [{
+    "@id": "http://example.org/ns/baz",
+    "@type": [ "http://example.org/ns/bar" ]
+  }]
+}]

--- a/tests/expand/m020-in.jsonld
+++ b/tests/expand/m020-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/ns/",
+    "@base": "http://example.org/base/",
+    "foo": { "@type": "literal", "@container": "@type" }
+  },
+  "foo": {"bar": "baz"}
+}

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -1639,6 +1639,38 @@
       "input": "toRdf/m016-in.jsonld",
       "expect": "toRdf/m016-out.nq",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+      }, {
+        "@id": "#tm017",
+        "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+        "name": "string value of type map expands to node reference",
+        "purpose": "index on @type",
+        "input": "toRdf/m017-in.jsonld",
+        "expect": "toRdf/m017-out.nq",
+        "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+      }, {
+        "@id": "#tm018",
+        "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+        "name": "string value of type map expands to node reference with @type: @id",
+        "purpose": "index on @type",
+        "input": "toRdf/m018-in.jsonld",
+        "expect": "toRdf/m018-out.nq",
+        "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+      }, {
+        "@id": "#tm019",
+        "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+        "name": "string value of type map expands to node reference with @type: @vocab",
+        "purpose": "index on @type",
+        "input": "toRdf/m019-in.jsonld",
+        "expect": "toRdf/m019-out.nq",
+        "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+      }, {
+        "@id": "#tm020",
+        "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
+        "name": "string value of type map must not be a literal",
+        "purpose": "index on @type",
+        "input": "toRdf/m020-in.jsonld",
+        "expect": "invalid type mapping",
+        "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tn001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],

--- a/tests/toRdf/m017-in.jsonld
+++ b/tests/toRdf/m017-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/ns/",
+    "@base": "http://example.org/base/",
+    "foo": { "@container": "@type" }
+  },
+  "foo": {"bar": "baz"}
+}

--- a/tests/toRdf/m017-out.nq
+++ b/tests/toRdf/m017-out.nq
@@ -1,0 +1,2 @@
+<http://example.org/base/baz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/ns/bar> .
+_:b0 <http://example.org/ns/foo> <http://example.org/base/baz> .

--- a/tests/toRdf/m018-in.jsonld
+++ b/tests/toRdf/m018-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/ns/",
+    "@base": "http://example.org/base/",
+    "foo": { "@type": "@id", "@container": "@type" }
+  },
+  "foo": {"bar": "baz"}
+}

--- a/tests/toRdf/m018-out.nq
+++ b/tests/toRdf/m018-out.nq
@@ -1,0 +1,2 @@
+<http://example.org/base/baz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/ns/bar> .
+_:b0 <http://example.org/ns/foo> <http://example.org/base/baz> .

--- a/tests/toRdf/m019-in.jsonld
+++ b/tests/toRdf/m019-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/ns/",
+    "@base": "http://example.org/base/",
+    "foo": { "@type": "@vocab", "@container": "@type" }
+  },
+  "foo": {"bar": "baz"}
+}

--- a/tests/toRdf/m019-out.nq
+++ b/tests/toRdf/m019-out.nq
@@ -1,0 +1,2 @@
+<http://example.org/ns/baz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/ns/bar> .
+_:b0 <http://example.org/ns/foo> <http://example.org/ns/baz> .

--- a/tests/toRdf/m020-in.jsonld
+++ b/tests/toRdf/m020-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/ns/",
+    "@base": "http://example.org/base/",
+    "foo": { "@type": "literal", "@container": "@type" }
+  },
+  "foo": {"bar": "baz"}
+}


### PR DESCRIPTION
Also, fix compaction of type maps to have string values instead of node references.

Fixes #121.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/123.html" title="Last updated on Jul 21, 2019, 9:55 PM UTC (e15feb1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/123/91311ff...e15feb1.html" title="Last updated on Jul 21, 2019, 9:55 PM UTC (e15feb1)">Diff</a>