### PR TITLE
Language tags

### DIFF
--- a/common/terms.html
+++ b/common/terms.html
@@ -113,8 +113,9 @@
     consists of a string and a non-empty language tag
     as defined by [[BCP47]].
     The <dfn data-cite="RDF11-CONCEPTS#dfn-language-tag">language tag</dfn> MUST be well-formed
-    according to <a data-cite="BCP47#section-2.2.9">section 2.2.9 Classes of Conformance</a> of [[BCP47]],
-    and is normalized to lowercase.</dd>
+    according to <a data-cite="BCP47#section-2.2.9">section 2.2.9 Classes of Conformance</a> of [[BCP47]].
+    <span class="changed note">Processors MAY normalize <a>language tags</a> to lowercase.</span>
+  </dd>
   <dt><dfn data-cite="LINKED-DATA" data-no-xref="" class="preserve">Linked Data</dfn></dt><dd>
     A set of documents, each containing a representation of a <a>linked data graph</a> or <a>dataset</a>.</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-graph" data-lt="linked data graph|graph" class="preserve">RDF graph</dfn></dt><dd>

--- a/index.html
+++ b/index.html
@@ -1275,7 +1275,10 @@
                   If it is not a <a>string</a>, an
                   <a data-link-for="JsonLdErrorCode">invalid default language</a>
                   error has been detected and processing is aborted.
-                  <span class="changed note">Processors MAY normalize <a>language tags</a> to lowercase.</span>
+                  <span class="changed">If <var>value</var> is not a <a>well-formed</a> according to
+                    <a data-cite="BCP47#section-2.2.9">section 2.2.9</a> of [[BCP47]],
+                    processors SHOULD issue a warning.</span>
+                  <span class="changed note">Processors MAY normalize <a>language tags</a> to lower case.</span>
                 </li>
               </ol>
             </li>
@@ -1633,11 +1636,14 @@
           <ol>
             <li>Initialize <var>language</var> to the value associated with the
               <code>@language</code> <a>entry</a>, which MUST be either <code>null</code>
-              or a <a>string</a>. Otherwise, an
-              <a data-link-for="JsonLdErrorCode">invalid language mapping</a>
+              or a <a>string</a>.
+              <span class="changed">If <var>language</var> is not a <a>well-formed</a> according to
+                <a data-cite="BCP47#section-2.2.9">section 2.2.9</a> of [[BCP47]],
+                processors SHOULD issue a warning.</span>
+              Otherwise, an <a data-link-for="JsonLdErrorCode">invalid language mapping</a>
               error has been detected and processing is aborted.</li>
             <li>Set the <a>language mapping</a> of <var>definition</var> to <var>language</var>.
-              <span class="changed note">Processors MAY normalize <a>language tags</a> to lowercase.</span>
+              <span class="changed note">Processors MAY normalize <a>language tags</a> to lower case.</span>
             </li>
           </ol>
         </li>
@@ -2138,13 +2144,16 @@
                   <var>value</var> is not a <a>string</a>, an
                   <a data-link-for="JsonLdErrorCode">invalid language-tagged string</a>
                   error has been detected and processing is aborted.
+                  <span class="changed">If <var>value</var> is not a <a>well-formed</a> according to
+                    <a data-cite="BCP47#section-2.2.9">section 2.2.9</a> of [[BCP47]],
+                    processors SHOULD issue a warning.</span>
                   <span class="changed">
                     Otherwise, set <var>expanded value</var> to <var>value</var>.
                     When the {{JsonLdOptions/frameExpansion}} flag is set, <var>value</var>
                     may also be an empty <a>map</a> or an array of zero or
                     <a>strings</a>. <var>expanded value</var> will be an
                     <a>array</a> of one or more <a>string</a> values.</span>
-                  <span class="changed note">Processors MAY normalize <a>language tags</a> to lowercase.</span>
+                  <span class="changed note">Processors MAY normalize <a>language tags</a> to lower case.</span>
                 </li>
                 <li class="changed">If <var>expanded property</var> is <code>@direction</code> and
                   <var>value</var> is neither `"ltr"` nor `"rtl"`, an
@@ -2284,7 +2293,10 @@
                           consisting of two
                           key-value pairs: (<code>@value</code>-<var>item</var>)
                           and (<code>@language</code>-<var>language</var>).
-                          <span class="changed note">Processors MAY normalize <a>language tags</a> to lowercase.</span>
+                          <span class="changed">If <var>item</var> is neither `@none` nor a <a>well-formed</a> according to
+                            <a data-cite="BCP47#section-2.2.9">section 2.2.9</a> of [[BCP47]],
+                            processors SHOULD issue a warning.</span>
+                          <span class="changed note">Processors MAY normalize <a>language tags</a> to lower case.</span>
                         </li>
                         <li class="changed">If <var>language</var> is <code>@none</code>,
                           or expands to <code>@none</code>, remove <code>@language</code> from <var>v</var>.</li>
@@ -3323,6 +3335,11 @@
         to choosing more generic <a>terms</a> when a more
         specifically-matching <a>term</a> is not available for a particular
         <a>IRI</a> and value combination.</p>
+
+      <p class="changed">Although normalizing <a>language tags</a> is optional,
+        the <a>inverse context</a> creates entries based on normalized
+        <a>language tags</a>, so that the proper term can be selected
+        regardless of representation.</p>
     </section>
 
     <section class="algorithm">
@@ -3335,7 +3352,8 @@
         <li>Initialize <var>result</var> to an empty <a class="changed">map</a>.</li>
         <li>Initialize <var>default language</var> to <code>@none</code>.
           If the <var>active context</var> has a <a>default language</a>,
