### PR TITLE
Updates and tests for `@included` as an array of node objects.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,10 @@
 GIT
   remote: https://github.com/ruby-rdf/json-ld.git
-  revision: 74095b73cdb722b681f34d0f165599c9cb48d844
+  revision: 172e0c960c9771fa9f963eca55d28fb63bce56b0
   branch: develop
   specs:
     json-ld (3.0.2)
+      htmlentities (~> 4.3)
       json-canonicalization (~> 0.1)
       link_header (~> 0.0, >= 0.0.8)
       multi_json (~> 1.13)
@@ -35,7 +36,7 @@ GEM
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     json-canonicalization (0.1.0)
-    json-ld-preloaded (3.0.2)
+    json-ld-preloaded (3.0.3)
       json-ld (~> 3.0)
       multi_json (~> 1.12)
       rdf (~> 3.0)
@@ -73,7 +74,7 @@ GEM
       sparql-client (~> 3.0)
     mini_portile2 (2.4.0)
     multi_json (1.13.1)
-    net-http-persistent (3.0.1)
+    net-http-persistent (3.1.0)
       connection_pool (~> 2.2)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
@@ -81,7 +82,7 @@ GEM
       nokogiri
     public_suffix (3.1.1)
     rack (2.0.7)
-    rake (12.3.2)
+    rake (12.3.3)
     rdf (3.0.12)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
@@ -133,7 +134,7 @@ GEM
     rdf-turtle (3.0.6)
       ebnf (~> 1.1)
       rdf (~> 3.0)
-    rdf-vocab (3.0.7)
+    rdf-vocab (3.0.8)
       rdf (~> 3.0, >= 3.0.11)
     rdf-xsd (3.0.1)
       rdf (~> 3.0)

--- a/common/jsonld.js
+++ b/common/jsonld.js
@@ -40,6 +40,19 @@ const jsonld = {
       status: 'unofficial',
       date: 'January 2014'
     },
