### PR TITLE
Add support for the `alternate` link relation

### DIFF
--- a/index.html
+++ b/index.html
@@ -6379,7 +6379,7 @@
       a context. When this is set, vocabulary-relative IRIs, such as the
       <a>entries</a> of <a>node objects</a>, are expanded or compacted relative
       to the <a>base IRI</a> and the <a>vocabulary mapping</a> using string concatenation.</li>
-    <li>In the <a>LoadDocumentCallback</a>, if the retrieved content is not `application/ld+json`
+    <li>In the <a>LoadDocumentCallback</a>, if the retrieved content is not any JSON media type
       and there is a link header with `rel=alternate` and `type=application/ld+json`, redirect
       to that content.</li>
   </ul>

--- a/index.html
+++ b/index.html
@@ -5824,7 +5824,7 @@
         <li>Set <var>documentUrl</var> to the location of the retrieved resource
           considering redirections (exclusive of HTTP status <code>303</code> "See Other" redirects
           as discussed in [[?cooluris]]).</li>
-        <li>If the retrieved resource's <a>Content-Type</a> is not <code>application/ld+json</code>
+        <li>If the retrieved resource's <a>Content-Type</a> is not <code>application/json</code>
           nor any media type with a <code>+json</code> suffix as defined in [[RFC6839]],
           and the response has an HTTP Link Header [[RFC8288]] using the <code>alternate</code> link relation
           with type `application/ld+json`,

--- a/index.html
+++ b/index.html
@@ -5809,7 +5809,7 @@
       <ol class="changed">
         <li>Create a new {{Promise}} <var>promise</var> and return it.
           The following steps are then executed asynchronously.</li>
-        <li>Set <var>document</var> to the body retrieved from
+        <li id="LoadDocumentCallback-step-2">Set <var>document</var> to the body retrieved from
           the resource identified by <a data-link-for="LoadDocumentCallback">url</a>,
           or by otherwise locating a resource associated with <a data-link-for="LoadDocumentCallback">url</a>.
           When requesting remote documents the request MUST prefer <a>Content-Type</a> <code>application/ld+json</code>
@@ -5824,6 +5824,13 @@
         <li>Set <var>documentUrl</var> to the location of the retrieved resource
           considering redirections (exclusive of HTTP status <code>303</code> "See Other" redirects
           as discussed in [[?cooluris]]).</li>
+        <li>If the retrieved resource's <a>Content-Type</a> is not <code>application/ld+json</code>
+          nor any media type with a <code>+json</code> suffix as defined in [[RFC6839]],
+          and the response has an HTTP Link Header [[RFC8259]] using the <code>alternate</code> link relation
+          with type `application/ld+json`,
+          set <var>url</var> to the associated <code>href</code> relative to the previous <var>url</var>
+          and restart the algorithm from <a href="#LoadDocumentCallback-step-2">step 2</a>,
+          ensuring that <var>documentUrl</var> is set to the original <var>url</var>.</li>
         <li>If the retrieved resource's <a>Content-Type</a> is <code>application/json</code>
           or any media type with a <code>+json</code> suffix as defined in [[RFC6839]]
           except <code>application/ld+json</code>,
@@ -6372,6 +6379,9 @@
       a context. When this is set, vocabulary-relative IRIs, such as the
       <a>entries</a> of <a>node objects</a>, are expanded or compacted relative
       to the <a>base IRI</a> and the <a>vocabulary mapping</a> using string concatenation.</li>
+    <li>In the <a>LoadDocumentCallback</a>, if the retrieved content is not `application/ld+json`
+      and there is a link header with `rel=alternate` and `type=application/ld+json`, redirect
+      to that content.</li>
   </ul>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -5826,7 +5826,7 @@
           as discussed in [[?cooluris]]).</li>
         <li>If the retrieved resource's <a>Content-Type</a> is not <code>application/ld+json</code>
           nor any media type with a <code>+json</code> suffix as defined in [[RFC6839]],
-          and the response has an HTTP Link Header [[RFC8259]] using the <code>alternate</code> link relation
+          and the response has an HTTP Link Header [[RFC8288]] using the <code>alternate</code> link relation
           with type `application/ld+json`,
           set <var>url</var> to the associated <code>href</code> relative to the previous <var>url</var>
           and restart the algorithm from <a href="#LoadDocumentCallback-step-2">step 2</a>,
