### PR TITLE
Base URL for rel=alternate is the alternate URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -5757,8 +5757,7 @@
           and the response has an HTTP Link Header [[RFC8288]] using the <code>alternate</code> link relation
           with type `application/ld+json`,
           set <var>url</var> to the associated <code>href</code> relative to the previous <var>url</var>
-          and restart the algorithm from <a href="#LoadDocumentCallback-step-2">step 2</a>,
-          ensuring that <var>documentUrl</var> is set to the original <var>url</var>.</li>
+          and restart the algorithm from <a href="#LoadDocumentCallback-step-2">step 2</a>.</li>
         <li id="LoadDocumentCallback-step-5">If the retrieved resource's <a>Content-Type</a> is <code>application/json</code>
           or any media type with a <code>+json</code> suffix as defined in [[RFC6839]]
           except <code>application/ld+json</code>,

--- a/tests/remote-doc-manifest.jsonld
+++ b/tests/remote-doc-manifest.jsonld
@@ -177,7 +177,7 @@
     }, {
       "@id": "#tla05",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "Base remains that of original document",
+      "name": "Base is that of the alternate URL",
       "purpose": "Load an alternate link if type is not ld+json and rel=alternate.",
       "option": {
         "httpLink": "<la05-alternate.jsonld>; rel=\"alternate\"; type=\"application/ld+json\""

--- a/tests/remote-doc/la05-out.jsonld
+++ b/tests/remote-doc/la05-out.jsonld
@@ -1,4 +1,4 @@
 [{
-  "@id": "https://w3c.github.io/json-ld-api/tests/remote-doc/la05-in.html",
+  "@id": "https://w3c.github.io/json-ld-api/tests/remote-doc/la05-alternate.jsonld",
   "http://example.org/content": [{"@value": "alternate"}]
 }]


### PR DESCRIPTION
not that of the original URL.

Fixes #139


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/142.html" title="Last updated on Aug 27, 2019, 6:01 PM UTC (54ab6e9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/142/ca800b3...54ab6e9.html" title="Last updated on Aug 27, 2019, 6:01 PM UTC (54ab6e9)">Diff</a>