### PR TITLE
Wrap multiple object values of a term which is a graph container

### DIFF
--- a/common/algorithm-terms.html
+++ b/common/algorithm-terms.html
@@ -16,7 +16,7 @@
     A <a>map</a> containing values for
     the <a>object embed flag</a>,
     the <a>require all flag</a>,
-    <span class="changed">the <a>embedded flag</a>,
+    <span class="changed">the <a data-cite="JSON-LD11-FRAMING#dfn-embedded-flag">embedded flag</a>,
     used internally to help determine if object embedding is appropriate,</span>
     the <a>explicit inclusion flag</a>,
     and the <a>omit default flag</a>.</dd>

--- a/index.html
+++ b/index.html
@@ -2954,13 +2954,13 @@
                     <li>If <var>container</var> includes <code>@graph</code> and <code>@id</code>:
                       <ol>
                         <li>Initialize <var>map object</var> to the value of <var>item active property</var>
-                          in <var class="changed">nest result</var>.</li>
+                          in <var>nest result</var>.</li>
                         <li>Initialize <var>map key</var> to the result of calling the
                           <a href="#iri-compaction">IRI Compaction algorithm</a>
                           passing <var>active context</var>, <var>inverse context</var>, and the value of <code>@id</code> in <var>expanded item</var>
                           or <code>@none</code> if no such value exists as <var>var</var>, with <var>vocab</var> set to <code>true</code>
                           if there is no <code>@id</code> <a>entry</a> in <var>expanded item</var>.</li>
-                        <li class="changed">If <var>compacted item</var> is not an
+                        <li>If <var>compacted item</var> is not an
                           <a>array</a> and <var>as array</var> is <code>true</code>,
                           set <var>compacted item</var> to an <a>array</a> containing that value.</li>
                         <li>If <var>map key</var> is not an <a>entry</a> in <var>map object</var>,
@@ -2975,11 +2975,11 @@
                       and <var>expanded item</var> is a <a>simple graph object</a>:
                       <ol>
                         <li>Initialize <var>map object</var> to the value of <var>item active property</var>
-                          in <var class="changed">nest result</var>.</li>
+                          in <var>nest result</var>.</li>
                         <li>Initialize <var>map key</var> the value of <code>@index</code> in
                           <var>expanded item</var> or <code>@none</code>, if no such
                           value exists.</li>
-                        <li class="changed">If <var>compacted item</var> is not an
+                        <li>If <var>compacted item</var> is not an
                           <a>array</a> and <var>as array</var> is <code>true</code>,
                           set <var>compacted item</var> to an <a>array</a> containing that value.</li>
                         <li>If <var>map key</var> is not an <a>entry</a> in <var>map object</var>,
@@ -2991,17 +2991,27 @@
                       </ol>
                     </li>
                     <li>Otherwise, if <var>container</var> includes <code>@graph</code>
