### PR TITLE
Add minor spec update and tests for JSON literal string and null values.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2150,7 +2150,9 @@
                   <var>active property</var>, <var>value</var> for <var>element</var>,
                   <span class="changed">and the {{JsonLdOptions/frameExpansion}}
                     and {{JsonLdOptions/ordered}} flags</span>.</li>
-                <li>Unless <var>expanded value</var> is <code>null</code>, set
+                <li>Unless <var>expanded value</var> is <code>null</code>,
+                  <span class="changed">and <var>expanded property</var> is `@value`,
+                    and <var>input type</var> is `@json`</span>, set
                   the <var>expanded property</var> <a>entry</a> of <var>result</var> to
                   <var>expanded value</var>.</li>
                 <li>Continue with the next <var>key</var> from <var>element</var>.</li>

--- a/tests/compact-manifest.html
+++ b/tests/compact-manifest.html
@@ -5054,6 +5054,74 @@ Test tjs09 Compact already expanded JSON literal with aliased keys
 </dd>
 </dl>
 </dd>
+<dt id='tjs10'>
+Test tjs10 Compact JSON literal (string)
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tjs10</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:CompactTest</dd>
+<dt>Purpose</dt>
+<dd>Tests compacting property with @type @json to a JSON literal (string).</dd>
+<dt>input</dt>
+<dd>
+<a href='compact/js10-in.jsonld'>compact/js10-in.jsonld</a>
+</dd>
+<dt>context</dt>
+<dd>
+<a href='compact/js10-context.jsonld'>compact/js10-context.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='compact/js10-out.jsonld'>compact/js10-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+<dt>processingMode</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='tjs11'>
+Test tjs11 Compact JSON literal (null)
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tjs11</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:CompactTest</dd>
+<dt>Purpose</dt>
+<dd>Tests compacting property with @type @json to a JSON literal (null).</dd>
+<dt>input</dt>
+<dd>
+<a href='compact/js11-in.jsonld'>compact/js11-in.jsonld</a>
+</dd>
+<dt>context</dt>
+<dd>
+<a href='compact/js11-context.jsonld'>compact/js11-context.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='compact/js11-out.jsonld'>compact/js11-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+<dt>processingMode</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
 <dt id='tm001'>
 Test tm001 Indexes to object not having an @id
 </dt>

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -1436,6 +1436,24 @@
       "context": "compact/js09-context.jsonld",
       "expect": "compact/js09-out.jsonld",
       "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tjs10",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Compact JSON literal (string)",
+      "purpose": "Tests compacting property with @type @json to a JSON literal (string).",
+      "input": "compact/js10-in.jsonld",
+      "context": "compact/js10-context.jsonld",
+      "expect": "compact/js10-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tjs11",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Compact JSON literal (null)",
+      "purpose": "Tests compacting property with @type @json to a JSON literal (null).",
+      "input": "compact/js11-in.jsonld",
+      "context": "compact/js11-context.jsonld",
+      "expect": "compact/js11-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.1"}
    }, {
       "@id": "#tm001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],

--- a/tests/compact/js10-context.jsonld
+++ b/tests/compact/js10-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "e": {"@id": "http://example.org/vocab#string", "@type": "@json"}
+  }
+}

--- a/tests/compact/js10-in.jsonld
+++ b/tests/compact/js10-in.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example.org/vocab#string": [{
+    "@value": "string",
+    "@type": "@json"
+  }]
+}]

--- a/tests/compact/js10-out.jsonld
+++ b/tests/compact/js10-out.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "e": {"@id": "http://example.org/vocab#string", "@type": "@json"}
+  },
+  "e": "string"
+}

--- a/tests/compact/js11-context.jsonld
+++ b/tests/compact/js11-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "e": {"@id": "http://example.org/vocab#null", "@type": "@json"}
+  }
+}

--- a/tests/compact/js11-in.jsonld
+++ b/tests/compact/js11-in.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example.org/vocab#null": [{
+    "@value": null,
+    "@type": "@json"
+  }]
+}]

