### PR TITLE
Add wording to allow a default object

### DIFF
--- a/index.html
+++ b/index.html
@@ -2415,7 +2415,9 @@
                     transforming it into an <a>array</a>, if necessary.</span>
                   <span class="changed">
                     When the {{JsonLdOptions/frameExpansion}} flag is set, <var>value</var>
-                    may also be an empty <a>map</a>.
+                    may also be an empty <a>map</a>, or a <a>default object</a>.
+                    For a <a>default object</a>, the value of `@default` is restricted to be
+                    an <a>IRI</a>, which is expanded as above.
                   </span>
                   <div class="note">
                     No transformation from a <a>string</a> <var>value</var> to an <a>array</a>


### PR DESCRIPTION
containing an _IRI_ as the value of `@type` when framing.

For w3c/json-ld-framing#74.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/174.html" title="Last updated on Oct 21, 2019, 5:16 PM UTC (f6c7fb2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/174/2abfba2...f6c7fb2.html" title="Last updated on Oct 21, 2019, 5:16 PM UTC (f6c7fb2)">Diff</a>