+    "JSON.API": {
+      title: "JSON API",
+      href: "https://jsonapi.org/format/",
+      authors: [
+        'Steve Klabnik',
+        'Yehuda Katz',
+        'Dan Gebhardt',
+        'Tyler Kellen',
+        'Ethan Resnick'
+      ],
+      status: 'unofficial',
+      date: '29 May 2015'
+    },
     "JCS": {
       title: "JSON Canonicalization Scheme (JCS)",
       href: 'https://tools.ietf.org/html/draft-rundgren-json-canonicalization-scheme-05',

--- a/common/terms.html
+++ b/common/terms.html
@@ -225,6 +225,9 @@
     A <a>named graph</a> created from the value of a <a>map entry</a>
     having an <a>expanded term definition</a>
     where <code>@container</code> is set to  <code>@graph</code>.</dd>
+  <dt class="changed"><dfn data-cite="JSON-LD11#dfn-included-block">included block</dfn></dt><dd class="changed">
+    An <a>included block</a> is an <a>entry</a> in a <a>node object</a> where the key is `@included` or an alias
+    and the value is one ore more <a>node objects</a>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-index-map">index map</dfn></dt><dd>
     An <a>index map</a> is a <a>map</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@index</code>,

--- a/common/terms.html
+++ b/common/terms.html
@@ -226,7 +226,7 @@
     having an <a>expanded term definition</a>
     where <code>@container</code> is set to  <code>@graph</code>.</dd>
   <dt class="changed"><dfn data-cite="JSON-LD11#dfn-included-block">included block</dfn></dt><dd class="changed">
-    An <a>included block</a> is an <a>entry</a> in a <a>node object</a> where the key is `@included` or an alias
+    An <a>included block</a> is an <a>entry</a> in a <a>node object</a> where the key is either `@included` or an alias of `@included`
     and the value is one ore more <a>node objects</a>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-index-map">index map</dfn></dt><dd>
     An <a>index map</a> is a <a>map</a> value of a <a>term</a>

--- a/index.html
+++ b/index.html
@@ -4314,7 +4314,7 @@
               the <code>@graph</code> <a>entry</a> from <var>element</var>.</li>
             <li class="changed">If <var>element</var> has an `@included` <a>entry</a>,
               recursively invoke this algorithm passing the value of the `@included <a>entry</a> for <var>element</var>,
-              <var>node map</var>, <var>active subject</var>, <var>active property</var>, and <var>active graph</var>
+              <var>node map</var>, and <var>active graph</var>
               before removing the `@included` <a>entry</a> from <var>element</var>.</li>
             <li>Finally, for each key-value pair <var>property</var>-<var>value</var> in <var>element</var> ordered by
               <var>property</var> perform the following steps:

--- a/index.html
+++ b/index.html
@@ -2014,7 +2014,7 @@
                   <a data-link-for="JsonLdErrorCode">invalid reverse property map</a>
                   error has been detected and processing is aborted.</li>
                 <li>If <var>result</var> has already an <var>expanded property</var> <a>entry</a>,
-                  <span class="changed">other than `@type`</span>,
+                  <span class="changed">other than `@included` or `@type`</span>,
                   a <a data-link-for="JsonLdErrorCode">colliding keywords</a>
                   error has been detected and processing is aborted.</li>
                 <li>If <var>expanded property</var> is <code>@id</code> and
@@ -2064,6 +2064,19 @@
                     and <a data-link-for="JsonLdOptions">ordered</a> flags</span>,
                   <span class="changed">
                     ensuring that <var>expanded value</var> is an <a>array</a> of one or more <a>maps</a></span>.</li>
+                <li class="changed">If <var>expanded property</var> is `@included`
+                  and <a>processing mode</a> is `json-ld-1.1`,
+                  set <var>expanded value</var> to the result of using
+                  this algorithm recursively passing <var>active context</var>,
+                  <var>active property</var>, <var>value</var> for <var>element</var>,
+                  and the <a data-link-for="JsonLdOptions">frameExpansion</a>
+                  and <a data-link-for="JsonLdOptions">ordered</a> flags,
+                  ensuring that the result is an <a>array</a>.
+                  If any element of <var>included result</var> is not a <a>node object</a>,
+                  an <a data-link-for="JsonLdErrorCode">invalid @included value</a>
+                  error has been detected and processing is aborted.
+                  If <var>result</var> already has an entry for `@include`,
+                  prepend the value of `@include` in <var>result</var> to <var>expanded value</var>.</li>
                 <li>Otherwise, if <var>expanded property</var> is <code>@value</code>,
                   <span class="changed"><a>processing mode</a> is <code>json-ld-1.1</code>, and
                     <var>input type</var> is <code>@json</code>,
@@ -4299,6 +4312,10 @@
               algorithm passing the value of the <code>@graph</code> <a>entry</a> for <var>element</var>,
               <var>node map</var>, and <var>id</var> for <var>active graph</var> before removing
               the <code>@graph</code> <a>entry</a> from <var>element</var>.</li>
+            <li class="changed">If <var>element</var> has an `@included` <a>entry</a>,
+              recursively invoke this algorithm passing the value of the `@included <a>entry</a> for <var>element</var>,
+              <var>node map</var>, <var>active subject</var>, <var>active property</var>, and <var>active graph</var>
+              before removing the `@included` <a>entry</a> from <var>element</var>.</li>
             <li>Finally, for each key-value pair <var>property</var>-<var>value</var> in <var>element</var> ordered by
               <var>property</var> perform the following steps:
               <ol>
@@ -6021,6 +6038,7 @@
             "invalid context entry",
             "invalid context nullification",
             "invalid default language",
+            "invalid @included value",
             "invalid IRI mapping",
             "invalid keyword alias",
             "invalid language map value",
@@ -6179,6 +6197,8 @@
           containing <a>protected</a> <a>term definitions</a>.</dd>
         <dt class="changed"><dfn>protected term redefinition</dfn></dt>
         <dd class="changed">An attempt was made to redefine a <a>protected</a> term.</dd>
+        <dt class="changed"><dfn>invalid @included value</dfn></dt>
+        <dd class="changed">An <a>included block</a> contains an invalid value.</dd>
       </dl>
     </section>
   </section> <!-- end of Error Handling -->
@@ -6338,6 +6358,13 @@
       authored for <code>JSON-LD 1.0</code>.</li>
     <li>The <a data-link-for="JsonLdErrorCode">colliding keywords</a> error is not issued for `@type`;
       instead, previous values of `@type` are prepended to any new values, when expanding.</li>
+    <li>A <a>node object</a> may include an <a>included block</a>,
+      which is used to contain a set of <a>node objects</a> which are treated
+      exactly as if they were <a>node objects</a> defined in an <a>array</a> including the containing
+      <a>node object</a>.
+      This allows the use of the object form of a JSON-LD document when there is more
+      than one <a>node object</a> being defined, and where those <a>node objects</a>
+      are not embedded as values of the containing <a>node object</a>.</li>
   </ul>
 </section>
 

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -1329,6 +1329,51 @@
       "expect": "compact/h004-out.jsonld",
       "option": {"specVersion": "json-ld-1.1", "extractAllScripts": true}
     }, {
+      "@id": "#tin01",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Basic Included array",
+      "purpose": "Tests included maps.",
+      "input": "compact/in01-in.jsonld",
+      "context": "compact/in01-context.jsonld",
+      "expect": "compact/in01-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tin02",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Basic Included object",
+      "purpose": "Tests included maps.",
+      "input": "compact/in02-in.jsonld",
+      "context": "compact/in02-context.jsonld",
+      "expect": "compact/in02-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tin03",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Multiple properties mapping to @included are folded together",
+      "purpose": "Tests included maps.",
+      "input": "compact/in03-in.jsonld",
+      "context": "compact/in03-context.jsonld",
+      "expect": "compact/in03-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tin04",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Included containing @included",
+      "purpose": "Tests included maps.",
+      "input": "compact/in04-in.jsonld",
+      "context": "compact/in04-context.jsonld",
+      "expect": "compact/in04-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tin05",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Property value with @included",
+      "purpose": "Tests included maps.",
+      "input": "compact/in05-in.jsonld",
+      "context": "compact/in05-context.jsonld",
+      "expect": "compact/in05-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tjs01",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Compact JSON literal (boolean true)",

--- a/tests/compact/in01-context.jsonld
+++ b/tests/compact/in01-context.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/",
+    "included": {"@id": "@included", "@container": "@set"}
+  }
+}