--- a/tests/compact/js11-out.jsonld
+++ b/tests/compact/js11-out.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "e": {"@id": "http://example.org/vocab#null", "@type": "@json"}
+  },
+  "e": null
+}

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -5630,6 +5630,62 @@ Test tjs10 Expand JSON literal aleady in expanded form with aliased keys
 </dd>
 </dl>
 </dd>
+<dt id='tjs11'>
+Test tjs11 Expand JSON literal (string)
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tjs11</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>Tests expanding JSON literal in expanded form with aliased keys in value object.</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/js11-in.jsonld'>expand/js11-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='expand/js11-out.jsonld'>expand/js11-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='tjs12'>
+Test tjs12 Expand JSON literal (null)
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tjs12</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>Tests expanding JSON literal in expanded form with aliased keys in value object.</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/js12-in.jsonld'>expand/js12-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='expand/js12-out.jsonld'>expand/js12-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
 <dt id='tl001'>
 Test tl001 Language map with null value
 </dt>

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -1677,6 +1677,22 @@
       "expect": "expand/js10-out.jsonld",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tjs11",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Expand JSON literal (string)",
+      "purpose": "Tests expanding JSON literal in expanded form with aliased keys in value object.",
+      "input": "expand/js11-in.jsonld",
+      "expect": "expand/js11-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tjs12",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Expand JSON literal (null)",
+      "purpose": "Tests expanding JSON literal in expanded form with aliased keys in value object.",
+      "input": "expand/js12-in.jsonld",
+      "expect": "expand/js12-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tl001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "Language map with null value",

--- a/tests/expand/js11-in.jsonld
+++ b/tests/expand/js11-in.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "e": {"@id": "http://example.org/vocab#string", "@type": "@json"}
+  },
+  "e": "string"
+}

--- a/tests/expand/js11-out.jsonld
+++ b/tests/expand/js11-out.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example.org/vocab#string": [{
+    "@value": "string",
+    "@type": "@json"
+  }]
+}]

--- a/tests/expand/js12-in.jsonld
+++ b/tests/expand/js12-in.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "e": {"@id": "http://example.org/vocab#null", "@type": "@json"}
+  },
+  "e": null
+}

--- a/tests/expand/js12-out.jsonld
+++ b/tests/expand/js12-out.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example.org/vocab#null": [{
+    "@value": null,
+    "@type": "@json"
+  }]
+}]

--- a/tests/flatten-manifest.html
+++ b/tests/flatten-manifest.html
@@ -87,7 +87,7 @@ to the <a href="mailto:json-ld-wg@w3.org">JSON-LD Working Group mailing list</a>
 <dt>baseIri</dt>
 <dd>https://w3c.github.io/json-ld-api/tests/</dd>
 </dl>
-<p>JSON-LD flattening tests.</p>
+<p>JSON-LD Flattening tests.</p>
 <section>
 <h2>
 Test sequence:

--- a/tests/fromRdf-manifest.html
+++ b/tests/fromRdf-manifest.html
@@ -865,6 +865,126 @@ Test tjs07 JSON literal (array)
 </dd>
 </dl>
 </dd>