@@ -5834,7 +5834,7 @@
         <li>If the retrieved resource's <a>Content-Type</a> is <code>application/json</code>
           or any media type with a <code>+json</code> suffix as defined in [[RFC6839]]
           except <code>application/ld+json</code>,
-          and the response has an HTTP Link Header [[RFC8259]] using the <code>http://www.w3.org/ns/json-ld#context</code> link relation,
+          and the response has an HTTP Link Header [[RFC8288]] using the <code>http://www.w3.org/ns/json-ld#context</code> link relation,
           set <var>contextUrl</var> to the associated <code>href</code>.
           <p>If multiple HTTP Link Headers using the <code>http://www.w3.org/ns/json-ld#context</code> link relation are found,
             the <var>promise</var> is rejected with a <a>JsonLdError</a> whose code is set to <a data-link-for="JsonLdErrorCode">multiple context link headers</a>
@@ -5979,7 +5979,7 @@
 
       <dl>
         <dt><dfn data-dfn-for="RemoteDocument">contextUrl</dfn></dt>
-        <dd>If available, the value of the HTTP Link Header [[RFC8259]]
+        <dd>If available, the value of the HTTP Link Header [[RFC8288]]
           using the <code>http://www.w3.org/ns/json-ld#context</code> link relation
           in the response.
           If the response's <a>Content-Type</a> is <code>application/ld+json</code>,
@@ -6197,7 +6197,7 @@
         <dt><dfn>loading remote context failed</dfn></dt>
         <dd>There was a problem encountered loading a remote context.</dd>
         <dt><dfn>multiple context link headers</dfn></dt>
-        <dd>Multiple HTTP Link Headers [[RFC8259]]
+        <dd>Multiple HTTP Link Headers [[RFC8288]]
           using the <code>http://www.w3.org/ns/json-ld#context</code> link relation
           have been detected.</dd>
         <dt><dfn>processing mode conflict</dfn></dt>

--- a/tests/remote-doc-manifest.jsonld
+++ b/tests/remote-doc-manifest.jsonld
@@ -134,6 +134,56 @@
       },
       "input": "remote-doc/0013-in.json",
       "expect": "remote-doc/0013-out.jsonld"
+    }, {
+      "@id": "#tla01",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Redirects if type is text/html",
+      "purpose": "Load an alternate link if type is not ld+json and rel=alternate.",
+      "option": {
+        "httpLink": "<la01-alternate.jsonld>; rel=\"alternate\"; type=\"application/ld+json\""
+      },
+      "input": "remote-doc/la01-in.html",
+      "expect": "remote-doc/la01-out.jsonld"
+    }, {
+      "@id": "#tla02",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Does not redirect if type is application/ld+json",
+      "purpose": "Load an alternate link if type is not ld+json and rel=alternate.",
+      "option": {
+        "httpLink": "<la02-alternate.jsonld>; rel=\"alternate\"; type=\"application/ld+json\""
+      },
+      "input": "remote-doc/la02-in.jsonld",
+      "expect": "remote-doc/la02-out.jsonld"
+    }, {
+      "@id": "#tla03",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Does not redirect if link type is not application/ld+json",
+      "purpose": "Load an alternate link if type is not ld+json and rel=alternate.",
+      "option": {
+        "httpLink": "<la03-alternate.json>; rel=\"alternate\"; type=\"application/json\""
+      },
+      "input": "remote-doc/la03-in.json",
+      "expect": "remote-doc/la03-out.jsonld"
+    }, {
+      "@id": "#tla04",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Does not redirect if type is application/json",
+      "purpose": "Load an alternate link if type is not ld+json and rel=alternate.",
+      "option": {
+        "httpLink": "<la04-alternate.jsonld>; rel=\"alternate\"; type=\"application/ld+json\""
+      },
+      "input": "remote-doc/la04-in.json",
+      "expect": "remote-doc/la04-out.jsonld"
+    }, {
+      "@id": "#tla05",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Base remains that of original document",
+      "purpose": "Load an alternate link if type is not ld+json and rel=alternate.",
+      "option": {
+        "httpLink": "<la05-alternate.jsonld>; rel=\"alternate\"; type=\"application/ld+json\""
+      },
+      "input": "remote-doc/la05-in.html",
+      "expect": "remote-doc/la05-out.jsonld"
     }
   ]
 }

