### PR TITLE
Add tests to check for keyword redefinition allowing `@protected`.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1365,8 +1365,10 @@
         <li class="changed">If <a>processing mode</a>
           is <code>json-ld-1.1</code>
           and <var>term</var> is <code>@type</code>, <var>value</var>
-          MUST be a <a>map</a> with the entry <code>@container</code>
-          and value <code>@set</code>. Any other value means that a
+          MUST be a <a>map</a> with only the entry <code>@container</code>
+          and value <code>@set</code>
+          and optional entry `@protected`.
+          Any other value means that a
           <a data-link-for="JsonLdErrorCode">keyword redefinition</a> error has
           been detected and processing is aborted.</li>
         <li><span class="changed">Otherwise</span>, since <a>keywords</a> cannot be overridden,

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -8128,6 +8128,90 @@ Test tpr29 Does not expand a Compact IRI using a non-prefix term.
 </dd>
 </dl>
 </dd>
+<dt id='tpr30'>
+Test tpr30 Keywords may be protected.
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tpr30</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>Keywords may not be redefined other than to protect them.</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/pr30-in.jsonld'>expand/pr30-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='expand/pr30-out.jsonld'>expand/pr30-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='tpr31'>
+Test tpr31 Protected keyword aliases cannot be overridden.
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tpr31</dd>
+<dt>Type</dt>
+<dd>jld:NegativeEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>Keywords may not be redefined other than to protect them.</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/pr31-in.jsonld'>expand/pr31-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+protected term redefinition
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='tpr32'>
+Test tpr32 Protected @type cannot be overridden.
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tpr32</dd>
+<dt>Type</dt>
+<dd>jld:NegativeEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>Keywords may not be redefined other than to protect them.</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/pr32-in.jsonld'>expand/pr32-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+protected term redefinition
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
 <dt id='tpr33'>
 Test tpr33 Fails if trying to declare a keyword alias as prefix.
 </dt>

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -2369,6 +2369,30 @@
       "input": "expand/pr29-in.jsonld",
       "expect": "expand/pr29-out.jsonld"
     }, {
+      "@id": "#tpr30",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Keywords may be protected.",
+      "purpose": "Keywords may not be redefined other than to protect them.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/pr30-in.jsonld",
+      "expect": "expand/pr30-out.jsonld"
+    }, {
+      "@id": "#tpr31",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "Protected keyword aliases cannot be overridden.",
+      "purpose": "Keywords may not be redefined other than to protect them.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/pr31-in.jsonld",
+      "expect": "protected term redefinition"
+    }, {
+      "@id": "#tpr32",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "Protected @type cannot be overridden.",
+      "purpose": "Keywords may not be redefined other than to protect them.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/pr32-in.jsonld",
+      "expect": "protected term redefinition"
+    }, {
       "@id": "#tpr33",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "Fails if trying to declare a keyword alias as prefix.",

--- a/tests/expand/pr30-in.jsonld
+++ b/tests/expand/pr30-in.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "id": {"@id": "@id", "@protected": true},
+    "type": {"@id" : "@type", "@container": "@set", "@protected" : true},
+    "@type": {"@container": "@set", "@protected": true}
+  },
+  "id": "http://example.com/1",
+  "type": "http://example.org/ns/Foo",
+  "@type": "http://example.org/ns/Bar"
+}

--- a/tests/expand/pr30-out.jsonld
+++ b/tests/expand/pr30-out.jsonld
@@ -2,8 +2,8 @@
   {
     "@id": "http://example.com/1",
     "@type": [
-      "http://example.org/ns/Foo",
-      "http://example.org/ns/Bar"
+      "http://example.org/ns/Bar",
+      "http://example.org/ns/Foo"
     ]
   }
 ]

--- a/tests/expand/pr30-out.jsonld
+++ b/tests/expand/pr30-out.jsonld
@@ -1,0 +1,9 @@
+[
+  {
+    "@id": "http://example.com/1",
+    "@type": [
+      "http://example.org/ns/Foo",
+      "http://example.org/ns/Bar"
+    ]
+  }
+]

--- a/tests/expand/pr31-in.jsonld
+++ b/tests/expand/pr31-in.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": [{
+    "@version": 1.1,
+    "id": {"@id": "@id", "@protected": true},
+    "type": {"@id" : "@type", "@container": "@set", "@protected" : true},
+    "@type": {"@container": "@set", "@protected": true}
+  }, {
+    "@version": 1.1,
+    "id": "http://example.com/id"
+  }],
+  "id": "http://example.com/1",
+  "type": ["http://example.org/ns/Foo"]
+}

--- a/tests/expand/pr32-in.jsonld
+++ b/tests/expand/pr32-in.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": [{
+    "@version": 1.1,
+    "id": {"@id": "@id", "@protected": true},
+    "type": {"@id" : "@type", "@container": "@set", "@protected" : true},
+    "@type": {"@container": "@set", "@protected": true}
+  }, {
+    "@version": 1.1,
+    "@type": {"@protected": true}
+  }],
+  "id": "http://example.com/1",
+  "type": ["http://example.org/ns/Foo"]
+}

