### PR TITLE
A proposal to make algotithms easier to read using foldable sections.

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,6 +264,24 @@
     text-decoration: none;
     color: #666;
   }
+
+  .algorithm summary::before {
+    content: "// ";
+  }
+
+  .algorithm summary {
+    padding-left: 2em;
+    font-style: italic;
+  }
+
+  /* required if we chose to put OLs *outside* the details,
+     to force them visible when printing */
+  @media screen {
+    .algorithm details:not([open]) + ol {
+      display: none;
+    }
+  }
+
 </style>
 </head>
 
@@ -1125,6 +1143,7 @@
           For each item <var>context</var> in <var>local context</var>:
           <ol>
             <li>If <var>context</var> is <code>null</code>:
+              <details><summary>clear context (unless protected)</summary></details>
               <ol>
                 <li class="changed">If <var>override protected</var> is <code>false</code> and <var>active context</var>
                   contains any <a>protected</a> <a>term definitions</a>,
@@ -1138,10 +1157,10 @@
                   <span class="note">In [[[JSON-LD]]], the <a>base IRI</a> was given
                     a default value here; this is now described conditionally
                     in <a href="#the-application-programming-interface" class="sectionRef"></a>.</span></li>
-                  </ol>
+              </ol>
             </li>
-            <li>If <var>context</var> is a <a>string</a>,
-              <ol>
+            <li>If <var>context</var> is a <a>string</a>:
+              <details><summary>dereference and process</summary><ol>
                 <li>Set <var>context</var> to the result of resolving <var>value</var> against
                   the base IRI which is established as specified in
                   <a data-cite="RFC3986#section-5.1">section 5.1 Establishing a Base URI</a>
@@ -1180,14 +1199,14 @@
                   passing <var>result</var> for <var>active context</var>,
                   <var>context</var> for <var>local context</var>, and <span class="changed">a copy of</span> <var>remote contexts</var>.</li>
                 <li>Continue with the next <var>context</var>.</li>
-              </ol>
+              </ol></details>
             </li>
             <li>If <var>context</var> is not a <a class="changed">map</a>, an
               <a data-link-for="JsonLdErrorCode">invalid local context</a>
               error has been detected and processing is aborted.</li>
             <li>Otherwise, <var>context</var> is a <a data-cite="JSON-LD11#dfn-context-definition">context definition</a>.</li>
             <li class="changed">If <var>context</var> has an <code>@version</code> <a>entry</a>:
-              <ol>
+              <details><summary>set processing mode</summary><ol>
                 <li>If the associated value is not <code>1.1</code>,
                   an <a data-link-for="JsonLdErrorCode">invalid @version value</a>
                   has been detected, and processing is aborted.</li>
@@ -1197,10 +1216,10 @@
                   error has been detected and processing is aborted.</li>
                 <li>Set <a>processing mode</a>,
                   to <code>json-ld-1.1</code>, if not already set.</li>
-              </ol>
+              </ol></details>
             </li>
             <li class="changed">If <var>context</var> has an <code>@import</code> <a>entry</a>:
-              <ol>
+              <details><summary>merge imported context</summary><ol>
                 <li>If <a>processing mode</a> is <code>json-ld-1.0</code>,
                   an <a data-link-for="JsonLdErrorCode">invalid context entry</a>
                   error has been detected and processing is aborted.</li>
@@ -1241,11 +1260,11 @@
                 <li>Set <var>context</var> to the result of merging <var>context</var>
                   into <var>import context</var>, replacing common entries
                   with those from <var>context</var>.</li>
-              </ol>
+              </ol></details>
             </li>
             <li>If <var>context</var> has an <code>@base</code> <a>entry</a> and <var>remote contexts</var> is empty, i.e., the currently
               being processed context is not a remote context:
-              <ol>
+              <details><summary>reset <a>base IRI</a></summary><ol>
                 <li>Initialize <var>value</var> to the value associated with the
                   <code>@base</code> <a>entry</a>.</li>
                 <li>If <var>value</var> is <code>null</code>, remove the
@@ -1260,10 +1279,10 @@
                 <li>Otherwise, an
                   <a data-link-for="JsonLdErrorCode">invalid base IRI</a>
                   error has been detected and processing is aborted.</li>
-              </ol>
+              </ol></details>
             </li>
             <li>If <var>context</var> has an <code>@vocab</code> <a>entry</a>:
-              <ol>
+              <details><summary>reset <a>vocabulary mapping</a></summary><ol>
                 <li>Initialize <var>value</var> to the value associated with the
                   <code>@vocab</code> <a>entry</a>.</li>
                 <li>If <var>value</var> is <a>null</a>, remove
@@ -1284,10 +1303,10 @@
                   error has been detected and processing is aborted.
                   <div class="issue atrisk">The use of <a>blank node identifiers</a> to value for <code>@vocab</code> is obsolete,
                     and may be removed in a future version of JSON-LD.</div></li>
-              </ol>
+              </ol></details>
             </li>
             <li>If <var>context</var> has an <code>@language</code> <a>entry</a>:
-              <ol>
+              <details><summary>reset <a>default language</a></summary><ol>
                 <li>Initialize <var>value</var> to the value associated with the
                   <code>@language</code> <a>entry</a>.</li>
                 <li>If <var>value</var> is <code>null</code>, remove
@@ -1297,10 +1316,10 @@
                   lowercased <var>value</var>. If it is not a <a>string</a>, an
                   <a data-link-for="JsonLdErrorCode">invalid default language</a>
                   error has been detected and processing is aborted.</li>
-              </ol>
+              </ol></details>
             </li>
             <li class="changed">If <var>context</var> has an <code>@propagate</code> <a>entry</a>:
-              <ol>
+              <details><summary>check its validity</summary><ol>
                 <li>If <a>processing mode</a> is <code>json-ld-1.0</code>,
                   an <a data-link-for="JsonLdErrorCode">invalid context entry</a>
                   error has been detected and processing is aborted.</li>
@@ -1309,7 +1328,7 @@
                   error has been detected and processing is aborted.</li>
                 <li>Otherwise, <a>previous context</a> was determined before,
                   and no further processing is necessary.</li>
-              </ol>
+              </ol></details>
             </li>
             <li>Create a <a class="changed">map</a> <var>defined</var> to keep
               track of whether or not a <a>term</a> has already been defined


### PR DESCRIPTION
As @iherman suggested, I'm using `<details>`
* the `<summary>` is a "comment" summarizing the embeded steps
* the rest of the `<details>` contains the list of steps

See the Context Processing Algorithm, Section 4.1.2,  for an example.
If the group thinks that is a good idea, I can apply it to the other algorithms.