-          set <var>default language</var> to the <a>default language</a> from the <a>active context</a>.</li>
+          set <var>default language</var> to the <a>default language</a> from the <a>active context</a>
+          <span class="changed">normalized to lower case</span>.</li>
         <li>For each key <a>term</a> and value <a>term definition</a> in
           the <var>active context</var>, ordered by shortest <a>term</a>
           first (breaking ties by choosing the lexicographically least
@@ -3412,9 +3430,11 @@
                 <li>If neither the <a>language mapping</a> nor the <a>direction mapping</a>
                   are `null`, set <var>lang dir</var> to the concatenation
                   of <a>language mapping</a> and <a>direction mapping</a>
-                  separated by an underscore (`"_"`).</li>
+                  separated by an underscore (`"_"`)
+                  normalized to lower case.</li>
                 <li>Otherwise, if <a>language mapping</a> is not `null`,
-                  set <var>lang dir</var> to the <a>language mapping</a>.
+                  set <var>lang dir</var> to the <a>language mapping</a>,
+                  normalized to lower case.
                 <li>Otherwise, if <a>direction mapping</a> is not `null`,
                   set <var>lang dir</var> to <a>direction mapping</a>
                   preceded by an underscore (`"_"`).</li>
@@ -3428,7 +3448,8 @@
               <ol>
                 <li>If the <a>language mapping</a> equals <code>null</code>,
                   set <var>language</var> to <code>@null</code>; otherwise set it
-                  to the <a>language mapping</a>.</li>
+                  to the <a>language mapping</a>,
+                  <span class="changed">normalized to lower case</span>.</li>
                 <li>If <var>language map</var> does not have a <var>language</var> <a>entry</a>,
                   create one and set its value to the <a>term</a>
                   being processed.</li>
@@ -3450,7 +3471,8 @@
               <ol>
                 <li>Initialize a variable <var>lang dir</var>
                   with the concatenation of <a>default language</a> and <a>default base direction</a>,
-                  separate by an underscore (`"_"`).</li>
+                  separate by an underscore (`"_"`),
+                  normalized to lower case.</li>
                 <li>If <var>language map</var> does not have a <var>lang dir</var> <a>entry</a>,
                   create one and set its value to the <a>term</a>
                   being processed.</li>
@@ -3464,8 +3486,9 @@
             </li>
             <li>Otherwise:
               <ol>
-                <li>If <var>language map</var> does not have a <var>default language</var>
-                  <a>entry</a>, create one and set its value to the <a>term</a>
+                <li>If <var>language map</var> does not have a <var>default language</var> <a>entry</a>
+                  <span class="changed">(after being normalized to lower case)</span>,
+                  create one and set its value to the <a>term</a>
                   being processed.</li>
                 <li>If <var>language map</var> does not have an <code>@none</code>
                   <a>entry</a>, create one and set its value to the <a>term</a>
@@ -3529,7 +3552,8 @@
 
       <p class="changed">When considering <a>language mapping</a>,
         the <a>direction mapping</a> is also considered, either with, or without,
-        a <a>language mapping</a>.</p>
+        a <a>language mapping</a>,
+        and the <a>language mapping</a> is normalized to lower case.</p>
 
       <p class="changed">In the case were this algorithm would return the input <a>IRI</a> as is,
         and that <a>IRI</a> can be mistaken for a <a>compact IRI</a> in the <a>active context</a>,
@@ -3557,14 +3581,17 @@
           <ol>
             <li class="changed">Initialize <var>default language</var>
               based on the <a data-lt="active context">active context's</a>
-              <a>default language</a> and <a>default base direction</a>:
+              <a>default language</a>, normalized to lower case and <a>default base direction</a>:
               <ol>
                 <li>If the <a data-lt="active context">active context's</a> <a>default base direction</a>
                   is not `null`, to the concatenation of
                   the <a data-lt="active context">active context's</a> <a>default language</a>
-                  and <a>default base direction</a>, separated by an underscore (`"_"`).</li>
+                  and <a>default base direction</a>, separated by an underscore (`"_"`),
+                  normalized to lower case.</li>
                 <li>Otherwise, to the <a data-lt="active context">active context's</a> <a>default language</a>,
-                  if it has one, otherwise to `@none`.</li>
+                  if it has one,
+                  normalized to lower case,
+                  otherwise to `@none`.</li>
               </ol>
             </li>
             <li class="changed">If <var>value</var> is a <a>map</a> containing
@@ -3612,10 +3639,11 @@
                         <li class="changed">If <var>item</var> contains an `@direction` <a>entry</a>,
                           then set <var>item language</var> to the concatenation of
                           the <var>item</var>'s `@language` entry (if any)
-                          the <var>item</var>'s `@direction`, separated by an underscore (`"_"`).</li>
+                          the <var>item</var>'s `@direction`, separated by an underscore (`"_"`),
+                          normalized to lower case.</li>
                         <li>Otherwise, if <var>item</var> contains an <code>@language</code> <a>entry</a>,
-                          then set <var>item language</var> to its associated
-                          value.</li>
+                          then set <var>item language</var> to its associated value,
+                          normalized to lower case.</li>
                         <li>Otherwise, if <var>item</var> contains a
                           <code>@type</code> <a>entry</a>, set <var>item type</var> to its
                           associated value.</li>
@@ -3687,13 +3715,15 @@
                       and does not contain an `@index` <a>entry</a>,
                       then set <var>type/language value</var> to the concatenation of
                       the <var>value</var>'s `@language` entry (if any)
-                      the <var>value</var>'s `@direction`, separated by an underscore (`"_"`).
+                      the <var>value</var>'s `@direction`, separated by an underscore (`"_"`),
+                      normalized to lower case.
                       Append `@language` and `@language@set` to
                       <var>containers</var>.</li>
                     <li>Otherwise, if <var>value</var> contains an <code>@language</code> <a>entry</a>
                       and does not contain an <code>@index</code> <a>entry</a>,
                       then set <var>type/language value</var> to its associated
-                      value and, append <code>@language</code>
+                      value and, append <code>@language</code>,
+                      normalized to lower case,
                       <span class="changed">and <code>@language@set</code></span> to
                       <var>containers</var>.</li>
                     <li>Otherwise, if <var>value</var> contains a
@@ -4809,6 +4839,7 @@
               set <var>datatype</var> to the result of appending <var>language</var>
               and the value of `@direction` in <var>item</var> separated by an underscore (`"_"`)
               to `https://www.w3.org/ns/i18n#`.
+              <span class="changed note">Processors MAY normalize <a>language tags</a> to lower case.</span>
               Initialize <var>literal</var> as an <a>RDF literal</a> using
               <var>value</var> and <var>datatype</var>.
               <div class="note">As `@direction` may be used without `@language`,
@@ -4823,7 +4854,8 @@
                 <li>If the <var>item</var> has an entry for `@language`,
                   create a new triple using <var>literal</var> as the subject,
                   `rdf:language` as the predicate, and the value of `@language` in <var>item</var>
-                  as the object, and add it to <var>list triples</var>.</li>
+                  as the object, and add it to <var>list triples</var>.
+                  <span class="changed note">Processors MAY normalize <a>language tags</a> to lower case.</span></li>
                 <li>Create a new triple using <var>literal</var> as the subject,
                   `rdf:direction` as the predicate, and the value of `@direction` in <var>item</var>
                   as the object, and add it to <var>list triples</var>.</li>
@@ -5373,7 +5405,7 @@
       <li>Native Numeric values SHOULD be serialized according to
         <a data-cite="?ECMASCRIPT#sec-tostring-applied-to-the-number-type">Section 7.1.12.1</a> of [[?ECMASCRIPT]],</li>
       <li>Strings SHOULD be serialized with Unicode codepoints from <code>U+0000</code> through <code>U+001F</code>
-        using lowercase hexadecimal Unicode notation (<code>\uhhhh</code>) unless in the set
+        using lower case hexadecimal Unicode notation (<code>\uhhhh</code>) unless in the set
         of predefined JSON control characters <code>U+0008</code>, <code>U+0009</code>,
         <code>U+000A</code>, <code>U+000C</code> or <code>U+000D</code>
         which SHOULD be serialized as <code>\b</code>, <code>\t</code>, <code>\n</code>, <code>\f</code> and <code>\r</code> respectively.
@@ -6668,7 +6700,7 @@
       to that content.</li>
     <li><a>Value objects</a>, and associated <a>context</a> and <a>term definitions</a> have been updated to 
       support `@direction` for setting the <a>base direction</a> of strings.</li>
-    <li>It is no longer required that language tags be normalized to lowercase,
+    <li>It is no longer required that language tags be normalized to lower case,
       other than for testing considerations.
       Language tags that are not valid according to [[BCP47]] are rejected.</li>
   </ul>

--- a/index.html
+++ b/index.html
@@ -1273,7 +1273,7 @@
                   If it is not a <a>string</a>, an
                   <a data-link-for="JsonLdErrorCode">invalid default language</a>
                   error has been detected and processing is aborted.
-                  <span class="changed">If <var>value</var> is not a <a>well-formed</a> according to
+                  <span class="changed">If <var>value</var> is not <a>well-formed</a> according to
                     <a data-cite="BCP47#section-2.2.9">section 2.2.9</a> of [[BCP47]],
                     processors SHOULD issue a warning.</span>
                   <span class="changed note">Processors MAY normalize <a>language tags</a> to lower case.</span>
@@ -1635,7 +1635,7 @@
             <li>Initialize <var>language</var> to the value associated with the
               <code>@language</code> <a>entry</a>, which MUST be either <code>null</code>
               or a <a>string</a>.
-              <span class="changed">If <var>language</var> is not a <a>well-formed</a> according to
+              <span class="changed">If <var>language</var> is not <a>well-formed</a> according to
                 <a data-cite="BCP47#section-2.2.9">section 2.2.9</a> of [[BCP47]],
                 processors SHOULD issue a warning.</span>
               Otherwise, an <a data-link-for="JsonLdErrorCode">invalid language mapping</a>
@@ -2142,7 +2142,7 @@
                   <var>value</var> is not a <a>string</a>, an
                   <a data-link-for="JsonLdErrorCode">invalid language-tagged string</a>
                   error has been detected and processing is aborted.
-                  <span class="changed">If <var>value</var> is not a <a>well-formed</a> according to
+                  <span class="changed">If <var>value</var> is not <a>well-formed</a> according to
                     <a data-cite="BCP47#section-2.2.9">section 2.2.9</a> of [[BCP47]],
                     processors SHOULD issue a warning.</span>
                   <span class="changed">
@@ -2291,7 +2291,7 @@
                           consisting of two
                           key-value pairs: (<code>@value</code>-<var>item</var>)
                           and (<code>@language</code>-<var>language</var>).
-                          <span class="changed">If <var>item</var> is neither `@none` nor a <a>well-formed</a> according to
+                          <span class="changed">If <var>item</var> is neither `@none` nor <a>well-formed</a> according to
                             <a data-cite="BCP47#section-2.2.9">section 2.2.9</a> of [[BCP47]],
                             processors SHOULD issue a warning.</span>
                           <span class="changed note">Processors MAY normalize <a>language tags</a> to lower case.</span>
@@ -5101,7 +5101,7 @@
                       from the `rdf:value` entry in <var>cl node</var>.</li>
                     <li>Add an <a>entry</a> to <var>node</var> for `@language` with the value taken
                       from the `rdf:language` entry in <var>cl node</var>, if any.
-                      If that value is not a <a>well-formed</a> according to
+                      If that value is not <a>well-formed</a> according to
                       <a data-cite="BCP47#section-2.2.9">section 2.2.9</a> of [[BCP47]],
                       an <a data-link-for="JsonLdErrorCode">invalid language-tagged string</a>
                       error has been detected and processing is aborted.</li>

--- a/index.html
+++ b/index.html
@@ -2141,12 +2141,12 @@
                 <li>If <var>expanded property</var> is <code>@language</code> and
                   <var>value</var> is not a <a>string</a>, an
                   <a data-link-for="JsonLdErrorCode">invalid language-tagged string</a>
-                  error has been detected and processing is aborted.
-                  <span class="changed">If <var>value</var> is not <a>well-formed</a> according to
-                    <a data-cite="BCP47#section-2.2.9">section 2.2.9</a> of [[BCP47]],
-                    processors SHOULD issue a warning.</span>
+                  error has been detected and processing is aborted,
                   <span class="changed">
-                    Otherwise, set <var>expanded value</var> to <var>value</var>.
+                    otherwise, set <var>expanded value</var> to <var>value</var>.
+                    If <var>value</var> is not <a>well-formed</a> according to
+                    <a data-cite="BCP47#section-2.2.9">section 2.2.9</a> of [[BCP47]],
+                    processors SHOULD issue a warning.
                     When the {{JsonLdOptions/frameExpansion}} flag is set, <var>value</var>
                     may also be an empty <a>map</a> or an array of zero or
                     <a>strings</a>. <var>expanded value</var> will be an

--- a/index.html
+++ b/index.html
@@ -4163,6 +4163,7 @@
           </ol>
         </li>
         <li>Otherwise, if the value of `@language` in <var>item</var> exactly matches <var>language</var>,
+          <span class="changed">using a case-insenstive comparision</span>
           if it is not `null`, or is not present, if <var>language</var> is `null`,
           <span class="changed">and the value of `@direction` in <var>item</var> exactly matches <var>direction</var>,
             if it is not `null`, or is not present, if <var>direction</var> is `null`</span>:

--- a/index.html
+++ b/index.html
@@ -909,7 +909,9 @@
 
   <p><a>JSON-LD Processors</a> MUST NOT
     attempt to correct malformed <a>IRIs</a> or language tags;
-    however, they MAY issue validation warnings. IRIs are not modified other
+    however, they SHOULD issue validation warnings.
+    <span class="changed">Invalid language tags MUST be ignored.</span>
+    IRIs are not modified other
     than conversion between <a data-lt="relative IRI">relative</a> and
     <a>absolute IRIs</a>.</p>
 
@@ -1269,9 +1271,12 @@
                   any <a>default language</a> from <var>result</var>.</li>
                 <li>Otherwise, if <var>value</var> is <a>string</a>, the
                   <a>default language</a> of <var>result</var> is set to
-                  lowercased <var>value</var>. If it is not a <a>string</a>, an
+                  <var>value</var>.
+                  If it is not a <a>string</a>, an
                   <a data-link-for="JsonLdErrorCode">invalid default language</a>
-                  error has been detected and processing is aborted.</li>
+                  error has been detected and processing is aborted.
+                  <span class="changed note">Processors MAY normalize <a>language tags</a> to lowercase.</span>
+                </li>
               </ol>
             </li>
             <li class="changed">If <var>context</var> has an <code>@direction</code> <a>entry</a>:
@@ -1631,9 +1636,9 @@
               or a <a>string</a>. Otherwise, an
               <a data-link-for="JsonLdErrorCode">invalid language mapping</a>
               error has been detected and processing is aborted.</li>
-            <li>If <var>language</var> is a <a>string</a> set it to
-              lowercased <var>language</var>. Set the <a>language mapping</a>
-              of <var>definition</var> to <var>language</var>.</li>
+            <li>Set the <a>language mapping</a> of <var>definition</var> to <var>language</var>.
+              <span class="changed note">Processors MAY normalize <a>language tags</a> to lowercase.</span>
+            </li>
           </ol>
         </li>
         <li class="changed">If <var>value</var> contains the <a>entry</a> <code>@direction</code> and
@@ -2134,11 +2139,13 @@
                   <a data-link-for="JsonLdErrorCode">invalid language-tagged string</a>
                   error has been detected and processing is aborted.
                   <span class="changed">
-                    Otherwise, set <var>expanded value</var> to lowercased <var>value</var>.
+                    Otherwise, set <var>expanded value</var> to <var>value</var>.
                     When the {{JsonLdOptions/frameExpansion}} flag is set, <var>value</var>
                     may also be an empty <a>map</a> or an array of zero or
                     <a>strings</a>. <var>expanded value</var> will be an
-                    <a>array</a> of one or more <a>string</a> values converted to lower case.</span></li>
+                    <a>array</a> of one or more <a>string</a> values.</span>
+                  <span class="changed note">Processors MAY normalize <a>language tags</a> to lowercase.</span>
+                </li>
                 <li class="changed">If <var>expanded property</var> is <code>@direction</code> and
                   <var>value</var> is neither `"ltr"` nor `"rtl"`, an
                   <a data-link-for="JsonLdErrorCode">invalid base direction</a>
@@ -2276,8 +2283,9 @@
                         <li>Initialize a new <a class="changed">map</a> <var>v</var>
                           consisting of two
                           key-value pairs: (<code>@value</code>-<var>item</var>)
-                          and (<code>@language</code>-lowercased
-                          <var>language</var>).</li>
+                          and (<code>@language</code>-<var>language</var>).
+                          <span class="changed note">Processors MAY normalize <a>language tags</a> to lowercase.</span>
+                        </li>
                         <li class="changed">If <var>language</var> is <code>@none</code>,
                           or expands to <code>@none</code>, remove <code>@language</code> from <var>v</var>.</li>
                         <li class="changed">
@@ -6660,6 +6668,9 @@
       to that content.</li>
     <li><a>Value objects</a>, and associated <a>context</a> and <a>term definitions</a> have been updated to 
       support `@direction` for setting the <a>base direction</a> of strings.</li>
+    <li>It is no longer required that language tags be normalized to lowercase,
+      other than for testing considerations.
+      Language tags that are not valid according to [[BCP47]] are rejected.</li>
   </ul>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -908,12 +908,10 @@
       the algorithms defined in this specification</span>.</p>
 
   <p><a>JSON-LD Processors</a> MUST NOT
-    attempt to correct malformed <a>IRIs</a> or language tags;
+    attempt to correct malformed <a>IRIs</a> or <a>language tags</a>;
     however, they SHOULD issue validation warnings.
-    <span class="changed">Invalid language tags MUST be ignored.</span>
-    IRIs are not modified other
-    than conversion between <a data-lt="relative IRI">relative</a> and
-    <a>absolute IRIs</a>.</p>
+    IRIs are not modified other than conversion between
+    <a data-lt="relative IRI">relative</a> and <a>absolute IRIs</a>.</p>
 
   <p>A conforming <dfn data-lt="RDF Serializers/Deserializers">RDF Serializer/Deserializer</dfn> is a system that can
     <a href="#deserialize-json-ld-to-rdf-algorithm">deserialize JSON-LD to RDF</a> and

--- a/tests/README.md
+++ b/tests/README.md
@@ -59,6 +59,7 @@ JSON-LD Object comparison compares JSON objects, arrays, and values recursively 
 * JSON objects are compared member by member without regard to the ordering of members within the object. Each member must have a corresponding member in the object being compared to. Values are compared recursively.
 * JSON arrays are generally compared without regard to order (the lone exception being if the referencing key is `@list`). Each item within the array must be equivalent to an item in the array being compared to by using the comparison algorithm recursively. For values of `@list`, the order of these items is significant.
 * JSON values are compared using strict equality.
+* Values of `@language`, and other places where language tags may be used are specified in lowercase in the test results. Implementations should either normalize language tags for testing purposes, or compare language tags in a case-independent way.
 
 Note that some tests require re-expansion and comparison, as list values may exist as values of properties that have `@container: @list` and the comparison algorithm will not consider ordering significant.
 

--- a/tests/compact-manifest.html
+++ b/tests/compact-manifest.html
@@ -46,7 +46,7 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 <p>JSON-LD Object comparison compares JSON objects, arrays, and values recursively for equality.</p>
 
 <ul>
-<li>JSON objects are compared entry by entry without regard to the ordering of entriess within the object. Each entry must have a corresponding entry in the object being compared to. Values are compared recursively.</li>
+<li>JSON objects are compared entry by entry without regard to the ordering of entries within the object. Each entry must have a corresponding entry in the object being compared to. Values are compared recursively.</li>
 <li>JSON arrays are generally compared without regard to order (the lone exception being if the referencing key is <code>@list</code>). Each item within the array must be equivalent to an item in the array being compared to by using the comparison algorithm recursively. For values of <code>@list</code>, the order of these items is significant.</li>
 <li>JSON values are compared using strict equality.</li>
 <li>Values of <code>@language</code>, and other places where language tags may be used are specified in lowercase in the test results. Implementations should either normalize language tags for testing purposes, or compare language tags in a case-independent way.</li>

--- a/tests/compact-manifest.html
+++ b/tests/compact-manifest.html
@@ -46,9 +46,10 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 <p>JSON-LD Object comparison compares JSON objects, arrays, and values recursively for equality.</p>
 
 <ul>
-<li>JSON objects are compared member by member without regard to the ordering of members within the object. Each member must have a corresponding member in the object being compared to. Values are compared recursively.</li>
+<li>JSON objects are compared entry by entry without regard to the ordering of entriess within the object. Each entry must have a corresponding entry in the object being compared to. Values are compared recursively.</li>
 <li>JSON arrays are generally compared without regard to order (the lone exception being if the referencing key is <code>@list</code>). Each item within the array must be equivalent to an item in the array being compared to by using the comparison algorithm recursively. For values of <code>@list</code>, the order of these items is significant.</li>
 <li>JSON values are compared using strict equality.</li>
+<li>Values of <code>@language</code>, and other places where language tags may be used are specified in lowercase in the test results. Implementations should either normalize language tags for testing purposes, or compare language tags in a case-independent way.</li>
 </ul>
 
 <p>Note that some tests require re-expansion and comparison, as list values may exist as values of properties that have <code>@container: @list</code> and the comparison algorithm will not consider ordering significant.</p>

--- a/tests/compact-manifest.html
+++ b/tests/compact-manifest.html
@@ -407,7 +407,7 @@ Test t0013 @value with @language
 <dt>Type</dt>
 <dd>jld:PositiveEvaluationTest, jld:CompactTest</dd>
 <dt>Purpose</dt>
-<dd>Values with @language remain in expended form by default</dd>
+<dd>Values with @language remain in expanded form by default</dd>
 <dt>input</dt>
 <dd>
 <a href='compact/0013-in.jsonld'>compact/0013-in.jsonld</a>
@@ -4227,7 +4227,7 @@ Test tdi04 simple language map with term direction
 </dl>
 </dd>
 <dt id='tdi05'>
-Test tdi05 simple language mapwith overriding term direction
+Test tdi05 simple language map with overriding term direction
 </dt>
 <dd>
 <dl class='entry'>
@@ -4261,7 +4261,7 @@ Test tdi05 simple language mapwith overriding term direction
 </dl>
 </dd>
 <dt id='tdi06'>
-Test tdi06 simple language mapwith overriding null direction
+Test tdi06 simple language map with overriding null direction
 </dt>
 <dd>
 <dl class='entry'>
@@ -5359,6 +5359,191 @@ Test tjs11 Compact JSON literal (null)
 <dt>specVersion</dt>
 <dd>json-ld-1.1</dd>
 <dt>processingMode</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='tla01'>
+Test tla01 most specific term matching in @list.
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tla01</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:CompactTest</dd>
+<dt>Purpose</dt>
+<dd>The most specific term that matches all of the elements in the list, taking into account the default language, must be selected, without considering case of language.</dd>
+<dt>input</dt>
+<dd>
+<a href='compact/la01-in.jsonld'>compact/la01-in.jsonld</a>
+</dd>
+<dt>context</dt>
+<dd>
+<a href='compact/la01-context.jsonld'>compact/la01-context.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='compact/la01-out.jsonld'>compact/la01-out.jsonld</a>
+</dd>
+</dl>
+</dd>
+<dt id='tli01'>
+Test tli01 coerced @list containing an empty list
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tli01</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:CompactTest</dd>
+<dt>Purpose</dt>
+<dd>Lists of Lists</dd>
+<dt>input</dt>
+<dd>
+<a href='compact/li01-in.jsonld'>compact/li01-in.jsonld</a>
+</dd>
+<dt>context</dt>
+<dd>
+<a href='compact/li01-context.jsonld'>compact/li01-context.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='compact/li01-out.jsonld'>compact/li01-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='tli02'>
+Test tli02 coerced @list containing a list
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tli02</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:CompactTest</dd>
+<dt>Purpose</dt>
+<dd>Lists of Lists</dd>
+<dt>input</dt>
+<dd>
+<a href='compact/li02-in.jsonld'>compact/li02-in.jsonld</a>
+</dd>
+<dt>context</dt>
+<dd>
+<a href='compact/li02-context.jsonld'>compact/li02-context.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='compact/li02-out.jsonld'>compact/li02-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='tli03'>
+Test tli03 coerced @list containing an deep list
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tli03</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:CompactTest</dd>
+<dt>Purpose</dt>
+<dd>Lists of Lists</dd>
+<dt>input</dt>
+<dd>
+<a href='compact/li03-in.jsonld'>compact/li03-in.jsonld</a>
+</dd>
+<dt>context</dt>
+<dd>
+<a href='compact/li03-context.jsonld'>compact/li03-context.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='compact/li03-out.jsonld'>compact/li03-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='tli04'>
+Test tli04 coerced @list containing multiple lists
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tli04</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:CompactTest</dd>
+<dt>Purpose</dt>
+<dd>Lists of Lists</dd>
+<dt>input</dt>
+<dd>
+<a href='compact/li04-in.jsonld'>compact/li04-in.jsonld</a>
+</dd>
+<dt>context</dt>
+<dd>
+<a href='compact/li04-context.jsonld'>compact/li04-context.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='compact/li04-out.jsonld'>compact/li04-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='tli05'>
+Test tli05 coerced @list containing mixed list values
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tli05</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:CompactTest</dd>
+<dt>Purpose</dt>
+<dd>Lists of Lists</dd>
+<dt>input</dt>
+<dd>
+<a href='compact/li05-in.jsonld'>compact/li05-in.jsonld</a>
+</dd>
+<dt>context</dt>
+<dd>
+<a href='compact/li05-context.jsonld'>compact/li05-context.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='compact/li05-out.jsonld'>compact/li05-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
 <dd>json-ld-1.1</dd>
 </dl>
 </dd>
@@ -7216,166 +7401,6 @@ Test ts002 @context with array including @set uses array values
 <dl class='options'>
 <dt>processingMode</dt>
 <dd>json-ld-1.1</dd>
-<dt>specVersion</dt>
-<dd>json-ld-1.1</dd>
-</dl>
-</dd>
-</dl>
-</dd>
-<dt id='tli01'>
-Test tli01 coerced @list containing an empty list
-</dt>
-<dd>
-<dl class='entry'>
-<dt>id</dt>
-<dd>#tli01</dd>
-<dt>Type</dt>
-<dd>jld:PositiveEvaluationTest, jld:CompactTest</dd>
-<dt>Purpose</dt>
-<dd>Lists of Lists</dd>
-<dt>input</dt>
-<dd>
-<a href='compact/li01-in.jsonld'>compact/li01-in.jsonld</a>
-</dd>
-<dt>context</dt>
-<dd>
-<a href='compact/li01-context.jsonld'>compact/li01-context.jsonld</a>
-</dd>
-<dt>expect</dt>
-<dd>
-<a href='compact/li01-out.jsonld'>compact/li01-out.jsonld</a>
-</dd>
-<dt>Options</dt>
-<dd>
-<dl class='options'>
-<dt>specVersion</dt>
-<dd>json-ld-1.1</dd>
-</dl>
-</dd>
-</dl>
-</dd>
-<dt id='tli02'>
-Test tli02 coerced @list containing a list
-</dt>
-<dd>
-<dl class='entry'>
-<dt>id</dt>
-<dd>#tli02</dd>
-<dt>Type</dt>
-<dd>jld:PositiveEvaluationTest, jld:CompactTest</dd>
-<dt>Purpose</dt>
-<dd>Lists of Lists</dd>
-<dt>input</dt>
-<dd>
-<a href='compact/li02-in.jsonld'>compact/li02-in.jsonld</a>
-</dd>
-<dt>context</dt>
-<dd>
-<a href='compact/li02-context.jsonld'>compact/li02-context.jsonld</a>
-</dd>
-<dt>expect</dt>
-<dd>
-<a href='compact/li02-out.jsonld'>compact/li02-out.jsonld</a>
-</dd>
-<dt>Options</dt>
-<dd>
-<dl class='options'>
-<dt>specVersion</dt>
-<dd>json-ld-1.1</dd>
-</dl>
-</dd>
-</dl>
-</dd>
-<dt id='tli03'>
-Test tli03 coerced @list containing an deep list
-</dt>
-<dd>
-<dl class='entry'>
-<dt>id</dt>
-<dd>#tli03</dd>
-<dt>Type</dt>
-<dd>jld:PositiveEvaluationTest, jld:CompactTest</dd>
-<dt>Purpose</dt>
-<dd>Lists of Lists</dd>
-<dt>input</dt>
-<dd>
-<a href='compact/li03-in.jsonld'>compact/li03-in.jsonld</a>
-</dd>
-<dt>context</dt>
-<dd>
-<a href='compact/li03-context.jsonld'>compact/li03-context.jsonld</a>
-</dd>
-<dt>expect</dt>
-<dd>
-<a href='compact/li03-out.jsonld'>compact/li03-out.jsonld</a>
-</dd>
-<dt>Options</dt>
-<dd>
-<dl class='options'>
-<dt>specVersion</dt>
-<dd>json-ld-1.1</dd>
-</dl>
-</dd>
-</dl>
-</dd>
-<dt id='tli04'>
-Test tli04 coerced @list containing multiple lists
-</dt>
-<dd>
-<dl class='entry'>
-<dt>id</dt>
-<dd>#tli04</dd>
-<dt>Type</dt>
-<dd>jld:PositiveEvaluationTest, jld:CompactTest</dd>
-<dt>Purpose</dt>
-<dd>Lists of Lists</dd>
-<dt>input</dt>
-<dd>
-<a href='compact/li04-in.jsonld'>compact/li04-in.jsonld</a>
-</dd>
-<dt>context</dt>
-<dd>
-<a href='compact/li04-context.jsonld'>compact/li04-context.jsonld</a>
-</dd>
-<dt>expect</dt>
-<dd>
-<a href='compact/li04-out.jsonld'>compact/li04-out.jsonld</a>
-</dd>
-<dt>Options</dt>
-<dd>
-<dl class='options'>
-<dt>specVersion</dt>
-<dd>json-ld-1.1</dd>
-</dl>
-</dd>
-</dl>
-</dd>
-<dt id='tli05'>
-Test tli05 coerced @list containing mixed list values
-</dt>
-<dd>
-<dl class='entry'>
-<dt>id</dt>
-<dd>#tli05</dd>
-<dt>Type</dt>
-<dd>jld:PositiveEvaluationTest, jld:CompactTest</dd>
-<dt>Purpose</dt>
-<dd>Lists of Lists</dd>
-<dt>input</dt>
-<dd>
-<a href='compact/li05-in.jsonld'>compact/li05-in.jsonld</a>
-</dd>
-<dt>context</dt>
-<dd>
-<a href='compact/li05-context.jsonld'>compact/li05-context.jsonld</a>
-</dd>
-<dt>expect</dt>
-<dd>
-<a href='compact/li05-out.jsonld'>compact/li05-out.jsonld</a>
-</dd>
-<dt>Options</dt>
-<dd>
-<dl class='options'>
 <dt>specVersion</dt>
 <dd>json-ld-1.1</dd>
 </dl>

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -1214,7 +1214,7 @@
     }, {
       "@id": "#tdi05",
       "@type": [ "jld:PositiveEvaluationTest", "jld:CompactTest" ],
-      "name": "simple language mapwith overriding term direction",
+      "name": "simple language map with overriding term direction",
       "purpose": "Term selection with language maps and @direction.",
       "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.1"},
       "input": "compact/di05-in.jsonld",
