### PR TITLE
Fix expansion of link template variable json_file, regenerate html.

### DIFF
--- a/tests/compact-manifest.html
+++ b/tests/compact-manifest.html
@@ -16,7 +16,7 @@ Compaction
 </p>
 <h1>Compaction</h1>
 <p>This is an HTML version of a test manifest. The JSON-LD version of this manifest may be found at
-<a href="json_file">compact-manifest.jsonld</a>. The manifest vocabulary is described in the <a href="vocab.html">JSON-LD Test Vocabulary</a> (<a href="vocab.jsonld">JSON-LD</a>, <a href="vocab.ttl">Turtle</a>) and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
+<a href="compact-manifest.jsonld">compact-manifest.jsonld</a>. The manifest vocabulary is described in the <a href="vocab.html">JSON-LD Test Vocabulary</a> (<a href="vocab.jsonld">JSON-LD</a>, <a href="vocab.ttl">Turtle</a>) and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
 
 <p>The JSON-LD Test Suite is a set of tests that can
 be used to verify JSON-LD Processor conformance to the set of specifications

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -16,7 +16,7 @@ Expansion
 </p>
 <h1>Expansion</h1>
 <p>This is an HTML version of a test manifest. The JSON-LD version of this manifest may be found at
-<a href="json_file">expand-manifest.jsonld</a>. The manifest vocabulary is described in the <a href="vocab.html">JSON-LD Test Vocabulary</a> (<a href="vocab.jsonld">JSON-LD</a>, <a href="vocab.ttl">Turtle</a>) and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
+<a href="expand-manifest.jsonld">expand-manifest.jsonld</a>. The manifest vocabulary is described in the <a href="vocab.html">JSON-LD Test Vocabulary</a> (<a href="vocab.jsonld">JSON-LD</a>, <a href="vocab.ttl">Turtle</a>) and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
 
 <p>The JSON-LD Test Suite is a set of tests that can
 be used to verify JSON-LD Processor conformance to the set of specifications

--- a/tests/flatten-manifest.html
+++ b/tests/flatten-manifest.html
@@ -16,7 +16,7 @@ Flattening
 </p>
 <h1>Flattening</h1>
 <p>This is an HTML version of a test manifest. The JSON-LD version of this manifest may be found at
-<a href="json_file">flatten-manifest.jsonld</a>. The manifest vocabulary is described in the <a href="vocab.html">JSON-LD Test Vocabulary</a> (<a href="vocab.jsonld">JSON-LD</a>, <a href="vocab.ttl">Turtle</a>) and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
+<a href="flatten-manifest.jsonld">flatten-manifest.jsonld</a>. The manifest vocabulary is described in the <a href="vocab.html">JSON-LD Test Vocabulary</a> (<a href="vocab.jsonld">JSON-LD</a>, <a href="vocab.ttl">Turtle</a>) and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
 
 <p>The JSON-LD Test Suite is a set of tests that can
 be used to verify JSON-LD Processor conformance to the set of specifications

--- a/tests/fromRdf-manifest.html
+++ b/tests/fromRdf-manifest.html
@@ -16,7 +16,7 @@ Transform RDF to JSON-LD
 </p>
 <h1>Transform RDF to JSON-LD</h1>
 <p>This is an HTML version of a test manifest. The JSON-LD version of this manifest may be found at
-<a href="json_file">fromRdf-manifest.jsonld</a>. The manifest vocabulary is described in the <a href="vocab.html">JSON-LD Test Vocabulary</a> (<a href="vocab.jsonld">JSON-LD</a>, <a href="vocab.ttl">Turtle</a>) and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
+<a href="fromRdf-manifest.jsonld">fromRdf-manifest.jsonld</a>. The manifest vocabulary is described in the <a href="vocab.html">JSON-LD Test Vocabulary</a> (<a href="vocab.jsonld">JSON-LD</a>, <a href="vocab.ttl">Turtle</a>) and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
 
 <p>The JSON-LD Test Suite is a set of tests that can
 be used to verify JSON-LD Processor conformance to the set of specifications

--- a/tests/html-manifest.html
+++ b/tests/html-manifest.html
@@ -16,7 +16,7 @@ HTML
 </p>
 <h1>HTML</h1>
 <p>This is an HTML version of a test manifest. The JSON-LD version of this manifest may be found at
-<a href="json_file">html-manifest.jsonld</a>. The manifest vocabulary is described in the <a href="vocab.html">JSON-LD Test Vocabulary</a> (<a href="vocab.jsonld">JSON-LD</a>, <a href="vocab.ttl">Turtle</a>) and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
+<a href="html-manifest.jsonld">html-manifest.jsonld</a>. The manifest vocabulary is described in the <a href="vocab.html">JSON-LD Test Vocabulary</a> (<a href="vocab.jsonld">JSON-LD</a>, <a href="vocab.ttl">Turtle</a>) and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
 
 <p>The JSON-LD Test Suite is a set of tests that can
 be used to verify JSON-LD Processor conformance to the set of specifications

