### PR TITLE
Remove caveat about expanding values of terms which are graph contain…

### DIFF
--- a/index.html
+++ b/index.html
@@ -2240,8 +2240,7 @@
                         and <a data-link-for="JsonLdOptions">ordered</a> flags</span>.</li>
                     <li>For each <var>item</var> in <var>index value</var>:
                       <ol class="algorithm changed">
-                        <li>If <var>container mapping</var> includes <code>@graph</code>
-                          and if <var>item</var> is not a <a>graph object</a>,
+                        <li>If <var>container mapping</var> includes <code>@graph</code>,
                           set <var>item</var> to a new <a>map</a> containing the key-value pair
                           <code>@graph</code>-<var>item</var>,
                           ensuring that the value is represented using an <a>array</a>.</li>

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -580,7 +580,7 @@
     }, {
       "@id": "#t0081",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "Does not create an @graph container if value is a graph",
+      "name": "Creates an @graph container if value is a graph",
       "purpose": "Don't double-expand an already expanded graph",
       "input": "expand/0081-in.jsonld",
       "expect": "expand/0081-out.jsonld",

--- a/tests/expand/0081-out.jsonld
+++ b/tests/expand/0081-out.jsonld
@@ -1,7 +1,9 @@
 [{
   "http://example.org/input": [{
     "@graph": [{
-      "http://example.org/value": [{"@value": "x"}]
+      "@graph": [{
+        "http://example.org/value": [{"@value": "x"}]
+      }]
     }]
   }]
 }]

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -974,7 +974,7 @@
     }, {
       "@id": "#te081",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
-      "name": "Does not create an @graph container if value is a graph",
+      "name": "Creates an @graph container if value is a graph",
       "purpose": "Don't double-expand an already expanded graph",
       "input": "toRdf/e081-in.jsonld",
       "expect": "toRdf/e081-out.nq",
@@ -1090,7 +1090,7 @@
     }, {
       "@id": "#te095",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
-      "name": "Does not create an @graph container if value is a graph (multiple objects)",
+      "name": "Creates an @graph container if value is a graph (multiple objects)",
       "purpose": "Don't double-expand an already expanded graph",
       "input": "toRdf/e095-in.jsonld",
       "expect": "toRdf/e095-out.nq",
@@ -1146,7 +1146,7 @@
     }, {
       "@id": "#te102",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
-      "name": "Do not expand @graph container if value is a graph (multiple objects)",
+      "name": "Expand @graph container if value is a graph (multiple objects)",
       "purpose": "Does not create a new graph object if indexed value is already a graph object",
       "input": "toRdf/e102-in.jsonld",
       "expect": "toRdf/e102-out.nq",
@@ -1154,7 +1154,7 @@
     }, {
       "@id": "#te103",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
-      "name": "Do not expand @graph container if value is a graph (multiple graphs)",
+      "name": "Expand @graph container if value is a graph (multiple graphs)",
       "purpose": "Does not create a new graph object if indexed value is already a graph object",
       "input": "toRdf/e103-in.jsonld",
       "expect": "toRdf/e103-out.nq",
@@ -1162,7 +1162,7 @@
     }, {
       "@id": "#te104",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
-      "name": "Does not create an @graph container if value is a graph (mixed graph and object)",
+      "name": "Creates an @graph container if value is a graph (mixed graph and object)",
       "purpose": "Don't double-expand an already expanded graph",
       "input": "toRdf/e104-in.jsonld",
       "expect": "toRdf/e104-out.nq",

--- a/tests/toRdf/e081-out.nq
+++ b/tests/toRdf/e081-out.nq
@@ -1,2 +1,2 @@
 _:b0 <http://example.org/input> _:b1 .
-_:b2 <http://example.org/value> "x" _:b1 .
+_:b3 <http://example.org/value> "x" _:b2 .

--- a/tests/toRdf/e095-out.nq
+++ b/tests/toRdf/e095-out.nq
@@ -1,4 +1,4 @@
-_:b4 <http://example.org/value> "y" _:b3 .
-_:b0 <http://example.org/input> _:b3 .
 _:b0 <http://example.org/input> _:b1 .
-_:b2 <http://example.org/value> "x" _:b1 .
+_:b0 <http://example.org/input> _:b4 .
+_:b3 <http://example.org/value> "x" _:b2 .
+_:b6 <http://example.org/value> "y" _:b5 .

--- a/tests/toRdf/e102-out.nq
+++ b/tests/toRdf/e102-out.nq
@@ -1,3 +1,3 @@
 _:b0 <http://example.org/input> _:b1 .
-_:b3 <http://example.org/value> "y" _:b1 .
-_:b2 <http://example.org/value> "x" _:b1 .
+_:b3 <http://example.org/value> "x" _:b2 .
+_:b4 <http://example.org/value> "y" _:b2 .

--- a/tests/toRdf/e103-out.nq
+++ b/tests/toRdf/e103-out.nq
@@ -1,4 +1,4 @@
-_:b4 <http://example.org/value> "y" _:b3 .
-_:b0 <http://example.org/input> _:b3 .
 _:b0 <http://example.org/input> _:b1 .
-_:b2 <http://example.org/value> "x" _:b1 .
+_:b0 <http://example.org/input> _:b4 .
+_:b3 <http://example.org/value> "x" _:b2 .
+_:b6 <http://example.org/value> "y" _:b5 .

--- a/tests/toRdf/e104-out.nq
+++ b/tests/toRdf/e104-out.nq
@@ -1,4 +1,4 @@
-_:b4 <http://example.org/value> "y" _:b3 .
-_:b0 <http://example.org/input> _:b3 .
+_:b3 <http://example.org/value> "x" _:b2 .
+_:b5 <http://example.org/value> "y" _:b4 .
+_:b0 <http://example.org/input> _:b4 .
 _:b0 <http://example.org/input> _:b1 .
-_:b2 <http://example.org/value> "x" _:b1 .


### PR DESCRIPTION
…ers where the value is already a graph.

Fixes #144. Relates to #143.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/145.html" title="Last updated on Sep 1, 2019, 8:56 PM UTC (6507941)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/145/4399a93...6507941.html" title="Last updated on Sep 1, 2019, 8:56 PM UTC (6507941)">Diff</a>