@@ -1223,7 +1223,7 @@
     }, {
       "@id": "#tdi06",
       "@type": [ "jld:PositiveEvaluationTest", "jld:CompactTest" ],
-      "name": "simple language mapwith overriding null direction",
+      "name": "simple language map with overriding null direction",
       "purpose": "Term selection with language maps and @direction.",
       "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.1"},
       "input": "compact/di06-in.jsonld",
@@ -1517,7 +1517,15 @@
       "context": "compact/js11-context.jsonld",
       "expect": "compact/js11-out.jsonld",
       "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.1"}
-     }, {
+    }, {
+      "@id": "#tla01",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "most specific term matching in @list.",
+      "purpose": "The most specific term that matches all of the elements in the list, taking into account the default language, must be selected, without considering case of language.",
+      "input": "compact/la01-in.jsonld",
+      "context": "compact/la01-context.jsonld",
+      "expect": "compact/la01-out.jsonld"
+    }, {
       "@id": "#tli01",
       "@type": [ "jld:PositiveEvaluationTest", "jld:CompactTest" ],
       "name": "coerced @list containing an empty list",
@@ -1562,7 +1570,7 @@
       "context": "compact/li05-context.jsonld",
       "expect": "compact/li05-out.jsonld",
       "option": {"specVersion": "json-ld-1.1"}
-  }, {
+   }, {
       "@id": "#tm001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Indexes to object not having an @id",

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -106,7 +106,7 @@
       "@id": "#t0013",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "@value with @language",
-      "purpose": "Values with @language remain in expended form by default",
+      "purpose": "Values with @language remain in expanded form by default",
       "input": "compact/0013-in.jsonld",
       "context": "compact/0013-context.jsonld",
       "expect": "compact/0013-out.jsonld"
@@ -1517,7 +1517,52 @@
       "context": "compact/js11-context.jsonld",
       "expect": "compact/js11-out.jsonld",
       "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.1"}
