### PR TITLE
Encapsulate HTML processing

### DIFF
--- a/index.html
+++ b/index.html
@@ -940,52 +940,6 @@
       </tr>
     </tbody>
   </table>
-
-  <section>
-    <h2>Processor Levels</h2>
-
-    <!--
-      **************** IMPORTANT WARNING ****************
-      This section is duplicated (with a few adaptations)
-      in other JSON-LD specifications. Since these
-      definitions are normative, it is important to
-      reflect any change in the other documents.
-      ***************************************************
-    -->
-
-    <p>JSON-LD mostly uses the JSON syntax [[RFC8259]] along with
-      various micro-syntaxes based on XML Schema datatypes [[XMLSCHEMA11-2]].
-      However, it has become increasingly common to include JSON within
-      a <a data-cite="HTML/scripting.html#the-script-element">script element</a>
-      within an HTML document [[HTML]],
-      as described in <a href="#html-content-algorithms" class="sectionRef"></a>.
-      As not all processors operate in an environment which can include HTML,
-      this specification describes various categories of JSON-LD processors.</p>
-
-    <p>A <dfn data-cite="JSON-LD11#pure-json-processor">pure JSON Processor</dfn> only requires the use of a
-      JSON processor and is restricted to processing documents retrieved
-      with a JSON content type (e.g., <code>application/ld+json</code> or other JSON type).</p>
-
-    <p>A <dfn data-cite="JSON-LD11#full-processor">full Processor</dfn> is capable of processing JSON-LD embedded in HTML,
-      in addition to the capabilities of a <a>pure JSON Processor</a>.</p>
-
-    <section class="informative">
-      <h3>Additional Processor Levels</h3>
-
-      <p>In addition to the normatively defined processor levels, an additional processor
-        level is defined for reference.</p>
-
-      <p>A <dfn data-cite="JSON-LD11#event-based-json-processor">event-based JSON Processor</dfn> processes a stream of characters
-        expecting an event after each syntactic element is encountered.
-        Such processors are sensitive to the order of the members of <a>JSON objects</a>,
-        which can have a performance impact if the members of <a>JSON objects</a> are encountered in an unexpected order.
-        An <a>event-based JSON Processor</a> may process JSON-LD embedded in HTML.</p>
-
-      <p class="note">An <a>event-based JSON Processor</a>
-        may be sensitive to processing certain keywords in order, including
-        <code>@context</code>, <code>@id</code>, and <code>@type</code>.</p>
-    </section>
-  </section>
 </section> <!-- end of Conformance section -->
 
 <section>
@@ -5212,29 +5166,6 @@
   </section> <!-- end of Data Round Tripping -->
 </section>
 
-<section class="changed">
-  <h2>HTML Content Algorithms</h2>
-  <p class="note">This section describes features required of a <a>full Processor</a>.</p>
-  <section id="extract-script-content" class="algorithm">
-    <h3>Extract Script Content Algorithm</h3>
-
-    <p>The algorithm extracts the text content a
-      <a>JSON-LD script element</a> into a <a>map</a> or <a>array</a> of <a>maps</a>.
-      A <dfn>JSON-LD script element</dfn> is a <a data-cite="HTML/scripting.html#the-script-element">script element</a>
-      within an HTML [[HTML]] document with the <a data-cite="HTML/semantics.html#attr-link-type">type attribute</a> set to
-      <code>application/ld+json</code>.</p>
-
-    <p>The algorithm takes a single required input variable: <var>source</var>,
-      the <a data-cite="DOM#dom-node-textcontent">textContent</a> of an HTML <a data-cite="HTML/scripting.html#the-script-element">script element</a>.</p>
-
-    <ol>
-    <li>If <var>source</var> is not a valid JSON document,
-      an <a data-link-for="JsonLdErrorCode">invalid script element</a> has been detected, and processing is aborted.</li>
-    <li>Return the result of transforming <var>source</var> into the <a>internal representation</a>.</li>
-    </ol>
-  </section>
-</section>
-
 <section>
   <h2>The Application Programming Interface</h2>
 