--- a/tests/compact/in01-in.jsonld
+++ b/tests/compact/in01-in.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example.org/prop": [{"@value": "value"}],
+  "@included": [{
+    "http://example.org/prop": [{"@value": "value2"}]
+  }]
+}]

--- a/tests/compact/in01-out.jsonld
+++ b/tests/compact/in01-out.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/",
+    "included": {"@id": "@included", "@container": "@set"}
+  },
+  "prop": "value",
+  "included": [{
+    "prop": "value2"
+  }]
+}

--- a/tests/compact/in02-context.jsonld
+++ b/tests/compact/in02-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/"
+  }
+}

--- a/tests/compact/in02-in.jsonld
+++ b/tests/compact/in02-in.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example.org/prop": [{"@value": "value"}],
+  "@included": [{
+    "http://example.org/prop": [{"@value": "value2"}]
+  }]
+}]

--- a/tests/compact/in02-out.jsonld
+++ b/tests/compact/in02-out.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/"
+  },
+  "prop": "value",
+  "@included": {
+    "prop": "value2"
+  }
+}

--- a/tests/compact/in03-context.jsonld
+++ b/tests/compact/in03-context.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/",
+    "included": "@included"
+  }
+}

--- a/tests/compact/in03-in.jsonld
+++ b/tests/compact/in03-in.jsonld
@@ -1,0 +1,6 @@
+[{
+  "@included": [
+    {"http://example.org/prop": [{"@value": "value1"}]},
+    {"http://example.org/prop": [{"@value": "value2"}]}
+  ]
+}]

--- a/tests/compact/in03-out.jsonld
+++ b/tests/compact/in03-out.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/",
+    "included": "@included"
+  },
+  "included": [
+    {"prop": "value1"},
+    {"prop": "value2"}
+  ]
+}

--- a/tests/compact/in04-context.jsonld
+++ b/tests/compact/in04-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/"
+  }
+}

--- a/tests/compact/in04-in.jsonld
+++ b/tests/compact/in04-in.jsonld
@@ -1,0 +1,9 @@
+[{
+  "http://example.org/prop": [{"@value": "value"}],
+  "@included": [{
+    "http://example.org/prop": [{"@value": "value2"}],
+    "@included": [{
+      "http://example.org/prop": [{"@value": "value3"}]
+    }]
+  }]
+}]

--- a/tests/compact/in04-out.jsonld
+++ b/tests/compact/in04-out.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/"
+  },
+  "prop": "value",
+  "@included": {
+    "prop": "value2",
+    "@included": {
+      "prop": "value3"
+    }
+  }
+}

--- a/tests/compact/in05-context.jsonld
+++ b/tests/compact/in05-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/"
+  }
+}

--- a/tests/compact/in05-in.jsonld
+++ b/tests/compact/in05-in.jsonld
@@ -1,0 +1,8 @@
+[{
+  "http://example.org/prop": [{
+    "@type": ["http://example.org/Foo"],
+    "@included": [{
+      "@type": ["http://example.org/Bar"]
+    }]
+  }]
+}]

--- a/tests/compact/in05-out.jsonld
+++ b/tests/compact/in05-out.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/"
+  },
+  "prop": {
+    "@type": "Foo",
+    "@included": {
+      "@type": "Bar"
+    }
+  }
+}

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -1708,6 +1708,78 @@
       "input": "expand/hc05-in.jsonld",
       "expect": "invalid remote context"
     }, {
+      "@id": "#tin01",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Basic Included array",
+      "purpose": "Tests included maps.",
+      "input": "expand/in01-in.jsonld",
+      "expect": "expand/in01-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tin02",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Basic Included object",
+      "purpose": "Tests included maps.",
+      "input": "expand/in02-in.jsonld",
+      "expect": "expand/in02-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tin03",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Multiple properties mapping to @included are folded together",
+      "purpose": "Tests included maps.",
+      "input": "expand/in03-in.jsonld",
+      "expect": "expand/in03-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tin04",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Included containing @included",
+      "purpose": "Tests included maps.",
+      "input": "expand/in04-in.jsonld",
+      "expect": "expand/in04-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tin05",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Property value with @included",
+      "purpose": "Tests included maps.",
+      "input": "expand/in05-in.jsonld",
+      "expect": "expand/in05-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tin06",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "json.api example",
+      "purpose": "Tests included maps.",
+      "input": "expand/in06-in.jsonld",
+      "expect": "expand/in06-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tin07",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "Error if @included value is a string",
+      "purpose": "Tests included maps.",
+      "input": "expand/in07-in.jsonld",
+      "expect": "invalid @included value",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tin08",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "Error if @included value is a value object",
+      "purpose": "Tests included maps.",
+      "input": "expand/in08-in.jsonld",
+      "expect": "invalid @included value",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tin09",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "Error if @included value is a list object",
+      "purpose": "Tests included maps.",
+      "input": "expand/in09-in.jsonld",
+      "expect": "invalid @included value",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tjs01",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "Expand JSON literal (boolean true)",

--- a/tests/expand/in01-in.jsonld
+++ b/tests/expand/in01-in.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/"
+  },
+  "prop": "value",
+  "@included": [{
+    "prop": "value2"
+  }]
+}

--- a/tests/expand/in01-out.jsonld
+++ b/tests/expand/in01-out.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example.org/prop": [{"@value": "value"}],
+  "@included": [{
+    "http://example.org/prop": [{"@value": "value2"}]
+  }]
+}]