-   }, {
+     }, {
+      "@id": "#tli01",
+      "@type": [ "jld:PositiveEvaluationTest", "jld:CompactTest" ],
+      "name": "coerced @list containing an empty list",
+      "purpose": "Lists of Lists",
+      "input": "compact/li01-in.jsonld",
+      "context": "compact/li01-context.jsonld",
+      "expect": "compact/li01-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tli02",
+      "@type": [ "jld:PositiveEvaluationTest", "jld:CompactTest" ],
+      "name": "coerced @list containing a list",
+      "purpose": "Lists of Lists",
+      "input": "compact/li02-in.jsonld",
+      "context": "compact/li02-context.jsonld",
+      "expect": "compact/li02-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tli03",
+      "@type": [ "jld:PositiveEvaluationTest", "jld:CompactTest" ],
+      "name": "coerced @list containing an deep list",
+      "purpose": "Lists of Lists",
+      "input": "compact/li03-in.jsonld",
+      "context": "compact/li03-context.jsonld",
+      "expect": "compact/li03-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tli04",
+      "@type": [ "jld:PositiveEvaluationTest", "jld:CompactTest" ],
+      "name": "coerced @list containing multiple lists",
+      "purpose": "Lists of Lists",
+      "input": "compact/li04-in.jsonld",
+      "context": "compact/li04-context.jsonld",
+      "expect": "compact/li04-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tli05",
+      "@type": [ "jld:PositiveEvaluationTest", "jld:CompactTest" ],
+      "name": "coerced @list containing mixed list values",
+      "purpose": "Lists of Lists",
+      "input": "compact/li05-in.jsonld",
+      "context": "compact/li05-context.jsonld",
+      "expect": "compact/li05-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+  }, {
       "@id": "#tm001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Indexes to object not having an @id",
@@ -2015,51 +2060,6 @@
       "context": "compact/s002-context.jsonld",
       "expect": "compact/s002-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
-    }, {
-      "@id": "#tli01",
-      "@type": [ "jld:PositiveEvaluationTest", "jld:CompactTest" ],
-      "name": "coerced @list containing an empty list",
-      "purpose": "Lists of Lists",
-      "input": "compact/li01-in.jsonld",
-      "context": "compact/li01-context.jsonld",
-      "expect": "compact/li01-out.jsonld",
-      "option": {"specVersion": "json-ld-1.1"}
-    }, {
-      "@id": "#tli02",
-      "@type": [ "jld:PositiveEvaluationTest", "jld:CompactTest" ],
-      "name": "coerced @list containing a list",
-      "purpose": "Lists of Lists",
-      "input": "compact/li02-in.jsonld",
-      "context": "compact/li02-context.jsonld",
-      "expect": "compact/li02-out.jsonld",
-      "option": {"specVersion": "json-ld-1.1"}
-    }, {
-      "@id": "#tli03",
-      "@type": [ "jld:PositiveEvaluationTest", "jld:CompactTest" ],
-      "name": "coerced @list containing an deep list",
-      "purpose": "Lists of Lists",
-      "input": "compact/li03-in.jsonld",
-      "context": "compact/li03-context.jsonld",
-      "expect": "compact/li03-out.jsonld",
-      "option": {"specVersion": "json-ld-1.1"}
-    }, {
-      "@id": "#tli04",
-      "@type": [ "jld:PositiveEvaluationTest", "jld:CompactTest" ],
-      "name": "coerced @list containing multiple lists",
-      "purpose": "Lists of Lists",
-      "input": "compact/li04-in.jsonld",
-      "context": "compact/li04-context.jsonld",
-      "expect": "compact/li04-out.jsonld",
-      "option": {"specVersion": "json-ld-1.1"}
-    }, {
-      "@id": "#tli05",
-      "@type": [ "jld:PositiveEvaluationTest", "jld:CompactTest" ],
-      "name": "coerced @list containing mixed list values",
-      "purpose": "Lists of Lists",
-      "input": "compact/li05-in.jsonld",
-      "context": "compact/li05-context.jsonld",
-      "expect": "compact/li05-out.jsonld",
-      "option": {"specVersion": "json-ld-1.1"}
    }, {
       "@id": "#ttn01",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],

