### PR TITLE
Enable generalized RDF in expansion test 75 for toRdf

### DIFF
--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -922,7 +922,10 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
       "name": "@vocab as blank node identifier",
       "purpose": "Use @vocab to map all properties to blank node identifiers",
-      "option": {"processingMode": "json-ld-1.0"},
+      "option": {
+        "processingMode": "json-ld-1.0",
+        "produceGeneralizedRdf": true
+      },
       "input": "toRdf/e075-in.jsonld",
       "expect": "toRdf/e075-out.nq"
     }, {


### PR DESCRIPTION
Expansion test 75 (in toRdf manifest) produces blank node predicates.
By default, triples with bnode predicates are skipped, unless `produceGeneralizedRdf` is enabled.
As such, this flag should be enabled for this test.