--- a/tests/expand/in02-in.jsonld
+++ b/tests/expand/in02-in.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/"
+  },
+  "prop": "value",
+  "@included": {
+    "prop": "value2"
+  }
+}

--- a/tests/expand/in02-out.jsonld
+++ b/tests/expand/in02-out.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example.org/prop": [{"@value": "value"}],
+  "@included": [{
+    "http://example.org/prop": [{"@value": "value2"}]
+  }]
+}]

--- a/tests/expand/in03-in.jsonld
+++ b/tests/expand/in03-in.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/",
+    "included1": "@included",
+    "included2": "@included"
+  },
+  "included1": {"prop": "value1"},
+  "included2": {"prop": "value2"}
+}

--- a/tests/expand/in03-out.jsonld
+++ b/tests/expand/in03-out.jsonld
@@ -1,0 +1,6 @@
+[{
+  "@included": [
+    {"http://example.org/prop": [{"@value": "value1"}]},
+    {"http://example.org/prop": [{"@value": "value2"}]}
+  ]
+}]

--- a/tests/expand/in04-in.jsonld
+++ b/tests/expand/in04-in.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/"
+  },
+  "prop": "value",
+  "@included": {
+    "prop": "value2",
+    "@included": {
+      "prop": "value3"
+    }
+  }
+}

--- a/tests/expand/in04-out.jsonld
+++ b/tests/expand/in04-out.jsonld
@@ -1,0 +1,9 @@
+[{
+  "http://example.org/prop": [{"@value": "value"}],
+  "@included": [{
+    "http://example.org/prop": [{"@value": "value2"}],
+    "@included": [{
+      "http://example.org/prop": [{"@value": "value3"}]
+    }]
+  }]
+}]

--- a/tests/expand/in05-in.jsonld
+++ b/tests/expand/in05-in.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/"
+  },
+  "prop": {
+    "@type": "Foo",
+    "@included": {
+      "@type": "Bar"
+    }
+  }
+}

--- a/tests/expand/in05-out.jsonld
+++ b/tests/expand/in05-out.jsonld
@@ -1,0 +1,8 @@
+[{
+  "http://example.org/prop": [{
+    "@type": ["http://example.org/Foo"],
+    "@included": [{
+      "@type": ["http://example.org/Bar"]
+    }]
+  }]
+}]

--- a/tests/expand/in06-in.jsonld
+++ b/tests/expand/in06-in.jsonld
@@ -1,0 +1,90 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/vocab#",
+    "@base": "http://example.org/base/",
+    "id": "@id",
+    "type": "@type",
+    "data": "@nest",
+    "attributes": "@nest",
+    "links": "@nest",
+    "relationships": "@nest",
+    "included": "@included",
+    "self": {"@type": "@id"},
+    "related": {"@type": "@id"},
+    "comments": {
+      "@context": {
+        "data": null
+      }
+    }
+  },
+  "data": [{
+    "type": "articles",
+    "id": "1",
+    "attributes": {
+      "title": "JSON:API paints my bikeshed!"
+    },
+    "links": {
+      "self": "http://example.com/articles/1"
+    },
+    "relationships": {
+      "author": {
+        "links": {
+          "self": "http://example.com/articles/1/relationships/author",
+          "related": "http://example.com/articles/1/author"
+        },
+        "data": { "type": "people", "id": "9" }
+      },
+      "comments": {
+        "links": {
+          "self": "http://example.com/articles/1/relationships/comments",
+          "related": "http://example.com/articles/1/comments"
+        },
+        "data": [
+          { "type": "comments", "id": "5" },
+          { "type": "comments", "id": "12" }
+        ]
+      }
+    }
+  }],
+  "included": [{
+    "type": "people",
+    "id": "9",
+    "attributes": {
+      "first-name": "Dan",
+      "last-name": "Gebhardt",
+      "twitter": "dgeb"
+    },
+    "links": {
+      "self": "http://example.com/people/9"
+    }
+  }, {
+    "type": "comments",
+    "id": "5",
+    "attributes": {
+      "body": "First!"
+    },
+    "relationships": {
+      "author": {
+        "data": { "type": "people", "id": "2" }
+      }
+    },
+    "links": {
+      "self": "http://example.com/comments/5"
+    }
+  }, {
+    "type": "comments",
+    "id": "12",
+    "attributes": {
+      "body": "I like XML better"
+    },
+    "relationships": {
+      "author": {
+        "data": { "type": "people", "id": "9" }
+      }
+    },
+    "links": {
+      "self": "http://example.com/comments/12"
+    }
+  }]
+}