-                      and <var>expanded item</var> is a <a>simple graph
-                      object</a> the value cannot be represented as a map
-                      object. If <var>compacted item</var> is not an <a>array</a>
-                      and <var>as array</var> is <code>true</code>, set
-                      <var>compacted item</var> to an <a>array</a> containing
-                      that value. If the value of an <var>item active property</var> <a>entry</a> in
-                      <var class="changed">nest result</var> is not an <a>array</a>,
-                      set it to a new <a>array</a> containing only the value.
-                      Then append <var>compacted item</var> to the value if
-                      <var>compacted item</var> is not an <a>array</a>,
-                      otherwise, concatenate it.
+                      and <var>expanded item</var> is a <a>simple graph object</a>
+                      the value cannot be represented as a map object.
+                      <ol>
+                        <li>If <var>compacted item</var> is not an <a>array</a>
+                          and <var>as array</var> is <code>true</code>,
+                          set <var>compacted item</var> to an <a>array</a> containing that value.</li>
+                        <li>If <var>compacted item</var> is an <a>array</a>
+                          with more than one value, it cannot be directly represented,
+                          as multiple objects would be interpreted as different named graphs.
+                          Set <var>compacted item</var> to a new <a>map</a>,
+                          containing the key created by calling the <a href="#iri-compaction">IRI Compaction algorithm</a>
+                          passing <var>active context</var>, <var>inverse context</var>, `@included` as
+                          <var>var</var>, and `true` for
+                          <var>vocab</var> and the original <var>compacted item</var> as the value. </li>
+                        <li>If the value of an <var>item active property</var> <a>entry</a> in <var>nest result</var>
+                          is not an <a>array</a>,
+                          set it to a new <a>array</a> containing only the value.</li>
+                        <li>Then append <var>compacted item</var> to the value if
+                          <var>compacted item</var> is not an <a>array</a>,
+                          otherwise, concatenate it.</li>
+                      </ol>                      
                     </li>
                     <li>Otherwise, <var>container</var> does not include <code>@graph</code>
                       or otherwise does not match one of the previous cases, redo <var>compacted item</var>.

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -800,7 +800,7 @@
     }, {
       "@id": "#t0096",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
-      "name": "Compact @graph container (multiple objects)",
+      "name": "Compact @graph container (multiple graphs)",
       "purpose": "Ensure @graph appears properly in output",
       "input": "compact/0096-in.jsonld",
       "context": "compact/0096-context.jsonld",
@@ -809,7 +809,7 @@
     }, {
       "@id": "#t0097",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
-      "name": "Compact [@graph, @set] container (multiple objects)",
+      "name": "Compact [@graph, @set] container (multiple graphs)",
       "purpose": "Ensure @graph appears properly in output",
       "input": "compact/0097-in.jsonld",
       "context": "compact/0097-context.jsonld",
@@ -914,6 +914,24 @@
       "input": "compact/0108-in.jsonld",
       "context": "compact/0108-context.jsonld",
       "expect": "compact/0108-out.jsonld"
+    }, {
+      "@id": "#t0109",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Compact @graph container (multiple objects)",
+      "purpose": "Multiple objects in a simple graph with a graph container need to use @included",
+      "input": "compact/0109-in.jsonld",
+      "context": "compact/0109-context.jsonld",
+      "expect": "compact/0109-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#t0110",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Compact [@graph, @set] container (multiple objects)",
+      "purpose": "Multiple objects in a simple graph with a graph container need to use @included",
+      "input": "compact/0110-in.jsonld",
+      "context": "compact/0110-context.jsonld",
+      "expect": "compact/0110-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tc001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],

--- a/tests/compact/0109-context.jsonld
+++ b/tests/compact/0109-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "input": {"@id": "foo:input", "@container": "@graph"},
+    "value": "foo:value"
+  }
+}

--- a/tests/compact/0109-in.jsonld
+++ b/tests/compact/0109-in.jsonld
@@ -1,0 +1,8 @@
+[{
+  "foo:input": [{
+    "@graph": [
+      {"foo:value": "x"},
+      {"foo:value": "y"}
+    ]
+  }]
+}]

--- a/tests/compact/0109-out.jsonld
+++ b/tests/compact/0109-out.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "input": {"@id": "foo:input", "@container": "@graph"},
+    "value": "foo:value"
+  },
+  "input": {
+    "@included": [{
+      "value": "x"
+    }, {
+      "value": "y"
+    }]
+  }
+}

--- a/tests/compact/0110-context.jsonld
+++ b/tests/compact/0110-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "input": {"@id": "foo:input", "@container": ["@graph", "@set"]},
+    "value": "foo:value"
+  }
+}

--- a/tests/compact/0110-in.jsonld
+++ b/tests/compact/0110-in.jsonld
@@ -1,0 +1,8 @@
+[{
+  "foo:input": [{
+    "@graph": [
+      {"foo:value": "x"},
+      {"foo:value": "y"}
+    ]
+  }]
+}]

--- a/tests/compact/0110-out.jsonld
+++ b/tests/compact/0110-out.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "input": {"@id": "foo:input", "@container": ["@graph", "@set"]},
+    "value": "foo:value"
+  },
+  "input": [{
+    "@included": [{
+      "value": "x"
+    }, {
+      "value": "y"
+    }]
+  }]
+}


### PR DESCRIPTION
... using `@included`, to make sure they are all contained in a single graph.

Fixes #143.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/146.html" title="Last updated on Sep 2, 2019, 8:44 PM UTC (b3cf1f1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/146/717ea94...b3cf1f1.html" title="Last updated on Sep 2, 2019, 8:44 PM UTC (b3cf1f1)">Diff</a>