### PR TITLE
Fix IDL markup issues.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5471,6 +5471,9 @@
     <a data-cite="ECMASCRIPT#sec-promise-objects">Promises</a> are defined in [[ECMASCRIPT]].
     General use within specifications can be found in [[promises-guide]].</p>
 
+  <p class="note">Interfaces are marked `[Exposed=(Window,Worker)]`,
+    but the API is also intended for use outside of a browser context.</p>
+
   <section>
     <h3>The <dfn>JsonLdProcessor</dfn> Interface</h3>
 
@@ -5493,7 +5496,7 @@
       in this document mention this directly.</p>
 
     <pre class="idl">
-      [Exposed=Window]
+      [Exposed=(Window,Worker)]
       interface JsonLdProcessor {
         constructor();
         static Promise&lt;JsonLdDictionary> compact(
@@ -5787,7 +5790,7 @@
       which has a <a>default graph</a> accessible via the <a data-link-for="RdfDataset">defaultGraph</a> attribute.</p>
 
     <pre class="idl changed">
-      [Exposed=Window]
+      [Exposed=(Window,Worker)]
       interface RdfDataset {
         constructor();
         readonly attribute RdfGraph defaultGraph;
@@ -5831,7 +5834,7 @@
       which is composed of zero or more <a>RdfTriple</a> instances.</p>
 
     <pre class="idl changed">
-      [Exposed=Window]
+      [Exposed=(Window,Worker)]
       interface RdfGraph {
         constructor();
         void add(RdfTriple triple);
@@ -5860,7 +5863,7 @@
     <p>The <dfn>RdfTriple</dfn> interface describes an <a>triple</a>.</p>
 
     <pre class="idl changed">
-      [Exposed=Window]
+      [Exposed=(Window,Worker)]
       interface RdfTriple {
         constructor();
         readonly attribute USVString subject;
@@ -5888,7 +5891,7 @@
     <p>The <dfn>RdfLiteral</dfn> interface describes an <a>RDF Literal</a>.</p>
 
     <pre class="idl changed">
-      [Exposed=Window]
+      [Exposed=(Window,Worker)]
       interface RdfLiteral {
         constructor();
         readonly attribute USVString value;

--- a/index.html
+++ b/index.html
@@ -4947,7 +4947,7 @@
         that all default to <code>false</code>.</p>
 
       <p>The <var>dataset</var> is <a data-link-for="RdfDataset">iterable</a> to iterate over <a>graphs</a> and <a>graph names</a>
-        contained within the <a>RdfDataset</a>. Each <a>graph</a> is also <code>iterable</code>
+        contained within the <a>RdfDataset</a>. Each <a>graph</a> is also <a data-link-for="RdfGraph">iterable</a>
         for iterating over <a>triples</a> contained within the <a>RdfGraph</a>.</p>
 
       <ol>
@@ -5807,13 +5807,14 @@
         <dl class="parameters">
           <dt><dfn data-lt="RdfDataset-add-graphName" data-lt-noDefault>graphName</dfn></dt>
           <dd>The <a>graph name</a> associated with <a>graph</a>.
-            graphName MUST be a <a>well-formed</a> <a>IRI</a> or <a>blank node identifier</a>.
+            <a href="#dfn-rdfdataset-add-graphname">graphName</a> MUST be a
+            <a>well-formed</a> <a>IRI</a> or <a>blank node identifier</a>.
           </dd>
           <dt><dfn data-lt="RdfDataset-add-graph" data-lt-noDefault>graph</dfn></dt>
           <dd>The <a>RdfGraph</a> to add to the <a>RdfDataset</a>.</dd>
         </dl>
       </dd>
-      <dt><dfn data-dfn-for="RdfDataset">iterable</dfn></dt>
+      <dt><dfn data-dfn-for="RdfDataset"><code>iterable</code></dfn></dt>
       <dd>The <a data-cite="WEBIDL#dfn-value-pairs-to-iterate-over">value pairs to iterate over</a>
         are the list of <var>graph name</var>-<var>graph</var> pairs,
         with the <var>graph name</var> being <code>null</code>
@@ -5849,7 +5850,7 @@
           <dd>The <a>RdfTriple</a> to add to the <a>RdfGraph</a>.</dd>
         </dl>
       </dd>
-      <dt><code>iterable</code></dt>
+      <dt><dfn data-dfn-for="RdfGraph"><code>iterable</code></dfn></dt>
       <dd>A <a data-cite="WEBIDL#dfn-value-iterator">value iterator</a>
         over the <a>RdfTriple</a> instances associated with the graph.
         Note that a given <a>RdfTriple</a> instance may appear in more than one graph

--- a/index.html
+++ b/index.html
@@ -4636,7 +4636,7 @@
               Otherwise, initialize <var>graph</var> as an empty <a>RdfGraph</a>
               and add to <var>dataset</var> using its
               <a data-link-for="RdfDataset">add</a> method along with <var>graph name</var>
-              for <a data-lt="RdfDataset-add-graphName">graphName</a>.</li>
+              for <a data-lt="RdfDataset-add-graphName">`graphName`</a>.</li>
             <li>For each <var>subject</var> and <var>node</var> in <var>graph</var> ordered
               by <var>subject</var>:
               <ol>
@@ -5807,7 +5807,7 @@
         <dl class="parameters">
           <dt><dfn data-lt="RdfDataset-add-graphName" data-lt-noDefault>graphName</dfn></dt>
           <dd>The <a>graph name</a> associated with <a>graph</a>.
-            <a href="#dfn-rdfdataset-add-graphname">graphName</a> MUST be a
+            <a href="#dfn-rdfdataset-add-graphname">`graphName`</a> MUST be a
             <a>well-formed</a> <a>IRI</a> or <a>blank node identifier</a>.
           </dd>
           <dt><dfn data-lt="RdfDataset-add-graph" data-lt-noDefault>graph</dfn></dt>


### PR DESCRIPTION
This respec dfn support seems difficult to use.  Looking for comments if this patch is doing the right thing.
- The "iterable" properties didn't have a automatic `<code>` around them when using the dfn stuff.  Not sure why?  Other properties worked.  Added that by hand and made the RdfGraph version linkable.
- That `graphName` word looked out of place, so tried to link it back to the func arg, but couldn't figure out how other than with a hand written href.  That is probably wrong.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/163.html" title="Last updated on Oct 10, 2019, 9:55 PM UTC (f35b9e6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/163/9e19e9f...f35b9e6.html" title="Last updated on Oct 10, 2019, 9:55 PM UTC (f35b9e6)">Diff</a>