--- a/tests/expand/in06-out.jsonld
+++ b/tests/expand/in06-out.jsonld
@@ -1,0 +1,42 @@
+[{
+  "@id": "http://example.org/base/1",
+  "@type": ["http://example.org/vocab#articles"],
+  "http://example.org/vocab#title": [{"@value": "JSON:API paints my bikeshed!"}],
+  "http://example.org/vocab#self": [{"@id": "http://example.com/articles/1"}],
+  "http://example.org/vocab#author": [{
+    "@id": "http://example.org/base/9",
+    "@type": ["http://example.org/vocab#people"],
+    "http://example.org/vocab#self": [{"@id": "http://example.com/articles/1/relationships/author"}],
+    "http://example.org/vocab#related": [{"@id": "http://example.com/articles/1/author"}]
+  }],
+  "http://example.org/vocab#comments": [{
+    "http://example.org/vocab#self": [{"@id": "http://example.com/articles/1/relationships/comments"}],
+    "http://example.org/vocab#related": [{"@id": "http://example.com/articles/1/comments"}]
+  }],
+  "@included": [{
+    "@id": "http://example.org/base/9",
+    "@type": ["http://example.org/vocab#people"],
+    "http://example.org/vocab#first-name": [{"@value": "Dan"}],
+    "http://example.org/vocab#last-name": [{"@value": "Gebhardt"}],
+    "http://example.org/vocab#twitter": [{"@value": "dgeb"}],
+    "http://example.org/vocab#self": [{"@id": "http://example.com/people/9"}]
+  }, {
+    "@id": "http://example.org/base/5",
+    "@type": ["http://example.org/vocab#comments"],
+    "http://example.org/vocab#body": [{"@value": "First!"}],
+    "http://example.org/vocab#author": [{
+      "@id": "http://example.org/base/2",
+      "@type": ["http://example.org/vocab#people"]
+    }],
+    "http://example.org/vocab#self": [{"@id": "http://example.com/comments/5"}]
+  }, {
+    "@id": "http://example.org/base/12",
+    "@type": ["http://example.org/vocab#comments"],
+    "http://example.org/vocab#body": [{"@value": "I like XML better"}],
+    "http://example.org/vocab#author": [{
+      "@id": "http://example.org/base/9",
+      "@type": ["http://example.org/vocab#people"]
+    }],
+    "http://example.org/vocab#self": [{"@id": "http://example.com/comments/12"}]
+  }]
+}]

--- a/tests/expand/in07-in.jsonld
+++ b/tests/expand/in07-in.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/"
+  },
+  "@included": "string"
+}

--- a/tests/expand/in08-in.jsonld
+++ b/tests/expand/in08-in.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/"
+  },
+  "@included": {"@value": "value"}
+}

--- a/tests/expand/in09-in.jsonld
+++ b/tests/expand/in09-in.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/"
+  },
+  "@included": {"@list": ["value"]}
+}

--- a/tests/flatten-manifest.jsonld
+++ b/tests/flatten-manifest.jsonld
@@ -395,6 +395,54 @@
       "expect": "flatten/h004-out.jsonld",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tin01",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
+      "name": "Basic Included array",
+      "purpose": "Tests included maps.",
+      "input": "flatten/in01-in.jsonld",
+      "expect": "flatten/in01-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tin02",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
+      "name": "Basic Included object",
+      "purpose": "Tests included maps.",
+      "input": "flatten/in02-in.jsonld",
+      "expect": "flatten/in02-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tin03",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
+      "name": "Multiple properties mapping to @included are folded together",
+      "purpose": "Tests included maps.",
+      "input": "flatten/in03-in.jsonld",
+      "expect": "flatten/in03-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tin04",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
+      "name": "Included containing @included",
+      "purpose": "Tests included maps.",
+      "input": "flatten/in04-in.jsonld",
+      "expect": "flatten/in04-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tin05",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
+      "name": "Property value with @included",
+      "purpose": "Tests included maps.",
+      "input": "flatten/in05-in.jsonld",
+      "expect": "flatten/in05-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tin06",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
+      "name": "json.api example",
+      "purpose": "Tests included maps.",
+      "input": "flatten/in06-in.jsonld",
+      "expect": "flatten/in06-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tli01",
       "@type": [ "jld:PositiveEvaluationTest", "jld:FlattenTest" ],
       "name": "@list containing an deep list",

--- a/tests/flatten/in01-in.jsonld
+++ b/tests/flatten/in01-in.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/"
+  },
+  "prop": "value",
+  "@included": [{
+    "prop": "value2"
+  }]
+}

--- a/tests/flatten/in01-out.jsonld
+++ b/tests/flatten/in01-out.jsonld
@@ -1,0 +1,7 @@
+[{
+  "@id": "_:b0",
+  "http://example.org/prop": [{"@value": "value"}]
+}, {
+  "@id": "_:b1",
+  "http://example.org/prop": [{"@value": "value2"}]
+}]

--- a/tests/flatten/in02-in.jsonld
+++ b/tests/flatten/in02-in.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/"
+  },
+  "prop": "value",
+  "@included": {
+    "prop": "value2"
+  }
+}

--- a/tests/flatten/in02-out.jsonld
+++ b/tests/flatten/in02-out.jsonld
@@ -1,0 +1,7 @@
+[{
+  "@id": "_:b0",
+  "http://example.org/prop": [{"@value": "value"}]
+}, {
+  "@id": "_:b1",
+  "http://example.org/prop": [{"@value": "value2"}]
+}]

--- a/tests/flatten/in03-in.jsonld
+++ b/tests/flatten/in03-in.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/",
+    "included1": "@included",
+    "included2": "@included"
+  },
+  "included1": {"prop": "value1"},
+  "included2": {"prop": "value2"}
+}

--- a/tests/flatten/in03-out.jsonld
+++ b/tests/flatten/in03-out.jsonld
@@ -1,0 +1,7 @@
+[{
+  "@id": "_:b1",
+  "http://example.org/prop": [{"@value": "value1"}]
+}, {
+  "@id": "_:b2",
+  "http://example.org/prop": [{"@value": "value2"}]
+}]