--- a/tests/compact/la01-context.jsonld
+++ b/tests/compact/la01-context.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "type1": "http://example.com/t1",
+    "type2": "http://example.com/t2",
+    "@language": "de",
+    "termL": { "@id": "http://example.com/termLanguage" },
+    "termLL0": { "@id": "http://example.com/termLanguage", "@container": "@list" },
+    "termLL1": { "@id": "http://example.com/termLanguage", "@container": "@list", "@language": "eN" },
+    "termLL2": { "@id": "http://example.com/termLanguage", "@container": "@list", "@language": null },
+    "termT": { "@id": "http://example.com/termType" },
+    "termTL0": { "@id": "http://example.com/termType", "@container": "@list" },
+    "termTL1": { "@id": "http://example.com/termType", "@container": "@list", "@type": "type1" },
+    "termTL2": { "@id": "http://example.com/termType", "@container": "@list", "@type": "type2" }
+  }
+}

--- a/tests/compact/la01-in.jsonld
+++ b/tests/compact/la01-in.jsonld
@@ -1,0 +1,48 @@
+{
+
+  "@context": {
+    "type1": "http://example.com/t1",
+    "type2": "http://example.com/t2"
+  },
+  "@id": "http://example.com/id1",
+  "http://example.com/termLanguage": [
+    {
+      "@list": [
+        { "@value": "termLL0.1", "@language": "de" },
+        { "@value": "termLL0.2", "@language": "de" }
+      ]
+    },
+    {
+      "@list": [
+        { "@value": "termLL1.1", "@language": "en" },
+        { "@value": "termLL1.2", "@language": "en" }
+      ]
+    },
+    {
+      "@list": [
+        "termLL2.1",
+        "termLL2.2"
+      ]
+    }
+  ],
+  "http://example.com/termType": [
+    {
+      "@list": [
+        { "@value": "termTL0.1", "@type": "type1" },
+        { "@value": "termTL0.2", "@type": "type2" }
+      ]
+    },
+    {
+      "@list": [
+        { "@value": "termTL1.1", "@type": "type1" },
+        { "@value": "termTL1.2", "@type": "type1" }
+      ]
+    },
+    {
+      "@list": [
+        { "@value": "termTL2.1", "@type": "type2" },
+        { "@value": "termTL2.2", "@type": "type2" }
+      ]
+    }
+  ]
+}