--- a/tests/remote-doc/la01-alternate.jsonld
+++ b/tests/remote-doc/la01-alternate.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/"
+  },
+  "content": "alternate"
+}

--- a/tests/remote-doc/la01-in.html
+++ b/tests/remote-doc/la01-in.html
@@ -1,0 +1,16 @@
+<html>
+  <head>
+    <title>Content to be skipped</title>
+    <script type="application/ld+json">
+      {
+        "@context": {
+          "@vocab": "http://example.org/"
+        },
+        "content": "skipped"
+      }
+    </script>
+  </head>
+  <body>
+    <p>This content should be skipped</p>
+  </body>
+</html>

--- a/tests/remote-doc/la01-out.jsonld
+++ b/tests/remote-doc/la01-out.jsonld
@@ -1,0 +1,3 @@
+[{
+  "http://example.org/content": [{"@value": "alternate"}]
+}]

--- a/tests/remote-doc/la02-alternate.jsonld
+++ b/tests/remote-doc/la02-alternate.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/"
+  },
+  "content": "alternate"
+}

--- a/tests/remote-doc/la02-in.jsonld
+++ b/tests/remote-doc/la02-in.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/"
+  },
+  "content": "not skipped"
+}

--- a/tests/remote-doc/la02-out.jsonld
+++ b/tests/remote-doc/la02-out.jsonld
@@ -1,0 +1,3 @@
+[{
+  "http://example.org/content": [{"@value": "not skipped"}]
+}]

--- a/tests/remote-doc/la03-alternate.json
+++ b/tests/remote-doc/la03-alternate.json
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/"
+  },
+  "content": "alternate"
+}

--- a/tests/remote-doc/la03-in.json
+++ b/tests/remote-doc/la03-in.json
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/"
+  },
+  "content": "not skipped"
+}

--- a/tests/remote-doc/la03-out.jsonld
+++ b/tests/remote-doc/la03-out.jsonld
@@ -1,0 +1,3 @@
+[{
+  "http://example.org/content": [{"@value": "not skipped"}]
+}]

--- a/tests/remote-doc/la04-alternate.jsonld
+++ b/tests/remote-doc/la04-alternate.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/"
+  },
+  "content": "alternate"
+}

--- a/tests/remote-doc/la04-in.json
+++ b/tests/remote-doc/la04-in.json
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/"
+  },
+  "content": "not skipped"
+}

--- a/tests/remote-doc/la04-out.jsonld
+++ b/tests/remote-doc/la04-out.jsonld
@@ -1,0 +1,3 @@
+[{
+  "http://example.org/content": [{"@value": "not skipped"}]
+}]

--- a/tests/remote-doc/la05-alternate.jsonld
+++ b/tests/remote-doc/la05-alternate.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/"
+  },
+  "@id": "",
+  "content": "alternate"
+}

--- a/tests/remote-doc/la05-in.html
+++ b/tests/remote-doc/la05-in.html
@@ -1,0 +1,17 @@
+<html>
+  <head>
+    <title>Content to be skipped</title>
+    <script type="application/ld+json">
+      {
+        "@context": {
+          "@vocab": "http://example.org/"
+        },
+        "@id": "",
+        "content": "skipped"
+      }
+    </script>
+  </head>
+  <body>
+    <p>This content should be skipped</p>
+  </body>
+</html>

--- a/tests/remote-doc/la05-out.jsonld
+++ b/tests/remote-doc/la05-out.jsonld
@@ -1,0 +1,4 @@
+[{
+  "@id": "https://w3c.github.io/json-ld-api/tests/remote-doc/la05-in.html",
+  "http://example.org/content": [{"@value": "alternate"}]
+}]


### PR DESCRIPTION
… with type `application/ld+json` to be used as a redirect if the retrieved document is not JSON.

For w3c/json-ld-syntax#204.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/133.html" title="Last updated on Aug 14, 2019, 4:25 PM UTC (caecf69)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/133/a8094d9...caecf69.html" title="Last updated on Aug 14, 2019, 4:25 PM UTC (caecf69)">Diff</a>