+<dt id='tjs08'>
+Test tjs08 Invalid JSON literal (bare-word)
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tjs08</dd>
+<dt>Type</dt>
+<dd>jld:NegativeEvaluationTest, jld:FromRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Processors must generate an error when deserializing an invalid JSON literal.</dd>
+<dt>input</dt>
+<dd>
+<a href='fromRdf/js08-in.nq'>fromRdf/js08-in.nq</a>
+</dd>
+<dt>expect</dt>
+<dd>
+invalid JSON literal
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+<dt>processingMode</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='tjs09'>
+Test tjs09 Invalid JSON literal (invalid structure)
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tjs09</dd>
+<dt>Type</dt>
+<dd>jld:NegativeEvaluationTest, jld:FromRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Processors must generate an error when deserializing an invalid JSON literal.</dd>
+<dt>input</dt>
+<dd>
+<a href='fromRdf/js09-in.nq'>fromRdf/js09-in.nq</a>
+</dd>
+<dt>expect</dt>
+<dd>
+invalid JSON literal
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+<dt>processingMode</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='tjs10'>
+Test tjs10 JSON literal (string)
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tjs10</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:FromRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Tests creating property with rdf:type rdf:JSON to a JSON literal (string).</dd>
+<dt>input</dt>
+<dd>
+<a href='fromRdf/js10-in.nq'>fromRdf/js10-in.nq</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='fromRdf/js10-out.jsonld'>fromRdf/js10-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+<dt>processingMode</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='tjs11'>
+Test tjs11 JSON literal (null)
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tjs11</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:FromRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Tests creating property with rdf:type rdf:JSON to a JSON literal (null).</dd>
+<dt>input</dt>
+<dd>
+<a href='fromRdf/js11-in.nq'>fromRdf/js11-in.nq</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='fromRdf/js11-out.jsonld'>fromRdf/js11-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+<dt>processingMode</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
 <dt id='tli01'>
 Test tli01 @list containing empty @list
 </dt>