--- a/tests/compact/la01-out.jsonld
+++ b/tests/compact/la01-out.jsonld
@@ -1,0 +1,46 @@
+{
+  "@context": {
+    "type1": "http://example.com/t1",
+    "type2": "http://example.com/t2",
+    "@language": "de",
+    "termL": { "@id": "http://example.com/termLanguage" },
+    "termLL0": { "@id": "http://example.com/termLanguage", "@container": "@list" },
+    "termLL1": { "@id": "http://example.com/termLanguage", "@container": "@list", "@language": "eN" },
+    "termLL2": { "@id": "http://example.com/termLanguage", "@container": "@list", "@language": null },
+    "termT": { "@id": "http://example.com/termType" },
+    "termTL0": { "@id": "http://example.com/termType", "@container": "@list" },
+    "termTL1": { "@id": "http://example.com/termType", "@container": "@list", "@type": "type1" },
+    "termTL2": { "@id": "http://example.com/termType", "@container": "@list", "@type": "type2" }
+  },
+  "@id": "http://example.com/id1",
+  "termLL0": [
+    "termLL0.1",
+    "termLL0.2"
+  ],
+  "termLL1": [
+    "termLL1.1",
+    "termLL1.2"
+  ],
+  "termLL2": [
+    "termLL2.1",
+    "termLL2.2"
+  ],
+  "termTL0": [
+    {
+      "@type": "type1",
+      "@value": "termTL0.1"
+    },
+    {
+      "@type": "type2",
+      "@value": "termTL0.2"
+    }
+  ],
+  "termTL1": [
+    "termTL1.1",
+    "termTL1.2"
+  ],
+  "termTL2": [
+    "termTL2.1",
+    "termTL2.2"
+  ]
+}

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -46,9 +46,10 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 <p>JSON-LD Object comparison compares JSON objects, arrays, and values recursively for equality.</p>
 
 <ul>