--- a/tests/flatten/in04-in.jsonld
+++ b/tests/flatten/in04-in.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/"
+  },
+  "prop": "value",
+  "@included": {
+    "prop": "value2",
+    "@included": {
+      "prop": "value3"
+    }
+  }
+}

--- a/tests/flatten/in04-out.jsonld
+++ b/tests/flatten/in04-out.jsonld
@@ -1,0 +1,10 @@
+[{
+  "@id": "_:b0",
+  "http://example.org/prop": [{"@value": "value"}]
+}, {
+  "@id": "_:b1",
+  "http://example.org/prop": [{"@value": "value2"}]
+}, {
+  "@id": "_:b2",
+  "http://example.org/prop": [{"@value": "value3"}]
+}]

--- a/tests/flatten/in05-in.jsonld
+++ b/tests/flatten/in05-in.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/"
+  },
+  "prop": {
+    "@type": "Foo",
+    "@included": {
+      "@type": "Bar"
+    }
+  }
+}

--- a/tests/flatten/in05-out.jsonld
+++ b/tests/flatten/in05-out.jsonld
@@ -1,0 +1,13 @@
+[{
+  "@id": "_:b0",
+  "http://example.org/prop": [
+    {"@id": "_:b1"},
+    {"@id": "_:b2"}
+  ]
+}, {
+  "@id": "_:b1",
+  "@type": ["http://example.org/Foo"]
+}, {
+  "@id": "_:b2",
+  "@type": ["http://example.org/Bar"]
+}]

--- a/tests/flatten/in05-out.jsonld
+++ b/tests/flatten/in05-out.jsonld
@@ -1,9 +1,6 @@
 [{
   "@id": "_:b0",
-  "http://example.org/prop": [
-    {"@id": "_:b1"},
-    {"@id": "_:b2"}
-  ]
+  "http://example.org/prop": [{"@id": "_:b1"}]
 }, {
   "@id": "_:b1",
   "@type": ["http://example.org/Foo"]

--- a/tests/flatten/in06-in.jsonld
+++ b/tests/flatten/in06-in.jsonld
@@ -1,0 +1,90 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/vocab#",
+    "@base": "http://example.org/base/",
+    "id": "@id",
+    "type": "@type",
+    "data": "@nest",
+    "attributes": "@nest",
+    "links": "@nest",
+    "relationships": "@nest",
+    "included": "@included",
+    "self": {"@type": "@id"},
+    "related": {"@type": "@id"},
+    "comments": {
+      "@context": {
+        "data": null
+      }
+    }
+  },
+  "data": [{
+    "type": "articles",
+    "id": "1",
+    "attributes": {
+      "title": "JSON:API paints my bikeshed!"
+    },
+    "links": {
+      "self": "http://example.com/articles/1"
+    },
+    "relationships": {
+      "author": {
+        "links": {
+          "self": "http://example.com/articles/1/relationships/author",
+          "related": "http://example.com/articles/1/author"
+        },
+        "data": { "type": "people", "id": "9" }
+      },
+      "comments": {
+        "links": {
+          "self": "http://example.com/articles/1/relationships/comments",
+          "related": "http://example.com/articles/1/comments"
+        },
+        "data": [
+          { "type": "comments", "id": "5" },
+          { "type": "comments", "id": "12" }
+        ]
+      }
+    }
+  }],
+  "included": [{
+    "type": "people",
+    "id": "9",
+    "attributes": {
+      "first-name": "Dan",
+      "last-name": "Gebhardt",
+      "twitter": "dgeb"
+    },
+    "links": {
+      "self": "http://example.com/people/9"
+    }
+  }, {
+    "type": "comments",
+    "id": "5",
+    "attributes": {
+      "body": "First!"
+    },
+    "relationships": {
+      "author": {
+        "data": { "type": "people", "id": "2" }
+      }
+    },
+    "links": {
+      "self": "http://example.com/comments/5"
+    }
+  }, {
+    "type": "comments",
+    "id": "12",
+    "attributes": {
+      "body": "I like XML better"
+    },
+    "relationships": {
+      "author": {
+        "data": { "type": "people", "id": "9" }
+      }
+    },
+    "links": {
+      "self": "http://example.com/comments/12"
+    }
+  }]
+}

