### PR TITLE
Add tests for checking lowercasing of @language

### DIFF
--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -869,6 +869,13 @@
       "expect": "invalid vocab mapping",
       "option": {"specVersion": "json-ld-1.0"}
     }, {
+      "@id": "#t0117",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Language tags with mixed casing",
+      "purpose": "Language tags must be normalized to lowercase",
+      "input": "expand/0117-in.jsonld",
+      "expect": "expand/0117-out.jsonld"
+    }, {
       "@id": "#tc001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "adding new term",

--- a/tests/expand/0117-in.jsonld
+++ b/tests/expand/0117-in.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "property": { "@id": "http://example.com/vocab/property", "@language": "DE" },
+    "indexMap": { "@id": "http://example.com/vocab/indexMap", "@language": "eN", "@container": "@index" },
+    "property2": { "@id": "http://example.com/vocab/property2", "@container": "@language" }
+  },
+  "@id": "http://example.com/node",
+  "property": [
+    {
+      "@id": "http://example.com/propertyValueNode",
+      "indexMap": {
+        "expands to english string": "simple string"
+      }
+    },
+    "einfacher String",
+	{
+	  "@value": "woord",
+	  "@language": "NL-be"
+	}
+  ],
+  "property2": {
+    "EN": "The Queen",
+    "dE": [ "Die Königin", "Ihre Majestät" ]
+  }
+}

--- a/tests/expand/0117-out.jsonld
+++ b/tests/expand/0117-out.jsonld
@@ -1,0 +1,39 @@
+[
+  {
+    "@id": "http://example.com/node",
+    "http://example.com/vocab/property": [
+      {
+        "@id": "http://example.com/propertyValueNode",
+        "http://example.com/vocab/indexMap": [
+          {
+            "@value": "simple string",
+            "@language": "en",
+            "@index": "expands to english string"
+          }
+        ]
+      },
+      {
+        "@value": "einfacher String",
+        "@language": "de"
+      },
+      {
+        "@value": "woord",
+        "@language": "nl-be"
+      }
+    ],
+	"http://example.com/vocab/property2": [
+	  {
+	    "@value": "The Queen",
+	    "@language": "en"
+	  },
+	  {
+	    "@value": "Die Königin",
+	    "@language": "de"
+	  },
+	  {
+	    "@value": "Ihre Majestät",
+	    "@language": "de"
+	  }
+	]
+  }
+]

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -1263,6 +1263,13 @@
       "expect": "invalid vocab mapping",
       "option": {"specVersion": "json-ld-1.0"}
     }, {
+      "@id": "#te117",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Language tags with mixed casing",
+      "purpose": "Language tags must be normalized to lowercase",
+      "input": "toRdf/e117-in.jsonld",
+      "expect": "toRdf/e117-out.nq",
+    }, {
       "@id": "#tin01",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
       "name": "Basic Included array",

--- a/tests/toRdf/e117-in.jsonld
+++ b/tests/toRdf/e117-in.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": {
+    "property": { "@id": "http://example.com/vocab/property", "@language": "DE" },
+    "indexMap": { "@id": "http://example.com/vocab/indexMap", "@language": "eN", "@container": "@index" },
+    "property2": { "@id": "http://example.com/vocab/property2", "@container": "@language" }
+  },
+  "@id": "http://example.com/node",
+  "property": [
+    {
+      "@id": "http://example.com/propertyValueNode",
+      "indexMap": {
+        "expands to english string": "simple string"
+      }
+    },
+    "einfacher String",
+	{
+	  "@value": "woord",
+	  "@language": "NL-be"
+	}
+  ],
+  "property2": {
+    "EN": "The Queen",
+    "dE": [ "Die Königin", "Ihre Majestät" ]
+  }
+}

--- a/tests/toRdf/e117-out.nq
+++ b/tests/toRdf/e117-out.nq
@@ -1,0 +1,7 @@
+<http://example.com/node> <http://example.com/vocab/property2> "Die Königin"@de .
+<http://example.com/node> <http://example.com/vocab/property2> "Ihre Majestät"@de .
+<http://example.com/node> <http://example.com/vocab/property2> "The Queen"@en .
+<http://example.com/node> <http://example.com/vocab/property> "einfacher String"@de .
+<http://example.com/node> <http://example.com/vocab/property> "woord"@nl-be .
+<http://example.com/node> <http://example.com/vocab/property> <http://example.com/propertyValueNode> .
+<http://example.com/propertyValueNode> <http://example.com/vocab/indexMap> "simple string"@en .


### PR DESCRIPTION
I recently discovered that my implementation did not ensure lowercased languages, while this has been [required](https://w3c.github.io/json-ld-syntax/#dfn-language-tagged-string) since JSON-LD 1.0.
Apparently there weren't any test cases for this in the test suite, so this PR adds one (for expand and toRdf) for all the different language features.