-<li>JSON objects are compared member by member without regard to the ordering of members within the object. Each member must have a corresponding member in the object being compared to. Values are compared recursively.</li>
+<li>JSON objects are compared entry by entry without regard to the ordering of entriess within the object. Each entry must have a corresponding entry in the object being compared to. Values are compared recursively.</li>
 <li>JSON arrays are generally compared without regard to order (the lone exception being if the referencing key is <code>@list</code>). Each item within the array must be equivalent to an item in the array being compared to by using the comparison algorithm recursively. For values of <code>@list</code>, the order of these items is significant.</li>
 <li>JSON values are compared using strict equality.</li>
+<li>Values of <code>@language</code>, and other places where language tags may be used are specified in lowercase in the test results. Implementations should either normalize language tags for testing purposes, or compare language tags in a case-independent way.</li>
 </ul>
 
 <p>Note that some tests require re-expansion and comparison, as list values may exist as values of properties that have <code>@container: @list</code> and the comparison algorithm will not consider ordering significant.</p>

--- a/tests/flatten-manifest.html
+++ b/tests/flatten-manifest.html
@@ -46,9 +46,10 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 <p>JSON-LD Object comparison compares JSON objects, arrays, and values recursively for equality.</p>
 
 <ul>
-<li>JSON objects are compared member by member without regard to the ordering of members within the object. Each member must have a corresponding member in the object being compared to. Values are compared recursively.</li>
+<li>JSON objects are compared entry by entry without regard to the ordering of entriess within the object. Each entry must have a corresponding entry in the object being compared to. Values are compared recursively.</li>
 <li>JSON arrays are generally compared without regard to order (the lone exception being if the referencing key is <code>@list</code>). Each item within the array must be equivalent to an item in the array being compared to by using the comparison algorithm recursively. For values of <code>@list</code>, the order of these items is significant.</li>
 <li>JSON values are compared using strict equality.</li>
+<li>Values of <code>@language</code>, and other places where language tags may be used are specified in lowercase in the test results. Implementations should either normalize language tags for testing purposes, or compare language tags in a case-independent way.</li>
 </ul>
 
 <p>Note that some tests require re-expansion and comparison, as list values may exist as values of properties that have <code>@container: @list</code> and the comparison algorithm will not consider ordering significant.</p>

--- a/tests/fromRdf-manifest.html
+++ b/tests/fromRdf-manifest.html
@@ -41,9 +41,10 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 <p>JSON-LD Object comparison compares JSON objects, arrays, and values recursively for equality.</p>
 
 <ul>
