### PR TITLE
Remove incomplete and redundant step for `@type` and `@included`

### DIFF
--- a/index.html
+++ b/index.html
@@ -2382,8 +2382,6 @@
                   (unless <a>processing mode</a> is `json-ld-1.0`)</span>,
                   a <a data-link-for="JsonLdErrorCode">colliding keywords</a>
                   error has been detected and processing is aborted.</li>
-                <li class="changed">If <var>result</var> already has an <var>expanded property</var> <a>entry</a>,
-                  for `@included` or `@type`.</li>
                 <li>If <var>expanded property</var> is <code>@id</code> and
                   <var>value</var> is not a <a>string</a>, an
                   <a data-link-for="JsonLdErrorCode">invalid @id value</a>


### PR DESCRIPTION
in expansion algorithm.

Fixes #178.

cc/ @kasei


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/179.html" title="Last updated on Oct 28, 2019, 9:57 PM UTC (cb8ba95)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/179/629ec61...cb8ba95.html" title="Last updated on Oct 28, 2019, 9:57 PM UTC (cb8ba95)">Diff</a>