### PR TITLE
Expand contexts when processing keys in id-map.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2646,20 +2646,18 @@
                   in <var>value</var>, ordered lexicographically by <var>index</var>
                   <span class="changed">if {{JsonLdOptions/ordered}} is <code>true</code></span>:
                   <ol>
-                    <li class="changed">If <var>container mapping</var> includes <code>@type</code>:
-                      <ol>
-                        <li>Set <var>map context</var> to the <a>previous context</a>
-                          from <var>active context</var> if it exists, or <var>active context</var> otherwise.</li>
-                        <li>If <var>index</var>'s <a>term definition</a> in
-                          <var>map context</var> has a <a>local context</a>, update
-                          <var>map context</var> to the result of the
-                          <a href="#context-processing-algorithm">Context Processing algorithm</a>,
-                          passing <var>map context</var> as <var>active context</var>
-                          and the value of the <var>index</var>'s <a>local context</a>
-                          as <var>local context</var>.</li>
-                      </ol>
-                    </li>
-                    <li>Otherwise, set <var>map context</var> to <var>active context</var>.</li>
+                    <li class="changed">If <var>container mapping</var> includes `@id` or `@type`,
+                      set <var>map context</var> to the <a>previous context</a>
+                      from <var>active context</var> if it exists, or <var>active context</var> otherwise.</li>
+                    <li class="changed">If <var>container mapping</var> includes <code>@type</code>
+                      and <var>index</var>'s <a>term definition</a> in
+                      <var>map context</var> has a <a>local context</a>, update
+                      <var>map context</var> to the result of the
+                      <a href="#context-processing-algorithm">Context Processing algorithm</a>,
+                      passing <var>map context</var> as <var>active context</var>
+                      and the value of the <var>index</var>'s <a>local context</a>
+                      as <var>local context</var>.</li>
+                      <li>Otherwise, set <var>map context</var> to <var>active context</var>.</li>
                     <li>Set <var>expanded index</var> to the result of using the
                       <a href="#iri-expansion">IRI Expansion algorithm</a>,
                       passing <var>active context</var>, <var>index</var>, and <code>true</code>


### PR DESCRIPTION
Separate creating map context from rolling back term-scoped context when expanding container maps for `@id` and `@type`.

Fixes #159.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/173.html" title="Last updated on Oct 18, 2019, 10:07 PM UTC (d6f2e0d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/173/cebd4fc...d6f2e0d.html" title="Last updated on Oct 18, 2019, 10:07 PM UTC (d6f2e0d)">Diff</a>