@@ -5817,9 +5748,6 @@
             it MUST be added as a profile on <code>application/ld+json</code>.</p>
 
           <p>Processors MAY include other media types using a <code>+json</code> suffix as defined in [[RFC6839]].</p>
-
-          <p>A <a>full Processor</a> MUST include <code>text/html</code> at any preference level,
-            unless <a data-link-for="LoadDocumentOptions">requestProfile</a> is `http://www.w3.org/ns/json-ld#context`.</p>
         </li>
         <li>Set <var>documentUrl</var> to the location of the retrieved resource
           considering redirections (exclusive of HTTP status <code>303</code> "See Other" redirects
@@ -5831,7 +5759,7 @@
           set <var>url</var> to the associated <code>href</code> relative to the previous <var>url</var>
           and restart the algorithm from <a href="#LoadDocumentCallback-step-2">step 2</a>,
           ensuring that <var>documentUrl</var> is set to the original <var>url</var>.</li>
-        <li>If the retrieved resource's <a>Content-Type</a> is <code>application/json</code>
+        <li id="LoadDocumentCallback-step-5">If the retrieved resource's <a>Content-Type</a> is <code>application/json</code>
           or any media type with a <code>+json</code> suffix as defined in [[RFC6839]]
           except <code>application/ld+json</code>,
           and the response has an HTTP Link Header [[RFC8288]] using the <code>http://www.w3.org/ns/json-ld#context</code> link relation,
@@ -5843,79 +5771,9 @@
           <p class="note">The HTTP Link Header is ignored for documents served as <code>application/ld+json</code>
             or <code>text/html</code>.</p>
         </li>
-        <li>Otherwise, if the retrieved resource's <a>Content-Type</a> is <code>text/html</code>:
-          <ol>
-            <li>If the processor is a <a>pure JSON Processor</a>
-              the <var>promise</var> is rejected with a <a>JsonLdError</a> whose code is set to <a data-link-for="JsonLdErrorCode">loading document failed</a>
-              and processing is terminated.</li>
-            <li>Set <var>documentUrl</var> to the the <a data-cite="HTML/urls-and-fetching.html#document-base-url">Document Base URL</a>
-              of <a data-link-for="LoadDocumentCallback">url</a>, as defined in [[HTML]],
-              using the existing <var>documentUrl</var> as the document's URL.
-              <div class="issue atrisk">
-                The use of the <a data-cite="HTML/urls-and-fetching.html#document-base-url">Document Base URL</a>
-                from [[HTML]] for setting the <a>base IRI</a> of the enclosed JSON-LD
-                is an experimental feature, which may be changed in a future version of this specification.
-              </div>
-            </li>
-            <li>If the <a data-link-for="LoadDocumentCallback">url</a> parameter
-              contains a <a data-cite="RFC3986#section-3.5">fragment identifier</a>,
-              set <var>source</var> to the <a data-cite="DOM#dom-node-textcontent">textContent</a>
-              of the <a data-cite="HTML/scripting.html#the-script-element">script element</a> in <var>document</var>
-              having an <a data-cite="HTML/dom.html#the-id-attribute">id attribute</a>
-              that matches the fragment identifier, after decoding <a data-cite="RFC3986#section-2.1">percent encoded sequences</a>.
-              <p>If no such element is found,
-                or the located element is not a <a>JSON-LD script element</a>,
-                the <var>promise</var> is rejected with a <a>JsonLdError</a> whose code is set to <a data-link-for="JsonLdErrorCode">loading document failed</a>
-                and processing is terminated.</p>
-            </li>
-            <li>Otherwise, if the <a data-link-for="LoadDocumentOptions">profile</a>
-              option is specified,
-              set <var>source</var> to the result of transforming the
-              <a data-cite="DOM#dom-node-textcontent">textContent</a>
-              of the first <a data-cite="HTML/scripting.html#the-script-element">script element</a> in <var>document</var>
-              having an <a data-cite="HTML/semantics.html#attr-link-type">type attribute</a>
-              of <code>application/ld+json</code> along with the value of the
-              <a data-link-for="LoadDocumentOptions">profile</a> option, if found.</li>
-            <li>If <var>source</var> is still undefined and the <a data-link-for="LoadDocumentOptions">extractAllScripts</a> option is not present, or <code>false</code>,
-              set <var>source</var> to the <a data-cite="DOM#dom-node-textcontent">textContent</a>
-              of the first <a>JSON-LD script element</a> in <var>document</var>.
-              <p>If no such element is found,
-                or the located element is not a <a>JSON-LD script element</a>,
-                the <var>promise</var> is rejected with a <a>JsonLdError</a> whose code is set to <a data-link-for="JsonLdErrorCode">loading document failed</a>
-                and processing is terminated.</p></li>
-            <li>If <var>source</var> is defined,
-              set <var>document</var> to the result of the
-              <a href="#extract-script-content">Extract Script Content algorithm</a>,
-              using <var>source</var>, rejecting <var>promise</var>
-              with a <a>JsonLdError</a> whose code set from the result, if an error is detected
-              and processing is terminated.
-            </li>
-            <li>Otherwise, <var>source</var> is undefined.
-              <ol>
-                <li>If the <a data-link-for="LoadDocumentOptions">extractAllScripts</a> option is not present, or <code>false</code>,
-                  the <var>promise</var> is rejected with a <a>JsonLdError</a> whose code is set to <a data-link-for="JsonLdErrorCode">loading document failed</a>
-                  and processing is terminated.</li>              
-                <li>Otherwise, the <a data-link-for="LoadDocumentOptions">extractAllScripts</a> option is <code>true</code>.
-                  Set <var>document</var> to a new empty <a>array</a>.
-                  For each <a>JSON-LD script element</a> in <var>input</var>:
-                  <ol>
-                    <li>Set <var>source</var> to its <a data-cite="DOM#dom-node-textcontent">textContent</a>.</li>
-                    <li>Set <var>script content</var> to the result of the <a href="#extract-script-content">Extract Script Content algorithm</a>,
-                      using <var>source</var>, rejecting <var>promise</var>
-                      with a <a>JsonLdError</a> whose code set from the result, if an error is detected
-                      and processing is terminated.</li>
-                    <li>If <var>script content</var> is an <a>array</a>, merge it to the end of <var>document</var>.</li>
-                    <li>Otherwise, append <var>script content</var> to <var>document</var>.</li>
-                  </ol>
-                </li>
-              </ol>
-            </li>
-          </ol>
-        </li>
         <li>Otherwise, the retrieved document's <a>Content-Type</a> is neither
           <code>application/json</code>,
           <code>application/ld+json</code>,
-          <code>text/html</code>,
           nor any other media type using a
           <code>+json</code> suffix as defined in [[RFC6839]].
           Reject the <var>promise</var> passing a <a data-link-for="JsonLdErrorCode">loading document failed</a> error.</li>
@@ -6002,6 +5860,113 @@
       </dl>
     </section>
   </section> <!-- end of Remote Document and Context Retrieval -->
+
+  <section class="changed">
+    <h2>HTML Content Algorithms</h2>
+    <p class="note">This section describes features available
+      with a <a data-link-for="JsonLdOptions">documentLoader</a> supporting HTML script extraction.</p>
+    <p>Implementations of a <a data-link-for="JsonLdOptions">documentLoader</a> MAY support extracting JSON-LD from
+      <a data-cite="HTML/scripting.html#the-script-element">script elements</a> contained within an HTML [[HTML]] document.
+      This section describes the normative behavior of such processors.
+      Such a processor supports <dfn>HTML script extraction</dfn>.</p>
+
+    <section id="process-html"><h3>Process HTML</h3>
+      <p>This sections describe an extension to the algorithm specified
+        in <a>LoadDocumentCallback</a> to support extracting JSON-LD from HTML.</p>
+
+      <p><a href="#LoadDocumentCallback-step-2">Step 2</a> is updated to add the following: A processor supporting <a>HTML script extraction</a> MUST include <code>text/html</code> at any preference level,
+        unless <a data-link-for="LoadDocumentOptions">requestProfile</a> is `http://www.w3.org/ns/json-ld#context`.</p>
+
+      <p>After <a href="#LoadDocumentCallback-step-5">step 5</a>, add the following processing step:
+        Otherwise, if the retrieved resource's <a>Content-Type</a> is <code>text/html</code>:</p>
+      <ol>
+        <li>If the processor does not support <a>HTML script extraction</a>
+          the <var>promise</var> is rejected with a <a>JsonLdError</a> whose code is set to <a data-link-for="JsonLdErrorCode">loading document failed</a>
+          and processing is terminated.</li>
+        <li>Set <var>documentUrl</var> to the the <a data-cite="HTML/urls-and-fetching.html#document-base-url">Document Base URL</a>
+          of <a data-link-for="LoadDocumentCallback">url</a>, as defined in [[HTML]],
+          using the existing <var>documentUrl</var> as the document's URL.
+          <div class="issue atrisk">
+            The use of the <a data-cite="HTML/urls-and-fetching.html#document-base-url">Document Base URL</a>
+            from [[HTML]] for setting the <a>base IRI</a> of the enclosed JSON-LD
+            is an experimental feature, which may be changed in a future version of this specification.
+          </div>
+        </li>
+        <li>If the <a data-link-for="LoadDocumentCallback">url</a> parameter
+          contains a <a data-cite="RFC3986#section-3.5">fragment identifier</a>,
+          set <var>source</var> to the <a data-cite="DOM#dom-node-textcontent">textContent</a>
+          of the <a data-cite="HTML/scripting.html#the-script-element">script element</a> in <var>document</var>
+          having an <a data-cite="HTML/dom.html#the-id-attribute">id attribute</a>
+          that matches the fragment identifier, after decoding <a data-cite="RFC3986#section-2.1">percent encoded sequences</a>.
+          <p>If no such element is found,
+            or the located element is not a <a>JSON-LD script element</a>,
+            the <var>promise</var> is rejected with a <a>JsonLdError</a> whose code is set to <a data-link-for="JsonLdErrorCode">loading document failed</a>
+            and processing is terminated.</p>
+        </li>
+        <li>Otherwise, if the <a data-link-for="LoadDocumentOptions">profile</a>
+          option is specified,
+          set <var>source</var> to the result of transforming the
+          <a data-cite="DOM#dom-node-textcontent">textContent</a>
+          of the first <a data-cite="HTML/scripting.html#the-script-element">script element</a> in <var>document</var>
+          having an <a data-cite="HTML/semantics.html#attr-link-type">type attribute</a>
+          of <code>application/ld+json</code> along with the value of the
+          <a data-link-for="LoadDocumentOptions">profile</a> option, if found.</li>
+        <li>If <var>source</var> is still undefined and the <a data-link-for="LoadDocumentOptions">extractAllScripts</a> option is not present, or <code>false</code>,
+          set <var>source</var> to the <a data-cite="DOM#dom-node-textcontent">textContent</a>
+          of the first <a>JSON-LD script element</a> in <var>document</var>.
+          <p>If no such element is found,
+            or the located element is not a <a>JSON-LD script element</a>,
+            the <var>promise</var> is rejected with a <a>JsonLdError</a> whose code is set to <a data-link-for="JsonLdErrorCode">loading document failed</a>
+            and processing is terminated.</p></li>
+        <li>If <var>source</var> is defined,
+          set <var>document</var> to the result of the
+          <a href="#extract-script-content">Extract Script Content algorithm</a>,
+          using <var>source</var>, rejecting <var>promise</var>
+          with a <a>JsonLdError</a> whose code set from the result, if an error is detected
+          and processing is terminated.
+        </li>
+        <li>Otherwise, <var>source</var> is undefined.
+          <ol>
+            <li>If the <a data-link-for="LoadDocumentOptions">extractAllScripts</a> option is not present, or <code>false</code>,
+              the <var>promise</var> is rejected with a <a>JsonLdError</a> whose code is set to <a data-link-for="JsonLdErrorCode">loading document failed</a>
+              and processing is terminated.</li>              
+            <li>Otherwise, the <a data-link-for="LoadDocumentOptions">extractAllScripts</a> option is <code>true</code>.
+              Set <var>document</var> to a new empty <a>array</a>.
+              For each <a>JSON-LD script element</a> in <var>input</var>:
+              <ol>
+                <li>Set <var>source</var> to its <a data-cite="DOM#dom-node-textcontent">textContent</a>.</li>
+                <li>Set <var>script content</var> to the result of the <a href="#extract-script-content">Extract Script Content algorithm</a>,
+                  using <var>source</var>, rejecting <var>promise</var>
+                  with a <a>JsonLdError</a> whose code set from the result, if an error is detected
+                  and processing is terminated.</li>
+                <li>If <var>script content</var> is an <a>array</a>, merge it to the end of <var>document</var>.</li>
+                <li>Otherwise, append <var>script content</var> to <var>document</var>.</li>
+              </ol>
+            </li>
+          </ol>
+        </li>
+      </ol>
+    </section>
+
+    <section id="extract-script-content" class="algorithm">
+      <h3>Extract Script Content Algorithm</h3>
+
+      <p>The algorithm extracts the text content a
+        <a>JSON-LD script element</a> into a <a>map</a> or <a>array</a> of <a>maps</a>.
+        A <dfn>JSON-LD script element</dfn> is a <a data-cite="HTML/scripting.html#the-script-element">script element</a>
+        within an HTML [[HTML]] document with the <a data-cite="HTML/semantics.html#attr-link-type">type attribute</a> set to
+        <code>application/ld+json</code>.</p>
+
+      <p>The algorithm takes a single required input variable: <var>source</var>,
+        the <a data-cite="DOM#dom-node-textcontent">textContent</a> of an HTML <a data-cite="HTML/scripting.html#the-script-element">script element</a>.</p>
+
+      <ol>
+      <li>If <var>source</var> is not a valid JSON document,
+        an <a data-link-for="JsonLdErrorCode">invalid script element</a> has been detected, and processing is aborted.</li>
+      <li>Return the result of transforming <var>source</var> into the <a>internal representation</a>.</li>
+      </ol>
+    </section>
+  </section>
 
   <section>
     <h3>Error Handling</h3>
@@ -6350,7 +6315,6 @@
     <li>Added support for <a>JSON literals</a>.</li>
     <li><a>Term definitions</a> with keys which are of the form of a <a>compact IRI</a> or <a>absolute IRI</a> MUST NOT
       expand to an <a>IRI</a> other than the expansion of the key itself.</li>
-    <li>Define different processor modes: <a>pure JSON Processor</a>, <a>event-based JSON processor</a>, and <a>full Processor</a>.</li>
     <li>Consolidate <a>RemoteDocument</a> processing into the <a>LoadDocumentCallback</a>
       including variations on HTML processing.</li>
     <li>The <a href="#iri-compaction">IRI compaction algorithm</a> may generate an error if the result is an


### PR DESCRIPTION
Move HTML bits into a separate section, with callouts into the documentLoader algorithm to contain HTML-related processing. Also, removes processor levels describing this as a processor supporting "HTML script extraction".

For w3c/json-ld-syntax#213.