--- a/tests/toRdf-manifest.html
+++ b/tests/toRdf-manifest.html
@@ -7066,6 +7066,90 @@ Test tpr29 Does not expand a Compact IRI using a non-prefix term.
 </dd>
 </dl>
 </dd>
+<dt id='tpr30'>
+Test tpr30 Keywords may be protected.
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tpr30</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Keywords may not be redefined other than to protect them.</dd>
+<dt>input</dt>
+<dd>
+<a href='toRdf/pr30-in.jsonld'>toRdf/pr30-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='toRdf/pr30-out.nq'>toRdf/pr30-out.nq</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='tpr31'>
+Test tpr31 Protected keyword aliases cannot be overridden.
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tpr31</dd>
+<dt>Type</dt>
+<dd>jld:NegativeEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Keywords may not be redefined other than to protect them.</dd>
+<dt>input</dt>
+<dd>
+<a href='toRdf/pr31-in.jsonld'>toRdf/pr31-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+term redefinition
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='tpr32'>
+Test tpr32 Protected @type cannot be overridden.
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tpr32</dd>
+<dt>Type</dt>
+<dd>jld:NegativeEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Keywords may not be redefined other than to protect them.</dd>
+<dt>input</dt>
+<dd>
+<a href='toRdf/pr32-in.jsonld'>toRdf/pr32-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+protected term redefinition
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
 <dt id='tpr33'>
 Test tpr33 Fails if trying to declare a keyword alias as prefix.
 </dt>

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -2111,6 +2111,30 @@
       "input": "toRdf/pr29-in.jsonld",
       "expect": "toRdf/pr29-out.nq"
     }, {
+      "@id": "#tpr30",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Keywords may be protected.",
+      "purpose": "Keywords may not be redefined other than to protect them.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "toRdf/pr30-in.jsonld",
+      "expect": "toRdf/pr30-out.nq"
+    }, {
+      "@id": "#tpr31",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
+      "name": "Protected keyword aliases cannot be overridden.",
+      "purpose": "Keywords may not be redefined other than to protect them.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "toRdf/pr31-in.jsonld",
+      "expect": "term redefinition"
+    }, {
+      "@id": "#tpr32",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
+      "name": "Protected @type cannot be overridden.",
+      "purpose": "Keywords may not be redefined other than to protect them.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "toRdf/pr32-in.jsonld",
+      "expect": "protected term redefinition"
+    }, {
       "@id": "#tpr33",
       "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
       "name": "Fails if trying to declare a keyword alias as prefix.",

--- a/tests/toRdf/pr30-in.jsonld
+++ b/tests/toRdf/pr30-in.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "id": {"@id": "@id", "@protected": true},
+    "type": {"@id" : "@type", "@container": "@set", "@protected" : true},
+    "@type": {"@container": "@set", "@protected": true}
+  },
+  "id": "http://example.com/1",
+  "type": "http://example.org/ns/Foo",
+  "@type": "http://example.org/ns/Bar"
+}

--- a/tests/toRdf/pr30-out.nq
+++ b/tests/toRdf/pr30-out.nq
@@ -1,0 +1,2 @@
+<http://example.com/1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/ns/Bar> .
+<http://example.com/1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/ns/Foo> .

--- a/tests/toRdf/pr31-in.jsonld
+++ b/tests/toRdf/pr31-in.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": [{
+    "@version": 1.1,
+    "id": {"@id": "@id", "@protected": true},
+    "type": {"@id" : "@type", "@container": "@set", "@protected" : true},
+    "@type": {"@container": "@set", "@protected": true}
+  }, {
+    "@version": 1.1,
+    "id": "http://example.com/id"
+  }],
+  "id": "http://example.com/1",
+  "type": ["http://example.org/ns/Foo"]
+}

--- a/tests/toRdf/pr32-in.jsonld
+++ b/tests/toRdf/pr32-in.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": [{
+    "@version": 1.1,
+    "id": {"@id": "@id", "@protected": true},
+    "type": {"@id" : "@type", "@container": "@set", "@protected" : true},
+    "@type": {"@container": "@set", "@protected": true}
+  }, {
+    "@version": 1.1,
+    "@type": {"@protected": true}
+  }],
+  "id": "http://example.com/1",
+  "type": ["http://example.org/ns/Foo"]
+}


### PR DESCRIPTION
For w3c/json-ld-syntax#246.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/158.html" title="Last updated on Sep 30, 2019, 6:42 PM UTC (3a748f4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/158/565f239...3a748f4.html" title="Last updated on Sep 30, 2019, 6:42 PM UTC (3a748f4)">Diff</a>