### PR TITLE
Add invalid JSON literal error and tests.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4981,7 +4981,11 @@
               and <var>value</var> is a <a>JSON literal</a>,
               set the <code>@value</code> <a>entry</a> to the result of
               turning the lexical value of <var>value</var>
-              into the <a>JSON-LD internal representation</a>, and set <var>type</var> to <code>@json</code>.</li>
+              into the <a>JSON-LD internal representation</a>, and set <var>type</var> to <code>@json</code>.
+              If the the lexical value of <var>value</var> is not valid JSON according to
+              the <a data-cite="RFC8259#section-2">JSON Grammar</a> [[RFC8259]],
+              an <a data-link-for="JsonLdErrorCode">invalid JSON literal</a>
+              error has been detected and processing is aborted.</li>
             <li>Otherwise, if <var>value</var> is a
               <a>language-tagged string</a>
               add a <a>entry</a> <code>@language</code> to <var>result</var> and set its value to the
@@ -6068,6 +6072,8 @@
         <dd>An <code>@id</code> <a>entry</a> was encountered whose value was not a <a>string</a>.</dd>
         <dt><dfn>invalid @index value</dfn></dt>
         <dd>An <code>@index</code> <a>entry</a> was encountered whose value was not a <a>string</a>.</dd>
+        <dt class="changed"><dfn>invalid JSON literal</dfn></dt>
+        <dd class="changed">An invalid JSON literal was detected.</dd>
         <dt class="changed"><dfn>invalid @nest value</dfn></dt>
         <dd class="changed">An invalid value for <code>@nest</code> has been found.</dd>
         <dt class="changed"><dfn>invalid @prefix value</dfn></dt>

--- a/tests/fromRdf-manifest.jsonld
+++ b/tests/fromRdf-manifest.jsonld
@@ -252,6 +252,22 @@
       "expect": "fromRdf/js07-out.jsonld",
       "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.1"}
     }, {
+      "@id": "#tjs08",
+      "@type": ["jld:NegativeEvaluationTest", "jld:FromRDFTest"],
+      "name": "Invalid JSON literal (bare-word)",
+      "purpose": "Processors must generate an error when deserializing an invalid JSON literal.",
+      "input": "fromRdf/js08-in.nq",
+      "expect": "invalid JSON literal",
+      "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tjs09",
+      "@type": ["jld:NegativeEvaluationTest", "jld:FromRDFTest"],
+      "name": "Invalid JSON literal (invalid structure)",
+      "purpose": "Processors must generate an error when deserializing an invalid JSON literal.",
+      "input": "fromRdf/js09-in.nq",
+      "expect": "invalid JSON literal",
+      "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.1"}
+    }, {
       "@id": "#tli01",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
       "name": "@list containing empty @list",

--- a/tests/fromRdf/js08-in.nq
+++ b/tests/fromRdf/js08-in.nq
@@ -1,0 +1,1 @@
+<http://example.org/vocab#id> <http://example.org/vocab#invalid> "bareword"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON> .

--- a/tests/fromRdf/js09-in.nq
+++ b/tests/fromRdf/js09-in.nq
@@ -1,0 +1,1 @@
+<http://example.org/vocab#id> <http://example.org/vocab#invalid> "[{]"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON> .


### PR DESCRIPTION
Fixes #149


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/150.html" title="Last updated on Sep 11, 2019, 7:40 PM UTC (53b941f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/150/dd0311b...53b941f.html" title="Last updated on Sep 11, 2019, 7:40 PM UTC (53b941f)">Diff</a>