--- a/tests/manifest.html
+++ b/tests/manifest.html
@@ -16,7 +16,7 @@ JSON-LD Test Suite
 </p>
 <h1>JSON-LD Test Suite</h1>
 <p>This is an HTML version of a test manifest. The JSON-LD version of this manifest may be found at
-<a href="json_file">manifest.jsonld</a>. The manifest vocabulary is described in the <a href="vocab.html">JSON-LD Test Vocabulary</a> (<a href="vocab.jsonld">JSON-LD</a>, <a href="vocab.ttl">Turtle</a>) and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
+<a href="manifest.jsonld">manifest.jsonld</a>. The manifest vocabulary is described in the <a href="vocab.html">JSON-LD Test Vocabulary</a> (<a href="vocab.jsonld">JSON-LD</a>, <a href="vocab.ttl">Turtle</a>) and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
 
 <p>The JSON-LD Test Suite is a set of tests that can
 be used to verify JSON-LD Processor conformance to the set of specifications

--- a/tests/remote-doc-manifest.html
+++ b/tests/remote-doc-manifest.html
@@ -16,7 +16,7 @@ Remote document
 </p>
 <h1>Remote document</h1>
 <p>This is an HTML version of a test manifest. The JSON-LD version of this manifest may be found at
-<a href="json_file">remote-doc-manifest.jsonld</a>. The manifest vocabulary is described in the <a href="vocab.html">JSON-LD Test Vocabulary</a> (<a href="vocab.jsonld">JSON-LD</a>, <a href="vocab.ttl">Turtle</a>) and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
+<a href="remote-doc-manifest.jsonld">remote-doc-manifest.jsonld</a>. The manifest vocabulary is described in the <a href="vocab.html">JSON-LD Test Vocabulary</a> (<a href="vocab.jsonld">JSON-LD</a>, <a href="vocab.ttl">Turtle</a>) and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
 
 <p>The JSON-LD Test Suite is a set of tests that can
 be used to verify JSON-LD Processor conformance to the set of specifications

--- a/tests/template.haml
+++ b/tests/template.haml
@@ -7,7 +7,7 @@
     %meta{"http-equiv" => "Content-Type", :content => "text/html;charset=utf-8"}
     %title
       = manifest['name']
-    %link{rel: "alternate", href: json_file}
+    %link{rel: "alternate", href: "#{json_file}"}
     %link{rel: "stylesheet", href: "https://www.w3.org/StyleSheets/TR/base"}
   %body
     %p
@@ -16,7 +16,7 @@
     %h1<=manifest['name']
     :markdown
       This is an HTML version of a test manifest. The JSON-LD version of this manifest may be found at
-      [#{json_file}](json_file). The manifest vocabulary is described in the [JSON-LD Test Vocabulary](vocab.html) ([JSON-LD](vocab.jsonld), [Turtle](vocab.ttl)) and is based on the [RDF Test Vocabulary](http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/).
+      [#{json_file}](#{json_file}). The manifest vocabulary is described in the [JSON-LD Test Vocabulary](vocab.html) ([JSON-LD](vocab.jsonld), [Turtle](vocab.ttl)) and is based on the [RDF Test Vocabulary](http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/).
 
       The JSON-LD Test Suite is a set of tests that can
       be used to verify JSON-LD Processor conformance to the set of specifications

--- a/tests/toRdf-manifest.html
+++ b/tests/toRdf-manifest.html
@@ -16,7 +16,7 @@ Transform JSON-LD to RDF
 </p>
 <h1>Transform JSON-LD to RDF</h1>
 <p>This is an HTML version of a test manifest. The JSON-LD version of this manifest may be found at
-<a href="json_file">toRdf-manifest.jsonld</a>. The manifest vocabulary is described in the <a href="vocab.html">JSON-LD Test Vocabulary</a> (<a href="vocab.jsonld">JSON-LD</a>, <a href="vocab.ttl">Turtle</a>) and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
+<a href="toRdf-manifest.jsonld">toRdf-manifest.jsonld</a>. The manifest vocabulary is described in the <a href="vocab.html">JSON-LD Test Vocabulary</a> (<a href="vocab.jsonld">JSON-LD</a>, <a href="vocab.ttl">Turtle</a>) and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
 
 <p>The JSON-LD Test Suite is a set of tests that can
 be used to verify JSON-LD Processor conformance to the set of specifications


### PR DESCRIPTION
The links e.g. to manifest.jsonld were giving a 404, pointing to a file `json_file`,
It looks like the template was missing the necessary details to expand the variable json_file.

You can currently observe the behavior by clicking the `manifest.jsonld` links at the following.
* [json-ld-api-tests](https://w3c.github.io/json-ld-api/tests/)
* [json-framing-ld-tests](https://w3c.github.io/json-ld-framing/tests/)