--- a/tests/fromRdf-manifest.jsonld
+++ b/tests/fromRdf-manifest.jsonld
@@ -268,6 +268,22 @@
       "expect": "invalid JSON literal",
       "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.1"}
     }, {
+      "@id": "#tjs10",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
+      "name": "JSON literal (string)",
+      "purpose": "Tests creating property with rdf:type rdf:JSON to a JSON literal (string).",
+      "input": "fromRdf/js10-in.nq",
+      "expect": "fromRdf/js10-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tjs11",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
+      "name": "JSON literal (null)",
+      "purpose": "Tests creating property with rdf:type rdf:JSON to a JSON literal (null).",
+      "input": "fromRdf/js11-in.nq",
+      "expect": "fromRdf/js11-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.1"}
+    }, {
       "@id": "#tli01",
       "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
       "name": "@list containing empty @list",

--- a/tests/fromRdf/js10-in.nq
+++ b/tests/fromRdf/js10-in.nq
@@ -1,0 +1,1 @@
+<http://example.org/vocab#id> <http://example.org/vocab#string> "\"string\""^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON> .

--- a/tests/fromRdf/js10-out.jsonld
+++ b/tests/fromRdf/js10-out.jsonld
@@ -1,0 +1,7 @@
+[{
+  "@id": "http://example.org/vocab#id",
+  "http://example.org/vocab#string": [{
+    "@value": "string",
+    "@type": "@json"
+  }]
+}]

--- a/tests/fromRdf/js11-in.nq
+++ b/tests/fromRdf/js11-in.nq
@@ -1,0 +1,1 @@
+<http://example.org/vocab#id> <http://example.org/vocab#null> "null"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON> .

--- a/tests/fromRdf/js11-out.jsonld
+++ b/tests/fromRdf/js11-out.jsonld
@@ -1,0 +1,7 @@
+[{
+  "@id": "http://example.org/vocab#id",
+  "http://example.org/vocab#null": [{
+    "@value": null,
+    "@type": "@json"
+  }]
+}]

--- a/tests/html-manifest.html
+++ b/tests/html-manifest.html
@@ -3,7 +3,7 @@
 <head>
 <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
 <title>
-Expansion
+HTML
 </title>
 <link href='html-manifest.jsonld' rel='alternate'>
 <link href='https://www.w3.org/StyleSheets/TR/base' rel='stylesheet'>
@@ -14,7 +14,7 @@ Expansion
 <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
 </a>
 </p>
-<h1>Expansion</h1>
+<h1>HTML</h1>
 <p>This is an HTML version of a test manifest. The JSON-LD version of this manifest may be found at
 <a href="json_file">html-manifest.jsonld</a>. The manifest vocabulary is described in the <a href="vocab.html">JSON-LD Test Vocabulary</a> (<a href="vocab.jsonld">JSON-LD</a>, <a href="vocab.ttl">Turtle</a>) and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
 

--- a/tests/remote-doc-manifest.html
+++ b/tests/remote-doc-manifest.html
@@ -101,7 +101,7 @@ to the <a href="mailto:json-ld-wg@w3.org">JSON-LD Working Group mailing list</a>
 <dt>baseIri</dt>
 <dd>https://w3c.github.io/json-ld-api/tests/</dd>
 </dl>
-<p>JSON-LD remote document tests.</p>
+<p>JSON-LD Remote Document tests.</p>
 <section>
 <h2>
 Test sequence:

--- a/tests/toRdf-manifest.html
+++ b/tests/toRdf-manifest.html
@@ -82,7 +82,7 @@ to the <a href="mailto:json-ld-wg@w3.org">JSON-LD Working Group mailing list</a>
 <dt>baseIri</dt>
 <dd>https://w3c.github.io/json-ld-api/tests/</dd>
 </dl>
-<p>JSON-LD to RDF tests.</p>
+<p>JSON-LD To RDF tests.</p>
 <section>
 <h2>
 Test sequence:
@@ -4474,6 +4474,62 @@ Test tjs13 Transform JSON literal with wierd canonicalization
 <dt>expect</dt>
 <dd>
 <a href='toRdf/js13-out.nq'>toRdf/js13-out.nq</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='tjs14'>
+Test tjs14 Tests transforming property with @type @json to a JSON literal (string)
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tjs14</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Tests transforming JSON literal with wierd canonicalization.</dd>
+<dt>input</dt>
+<dd>
+<a href='toRdf/js14-in.jsonld'>toRdf/js14-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='toRdf/js14-out.nq'>toRdf/js14-out.nq</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='tjs15'>
+Test tjs15 Tests transforming property with @type @json to a JSON literal (null)
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tjs15</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Tests transforming JSON literal with wierd canonicalization.</dd>
+<dt>input</dt>
+<dd>
+<a href='toRdf/js15-in.jsonld'>toRdf/js15-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='toRdf/js15-out.nq'>toRdf/js15-out.nq</a>
 </dd>
 <dt>Options</dt>
 <dd>

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -1395,6 +1395,22 @@
       "expect": "toRdf/js13-out.nq",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tjs14",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Tests transforming property with @type @json to a JSON literal (string)",
+      "purpose": "Tests transforming JSON literal with wierd canonicalization.",
+      "input": "toRdf/js14-in.jsonld",
+      "expect": "toRdf/js14-out.nq",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tjs15",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Tests transforming property with @type @json to a JSON literal (null)",
+      "purpose": "Tests transforming JSON literal with wierd canonicalization.",
+      "input": "toRdf/js15-in.jsonld",
+      "expect": "toRdf/js15-out.nq",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tli01",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
       "name": "@list containing @list",

--- a/tests/toRdf/js14-in.jsonld
+++ b/tests/toRdf/js14-in.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "e": {"@id": "http://example.org/vocab#string", "@type": "@json"}
+  },
+  "e": "string"
+}

--- a/tests/toRdf/js14-out.nq
+++ b/tests/toRdf/js14-out.nq
@@ -1,0 +1,1 @@
+_:b0 <http://example.org/vocab#string> "\"string\""^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON> .

--- a/tests/toRdf/js15-in.jsonld
+++ b/tests/toRdf/js15-in.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "e": {"@id": "http://example.org/vocab#null", "@type": "@json"}
+  },
+  "e": null
+}

--- a/tests/toRdf/js15-out.nq
+++ b/tests/toRdf/js15-out.nq
@@ -1,0 +1,1 @@
+_:b0 <http://example.org/vocab#null> "null"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON> .


### PR DESCRIPTION
Supplemental to #149.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/155.html" title="Last updated on Sep 23, 2019, 8:05 PM UTC (d78f6b0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/155/ea646cb...d78f6b0.html" title="Last updated on Sep 23, 2019, 8:05 PM UTC (d78f6b0)">Diff</a>