--- a/tests/flatten/in06-out.jsonld
+++ b/tests/flatten/in06-out.jsonld
@@ -1,0 +1,40 @@
+[{
+  "@id": "_:b0",
+  "http://example.org/vocab#self": [{"@id": "http://example.com/articles/1/relationships/comments"}
+  ],
+  "http://example.org/vocab#related": [{"@id": "http://example.com/articles/1/comments"}]
+  }, {
+  "@id": "http://example.org/base/1",
+  "@type": ["http://example.org/vocab#articles"],
+  "http://example.org/vocab#title": [{"@value": "JSON:API paints my bikeshed!"}],
+  "http://example.org/vocab#self": [{"@id": "http://example.com/articles/1"}],
+  "http://example.org/vocab#author": [{"@id": "http://example.org/base/9"}],
+  "http://example.org/vocab#comments": [{"@id": "_:b0"}]
+}, {
+  "@id": "http://example.org/base/12",
+  "@type": ["http://example.org/vocab#comments"],
+  "http://example.org/vocab#body": [{"@value": "I like XML better"}],
+  "http://example.org/vocab#author": [{"@id": "http://example.org/base/9"}],
+  "http://example.org/vocab#self": [{"@id": "http://example.com/comments/12"}]
+}, {
+  "@id": "http://example.org/base/2",
+  "@type": ["http://example.org/vocab#people"]
+}, {
+  "@id": "http://example.org/base/5",
+  "@type": ["http://example.org/vocab#comments"],
+  "http://example.org/vocab#body": [{"@value": "First!"}
+  ],
+  "http://example.org/vocab#author": [{"@id": "http://example.org/base/2"}],
+  "http://example.org/vocab#self": [{"@id": "http://example.com/comments/5"}]
+}, {
+  "@id": "http://example.org/base/9",
+  "@type": ["http://example.org/vocab#people"],
+  "http://example.org/vocab#first-name": [{"@value": "Dan"}],
+  "http://example.org/vocab#last-name": [{"@value": "Gebhardt"}],
+  "http://example.org/vocab#twitter": [{"@value": "dgeb"}],
+  "http://example.org/vocab#self": [
+    {"@id": "http://example.com/people/9"},
+    {"@id": "http://example.com/articles/1/relationships/author"}
+  ],
+  "http://example.org/vocab#related": [{"@id": "http://example.com/articles/1/author"}]
+}]

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -1400,6 +1400,54 @@
       "expect": "toRdf/h022-out.nq",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tin01",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Basic Included array",
+      "purpose": "Tests included maps.",
+      "input": "toRdf/in01-in.jsonld",
+      "expect": "toRdf/in01-out.nq",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tin02",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Basic Included object",
+      "purpose": "Tests included maps.",
+      "input": "toRdf/in02-in.jsonld",
+      "expect": "toRdf/in02-out.nq",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tin03",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Multiple properties mapping to @included are folded together",
+      "purpose": "Tests included maps.",
+      "input": "toRdf/in03-in.jsonld",
+      "expect": "toRdf/in03-out.nq",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tin04",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Included containing @included",
+      "purpose": "Tests included maps.",
+      "input": "toRdf/in04-in.jsonld",
+      "expect": "toRdf/in04-out.nq",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tin05",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Property value with @included",
+      "purpose": "Tests included maps.",
+      "input": "toRdf/in05-in.jsonld",
+      "expect": "toRdf/in05-out.nq",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tin06",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "json.api example",
+      "purpose": "Tests included maps.",
+      "input": "toRdf/in06-in.jsonld",
+      "expect": "toRdf/in06-out.nq",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tjs01",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
       "name": "Transform JSON literal (boolean true)",

--- a/tests/toRdf/in01-in.jsonld
+++ b/tests/toRdf/in01-in.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/"
+  },
+  "prop": "value",
+  "@included": [{
+    "prop": "value2"
+  }]
+}

--- a/tests/toRdf/in01-out.nq
+++ b/tests/toRdf/in01-out.nq
@@ -1,0 +1,2 @@
+_:b0 <http://example.org/prop> "value" .
+_:b1 <http://example.org/prop> "value2" .

--- a/tests/toRdf/in02-in.jsonld
+++ b/tests/toRdf/in02-in.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/"
+  },
+  "prop": "value",
+  "@included": {
+    "prop": "value2"
+  }
+}

--- a/tests/toRdf/in02-out.nq
+++ b/tests/toRdf/in02-out.nq
@@ -1,0 +1,2 @@
+_:b0 <http://example.org/prop> "value" .
+_:b1 <http://example.org/prop> "value2" .

--- a/tests/toRdf/in03-in.jsonld
+++ b/tests/toRdf/in03-in.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/",
+    "included1": "@included",
+    "included2": "@included"
+  },
+  "included1": {"prop": "value1"},
+  "included2": {"prop": "value2"}
+}

--- a/tests/toRdf/in03-out.nq
+++ b/tests/toRdf/in03-out.nq
@@ -1,0 +1,2 @@
+_:b1 <http://example.org/prop> "value1" .
+_:b2 <http://example.org/prop> "value2" .

--- a/tests/toRdf/in04-in.jsonld
+++ b/tests/toRdf/in04-in.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/"
+  },
+  "prop": "value",
+  "@included": {
+    "prop": "value2",
+    "@included": {
+      "prop": "value3"
+    }
+  }
+}

--- a/tests/toRdf/in04-out.nq
+++ b/tests/toRdf/in04-out.nq
@@ -1,0 +1,3 @@
+_:b0 <http://example.org/prop> "value" .
+_:b1 <http://example.org/prop> "value2" .
+_:b2 <http://example.org/prop> "value3" .

--- a/tests/toRdf/in05-in.jsonld
+++ b/tests/toRdf/in05-in.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/"
+  },
+  "prop": {
+    "@type": "Foo",
+    "@included": {
+      "@type": "Bar"
+    }
+  }
+}

--- a/tests/toRdf/in05-out.nq
+++ b/tests/toRdf/in05-out.nq
@@ -1,4 +1,3 @@
 _:b0 <http://example.org/prop> _:b1 .
-_:b0 <http://example.org/prop> _:b2 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/Foo> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/Bar> .

