### PR TITLE
Allow `@type` to be duplicated, either through aliasing, or nesting.

### DIFF
--- a/common/terms.html
+++ b/common/terms.html
@@ -331,7 +331,7 @@
     or an <a>expanded term definition</a>.
   </dd>
   <dt class="changed"><dfn data-cite="JSON-LD11#dfn-type-map">type map</dfn></dt><dd class="changed">
-    An <a>type map</a> is a <a>map</a> value of a <a>term</a>
+    A <a>type map</a> is a <a>map</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@type</code>,
     whose keys are interpreted as <a>IRIs</a>
     representing the <code>@type</code> of the associated <a>node object</a>;

--- a/index.html
+++ b/index.html
@@ -1971,7 +1971,8 @@
         <li class="changed">Set <var>type-scoped context</var> to <var>active context</var>.
           This is used for expanding values that may be relevant to any previous
           <a>type-scoped context</a>.</li>
-        <li class="changed">For each <var>key</var>/<var>value</var> pair in <var>element</var>
+        <li class="changed">For each <var>key</var> and <var>value</var> in <var>element</var>
+          ordered lexicographically by <var>key</var>
           where <var>key</var> expands to <code>@type</code> using the
           <a href="#iri-expansion">IRI Expansion algorithm</a>,
           passing <var>active context</var>, <var>key</var> for
@@ -1991,8 +1992,8 @@
         </li>
         <li>Initialize two empty <a class="changed">maps</a>, <var>result</var>
           <span class="changed">and <var>nests</var>.
-            Set <var>input type</var> to the last value of any <a>entry</a> of <var>element</var>
-            expanding to <code>@type</code></span>.
+            Set <var>input type</var> to the last value of the first <a>entry</a> in <var>element</var>
+            expanding to <code>@type</code>, ordering <a>entries</a> lexicographically by key</span>.
         </li>
         <li id="alg-expand-each-key-value">
           For each <var>key</var> and <var>value</var> in <var>element</var>,
@@ -2012,8 +2013,9 @@
                 <li>If <var>active property</var> equals <code>@reverse</code>, an
                   <a data-link-for="JsonLdErrorCode">invalid reverse property map</a>
                   error has been detected and processing is aborted.</li>
-                <li>If <var>result</var> has already an <var>expanded property</var> <a>entry</a>, a
-                  <a data-link-for="JsonLdErrorCode">colliding keywords</a>
+                <li>If <var>result</var> has already an <var>expanded property</var> <a>entry</a>,
+                  <span class="changed">other than `@type`</span>,
+                  a <a data-link-for="JsonLdErrorCode">colliding keywords</a>
                   error has been detected and processing is aborted.</li>
                 <li>If <var>expanded property</var> is <code>@id</code> and
                   <var>value</var> is not a <a>string</a>, an
@@ -2041,6 +2043,9 @@
                   <code>true</code> for <var>vocab</var>,
                   and <code>true</code> for <var>document relative</var> to expand the <var>value</var>
                   or each of its items.
+                  <span class="changed">If <var>result</var> already has an entry for `@type`,
+                    prepend the value of `@type` in <var>result</var> to <var>expanded value</var>,
+                    transforming it into an <a>array</a>, if necessary.</span>
                   <span class="changed">
                     When the <a data-link-for="JsonLdOptions">frameExpansion</a> flag is set, <var>value</var>
                     may also be an empty <a>map</a>.
@@ -2368,7 +2373,7 @@
                   in <var>element</var>, ensuring that it is an <a>array</a>.</li>
                 <li>For each <var>nested value</var> in <var>nested values</var>:
                   <ol>
-                    <li>If <var>nested value</var> is not a <a class="changed">map</a>, or any key within
+                    <li>If <var>nested value</var> is not a <a>map</a>, or any key within
                       <var>nested value</var> expands to <code>@value</code>, an
                       <a data-link-for="JsonLdErrorCode">invalid @nest value</a> error
                       has been detected and processing is aborted.</li>
@@ -6331,6 +6336,8 @@
     <li>A context may contain a <code>@import</code> <a>entry</a> used to reference a remote context
       within a context, allowing <code>JSON-LD 1.1</code> features to be added to contexts originally
       authored for <code>JSON-LD 1.0</code>.</li>
+    <li>The <a data-link-for="JsonLdErrorCode">colliding keywords</a> error is not issued for `@type`;
+      instead, previous values of `@type` are prepended to any new values, when expanding.</li>
   </ul>
 </section>
 

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -841,6 +841,14 @@
       "input": "expand/0113-in.jsonld",
       "expect": "expand/0113-out.jsonld"
     }, {
+      "@id": "#t0114",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Expansion allows multiple properties expanding to @type",
+      "purpose": "An exception for the colliding keywords error is made for @type",
+      "input": "expand/0114-in.jsonld",
+      "expect": "expand/0114-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tc001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "adding new term",
@@ -2082,6 +2090,14 @@
       "purpose": "Expansion using @nest",
       "input": "expand/n007-in.jsonld",
       "expect": "expand/n007-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tn008",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Multiple keys may mapping to @type when nesting",
+      "purpose": "Expansion using @nest",
+      "input": "expand/n008-in.jsonld",
+      "expect": "expand/n008-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tp001",

--- a/tests/expand/0114-in.jsonld
+++ b/tests/expand/0114-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "type1": "@type",
+    "type2": "@type"
+  },
+  "type1": "Type1",
+  "type2": "Type2"
+}