-<li>JSON objects are compared member by member without regard to the ordering of members within the object. Each member must have a corresponding member in the object being compared to. Values are compared recursively.</li>
+<li>JSON objects are compared entry by entry without regard to the ordering of entriess within the object. Each entry must have a corresponding entry in the object being compared to. Values are compared recursively.</li>
 <li>JSON arrays are generally compared without regard to order (the lone exception being if the referencing key is <code>@list</code>). Each item within the array must be equivalent to an item in the array being compared to by using the comparison algorithm recursively. For values of <code>@list</code>, the order of these items is significant.</li>
 <li>JSON values are compared using strict equality.</li>
+<li>Values of <code>@language</code>, and other places where language tags may be used are specified in lowercase in the test results. Implementations should either normalize language tags for testing purposes, or compare language tags in a case-independent way.</li>
 </ul>
 
 <p>Note that some tests require re-expansion and comparison, as list values may exist as values of properties that have <code>@container: @list</code> and the comparison algorithm will not consider ordering significant.</p>

--- a/tests/html-manifest.html
+++ b/tests/html-manifest.html
@@ -61,9 +61,10 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 <p>JSON-LD Object comparison compares JSON objects, arrays, and values recursively for equality.</p>
 
 <ul>
-<li>JSON objects are compared member by member without regard to the ordering of members within the object. Each member must have a corresponding member in the object being compared to. Values are compared recursively.</li>
+<li>JSON objects are compared entry by entry without regard to the ordering of entriess within the object. Each entry must have a corresponding entry in the object being compared to. Values are compared recursively.</li>
 <li>JSON arrays are generally compared without regard to order (the lone exception being if the referencing key is <code>@list</code>). Each item within the array must be equivalent to an item in the array being compared to by using the comparison algorithm recursively. For values of <code>@list</code>, the order of these items is significant.</li>
 <li>JSON values are compared using strict equality.</li>
+<li>Values of <code>@language</code>, and other places where language tags may be used are specified in lowercase in the test results. Implementations should either normalize language tags for testing purposes, or compare language tags in a case-independent way.</li>
 </ul>
 
 <p>Note that some tests require re-expansion and comparison, as list values may exist as values of properties that have <code>@container: @list</code> and the comparison algorithm will not consider ordering significant.</p>

--- a/tests/manifest.html
+++ b/tests/manifest.html
@@ -81,9 +81,10 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 <p>JSON-LD Object comparison compares JSON objects, arrays, and values recursively for equality.</p>
 
 <ul>
-<li>JSON objects are compared member by member without regard to the ordering of members within the object. Each member must have a corresponding member in the object being compared to. Values are compared recursively.</li>
+<li>JSON objects are compared entry by entry without regard to the ordering of entriess within the object. Each entry must have a corresponding entry in the object being compared to. Values are compared recursively.</li>
 <li>JSON arrays are generally compared without regard to order (the lone exception being if the referencing key is <code>@list</code>). Each item within the array must be equivalent to an item in the array being compared to by using the comparison algorithm recursively. For values of <code>@list</code>, the order of these items is significant.</li>
 <li>JSON values are compared using strict equality.</li>
+<li>Values of <code>@language</code>, and other places where language tags may be used are specified in lowercase in the test results. Implementations should either normalize language tags for testing purposes, or compare language tags in a case-independent way.</li>
 </ul>
 
 <p>Note that some tests require re-expansion and comparison, as list values may exist as values of properties that have <code>@container: @list</code> and the comparison algorithm will not consider ordering significant.</p>

--- a/tests/remote-doc-manifest.html
+++ b/tests/remote-doc-manifest.html
@@ -60,9 +60,10 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 <p>JSON-LD Object comparison compares JSON objects, arrays, and values recursively for equality.</p>
 
 <ul>
-<li>JSON objects are compared member by member without regard to the ordering of members within the object. Each member must have a corresponding member in the object being compared to. Values are compared recursively.</li>
+<li>JSON objects are compared entry by entry without regard to the ordering of entriess within the object. Each entry must have a corresponding entry in the object being compared to. Values are compared recursively.</li>
 <li>JSON arrays are generally compared without regard to order (the lone exception being if the referencing key is <code>@list</code>). Each item within the array must be equivalent to an item in the array being compared to by using the comparison algorithm recursively. For values of <code>@list</code>, the order of these items is significant.</li>
 <li>JSON values are compared using strict equality.</li>
+<li>Values of <code>@language</code>, and other places where language tags may be used are specified in lowercase in the test results. Implementations should either normalize language tags for testing purposes, or compare language tags in a case-independent way.</li>
 </ul>
 
 <p>Note that some tests require re-expansion and comparison, as list values may exist as values of properties that have <code>@container: @list</code> and the comparison algorithm will not consider ordering significant.</p>

--- a/tests/template.haml
+++ b/tests/template.haml
@@ -100,9 +100,10 @@
 
       JSON-LD Object comparison compares JSON objects, arrays, and values recursively for equality.
 
-      * JSON objects are compared member by member without regard to the ordering of members within the object. Each member must have a corresponding member in the object being compared to. Values are compared recursively.
+      * JSON objects are compared entry by entry without regard to the ordering of entriess within the object. Each entry must have a corresponding entry in the object being compared to. Values are compared recursively.
       * JSON arrays are generally compared without regard to order (the lone exception being if the referencing key is `@list`). Each item within the array must be equivalent to an item in the array being compared to by using the comparison algorithm recursively. For values of `@list`, the order of these items is significant.
       * JSON values are compared using strict equality.
+      * Values of `@language`, and other places where language tags may be used are specified in lowercase in the test results. Implementations should either normalize language tags for testing purposes, or compare language tags in a case-independent way.
 
       Note that some tests require re-expansion and comparison, as list values may exist as values of properties that have `@container: @list` and the comparison algorithm will not consider ordering significant.
 

--- a/tests/toRdf-manifest.html
+++ b/tests/toRdf-manifest.html
@@ -41,9 +41,10 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 <p>JSON-LD Object comparison compares JSON objects, arrays, and values recursively for equality.</p>
 
 <ul>
-<li>JSON objects are compared member by member without regard to the ordering of members within the object. Each member must have a corresponding member in the object being compared to. Values are compared recursively.</li>
+<li>JSON objects are compared entry by entry without regard to the ordering of entriess within the object. Each entry must have a corresponding entry in the object being compared to. Values are compared recursively.</li>
 <li>JSON arrays are generally compared without regard to order (the lone exception being if the referencing key is <code>@list</code>). Each item within the array must be equivalent to an item in the array being compared to by using the comparison algorithm recursively. For values of <code>@list</code>, the order of these items is significant.</li>
 <li>JSON values are compared using strict equality.</li>
+<li>Values of <code>@language</code>, and other places where language tags may be used are specified in lowercase in the test results. Implementations should either normalize language tags for testing purposes, or compare language tags in a case-independent way.</li>
 </ul>
 
 <p>Note that some tests require re-expansion and comparison, as list values may exist as values of properties that have <code>@container: @list</code> and the comparison algorithm will not consider ordering significant.</p>


### PR DESCRIPTION
* Remove requirement to normalize language tags to lower case, but note testing considerations.
* Notes about normalizing language tags, issuing warnings when not well-formed, and not considering case when using for term selection.
* Add a test for term selection where case of language does not match.

For #167.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/168.html" title="Last updated on Oct 14, 2019, 9:18 PM UTC (1c62284)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/168/5e314e9...1c62284.html" title="Last updated on Oct 14, 2019, 9:18 PM UTC (1c62284)">Diff</a>