### PR TITLE
Make expandContext option in tests a URI instead of a string

### DIFF
--- a/tests/context.jsonld
+++ b/tests/context.jsonld
@@ -22,7 +22,7 @@
     "compactArrays":        { "@type": "xsd:boolean" },
     "compactToRelative":    { "@type": "xsd:boolean" },
     "contentType":          { "@type": "xsd:boolean" },
-    "expandContext":        { "@type": "xsd:string" },
+    "expandContext":        { "@type": "@id" },
     "httpLink":             { "@type": "xsd:string", "@container": "@set" },
     "httpStatus":           { "@type": "xsd:integer" },
     "processingMode":       { "@type": "xsd:string" },


### PR DESCRIPTION
At the moment, this option is just a string containing a relative URI.
It would be more convenient for test suite handlers to make this option a URI, so that it is resolved to an absolute URI after parsing to RDF.

This will make it consistent with the `context` property for tests.