--- a/tests/expand/0114-out.jsonld
+++ b/tests/expand/0114-out.jsonld
@@ -1,0 +1,3 @@
+[{
+  "@type": ["http://example.org/Type1", "http://example.org/Type2"]
+}]

--- a/tests/expand/n008-in.jsonld
+++ b/tests/expand/n008-in.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "nest": "@nest"
+  },
+  "p1": "v1",
+  "nest": [
+    {"@type": "T1"},
+    {"@type": "T2"}
+  ]
+}

--- a/tests/expand/n008-out.jsonld
+++ b/tests/expand/n008-out.jsonld
@@ -1,0 +1,4 @@
+[{
+ "@type": ["http://example.org/T1", "http://example.org/T2"],
+ "http://example.org/p1": [{"@value": "v1"}]
+}]

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -1232,6 +1232,14 @@
       "input": "toRdf/e113-in.jsonld",
       "expect": "toRdf/e113-out.nq"
     }, {
+      "@id": "#te114",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Expansion allows multiple properties expanding to @type",
+      "purpose": "An exception for the colliding keywords error is made for @type",
+      "input": "toRdf/e114-in.jsonld",
+      "expect": "toRdf/e114-out.nq",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#th001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
       "name": "Transforms embedded JSON-LD script element",
@@ -1640,37 +1648,37 @@
       "expect": "toRdf/m016-out.nq",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
       }, {
-        "@id": "#tm017",
-        "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
-        "name": "string value of type map expands to node reference",
-        "purpose": "index on @type",
-        "input": "toRdf/m017-in.jsonld",
-        "expect": "toRdf/m017-out.nq",
-        "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
-      }, {
-        "@id": "#tm018",
-        "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
-        "name": "string value of type map expands to node reference with @type: @id",
-        "purpose": "index on @type",
-        "input": "toRdf/m018-in.jsonld",
-        "expect": "toRdf/m018-out.nq",
-        "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
-      }, {
-        "@id": "#tm019",
-        "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
-        "name": "string value of type map expands to node reference with @type: @vocab",
-        "purpose": "index on @type",
-        "input": "toRdf/m019-in.jsonld",
-        "expect": "toRdf/m019-out.nq",
-        "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
-      }, {
-        "@id": "#tm020",
-        "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
-        "name": "string value of type map must not be a literal",
-        "purpose": "index on @type",
-        "input": "toRdf/m020-in.jsonld",
-        "expect": "invalid type mapping",
-        "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+      "@id": "#tm017",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "string value of type map expands to node reference",
+      "purpose": "index on @type",
+      "input": "toRdf/m017-in.jsonld",
+      "expect": "toRdf/m017-out.nq",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tm018",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "string value of type map expands to node reference with @type: @id",
+      "purpose": "index on @type",
+      "input": "toRdf/m018-in.jsonld",
+      "expect": "toRdf/m018-out.nq",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tm019",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "string value of type map expands to node reference with @type: @vocab",
+      "purpose": "index on @type",
+      "input": "toRdf/m019-in.jsonld",
+      "expect": "toRdf/m019-out.nq",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tm020",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
+      "name": "string value of type map must not be a literal",
+      "purpose": "index on @type",
+      "input": "toRdf/m020-in.jsonld",
+      "expect": "invalid type mapping",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tn001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -1726,6 +1734,14 @@
       "purpose": "Expansion using @nest",
       "input": "toRdf/n007-in.jsonld",
       "expect": "toRdf/n007-out.nq",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tn008",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Multiple keys may mapping to @type when nesting",
+      "purpose": "Expansion using @nest",
+      "input": "toRdf/n008-in.jsonld",
+      "expect": "toRdf/n008-out.nq",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tnt01",

--- a/tests/toRdf/e114-in.jsonld
+++ b/tests/toRdf/e114-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "type1": "@type",
+    "type2": "@type"
+  },
+  "type1": "Type1",
+  "type2": "Type2"
+}

--- a/tests/toRdf/e114-out.nq
+++ b/tests/toRdf/e114-out.nq
@@ -1,0 +1,2 @@
+_:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/Type1> .
+_:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/Type2> .

--- a/tests/toRdf/n008-in.jsonld
+++ b/tests/toRdf/n008-in.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "nest": "@nest"
+  },
+  "p1": "v1",
+  "nest": [
+    {"@type": "T1"},
+    {"@type": "T2"}
+  ]
+}

--- a/tests/toRdf/n008-out.nq
+++ b/tests/toRdf/n008-out.nq
@@ -1,0 +1,3 @@
+_:b0 <http://example.org/p1> "v1" .
+_:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/T1> .
+_:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/T2> .


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/127.html" title="Last updated on Jul 26, 2019, 5:57 PM UTC (7165fb2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/127/74781a0...7165fb2.html" title="Last updated on Jul 26, 2019, 5:57 PM UTC (7165fb2)">Diff</a>