--- a/tests/toRdf/in05-out.nq
+++ b/tests/toRdf/in05-out.nq
@@ -1,0 +1,4 @@
+_:b0 <http://example.org/prop> _:b1 .
+_:b0 <http://example.org/prop> _:b2 .
+_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/Foo> .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/Bar> .

--- a/tests/toRdf/in06-in.jsonld
+++ b/tests/toRdf/in06-in.jsonld
@@ -1,0 +1,90 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://example.org/vocab#",
+    "@base": "http://example.org/base/",
+    "id": "@id",
+    "type": "@type",
+    "data": "@nest",
+    "attributes": "@nest",
+    "links": "@nest",
+    "relationships": "@nest",
+    "included": "@included",
+    "self": {"@type": "@id"},
+    "related": {"@type": "@id"},
+    "comments": {
+      "@context": {
+        "data": null
+      }
+    }
+  },
+  "data": [{
+    "type": "articles",
+    "id": "1",
+    "attributes": {
+      "title": "JSON:API paints my bikeshed!"
+    },
+    "links": {
+      "self": "http://example.com/articles/1"
+    },
+    "relationships": {
+      "author": {
+        "links": {
+          "self": "http://example.com/articles/1/relationships/author",
+          "related": "http://example.com/articles/1/author"
+        },
+        "data": { "type": "people", "id": "9" }
+      },
+      "comments": {
+        "links": {
+          "self": "http://example.com/articles/1/relationships/comments",
+          "related": "http://example.com/articles/1/comments"
+        },
+        "data": [
+          { "type": "comments", "id": "5" },
+          { "type": "comments", "id": "12" }
+        ]
+      }
+    }
+  }],
+  "included": [{
+    "type": "people",
+    "id": "9",
+    "attributes": {
+      "first-name": "Dan",
+      "last-name": "Gebhardt",
+      "twitter": "dgeb"
+    },
+    "links": {
+      "self": "http://example.com/people/9"
+    }
+  }, {
+    "type": "comments",
+    "id": "5",
+    "attributes": {
+      "body": "First!"
+    },
+    "relationships": {
+      "author": {
+        "data": { "type": "people", "id": "2" }
+      }
+    },
+    "links": {
+      "self": "http://example.com/comments/5"
+    }
+  }, {
+    "type": "comments",
+    "id": "12",
+    "attributes": {
+      "body": "I like XML better"
+    },
+    "relationships": {
+      "author": {
+        "data": { "type": "people", "id": "9" }
+      }
+    },
+    "links": {
+      "self": "http://example.com/comments/12"
+    }
+  }]
+}

--- a/tests/toRdf/in06-out.nq
+++ b/tests/toRdf/in06-out.nq
@@ -1,0 +1,23 @@
+<http://example.org/base/1> <http://example.org/vocab#author> <http://example.org/base/9> .
+<http://example.org/base/1> <http://example.org/vocab#comments> _:b0 .
+<http://example.org/base/1> <http://example.org/vocab#self> <http://example.com/articles/1> .
+<http://example.org/base/1> <http://example.org/vocab#title> "JSON:API paints my bikeshed!" .
+<http://example.org/base/1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/vocab#articles> .
+<http://example.org/base/2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/vocab#people> .
+<http://example.org/base/5> <http://example.org/vocab#author> <http://example.org/base/2> .
+<http://example.org/base/5> <http://example.org/vocab#body> "First!" .
+<http://example.org/base/5> <http://example.org/vocab#self> <http://example.com/comments/5> .
+<http://example.org/base/5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/vocab#comments> .
+<http://example.org/base/9> <http://example.org/vocab#first-name> "Dan" .
+<http://example.org/base/9> <http://example.org/vocab#last-name> "Gebhardt" .
+<http://example.org/base/9> <http://example.org/vocab#related> <http://example.com/articles/1/author> .
+<http://example.org/base/9> <http://example.org/vocab#self> <http://example.com/articles/1/relationships/author> .
+<http://example.org/base/9> <http://example.org/vocab#self> <http://example.com/people/9> .
+<http://example.org/base/9> <http://example.org/vocab#twitter> "dgeb" .
+<http://example.org/base/9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/vocab#people> .
+<http://example.org/base/12> <http://example.org/vocab#author> <http://example.org/base/9> .
+<http://example.org/base/12> <http://example.org/vocab#body> "I like XML better" .
+<http://example.org/base/12> <http://example.org/vocab#self> <http://example.com/comments/12> .
+<http://example.org/base/12> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/vocab#comments> .
+_:b0 <http://example.org/vocab#related> <http://example.com/articles/1/comments> .
+_:b0 <http://example.org/vocab#self> <http://example.com/articles/1/relationships/comments> .


### PR DESCRIPTION
For w3c/json-ld-syntax#19.

@dlongley If you could see if this formulation works better for you. At this point `@included` is an array of node objects, sort of like `@graph`. Fairly small impact on both Expansion and Flattening algorithms.

We could extend to allow id-maps, type-maps and so forth, but that doesn't provide any really new functionality.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/128.html" title="Last updated on Jul 31, 2019, 7:05 PM UTC (115b29a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/128/881a530...115b29a.html" title="Last updated on Jul 31, 2019, 7:05 PM UTC (115b29a)">Diff</a>