### PR TITLE
Clarify that expansion steps looking for entries

### DIFF
--- a/index.html
+++ b/index.html
@@ -2861,15 +2861,15 @@
                 containing only the <code>@id</code> <a>entry</a> is retained.</span></li>
           </ol>
         </li>
+        <li>If <var>result</var> is a
+          <a class="changed">map</a> that contains only an <code>@graph</code> <a>entry</a>,
+          set <var>result</var> that value.</li>
+        <li>Otherwise, if <var>result</var> is <code>null</code>,
+          set <var>result</var> to an empty <a>array</a>.</li>
+        <li>If <var>result</var> is not an <a>array</a>,
+          set <var>result</var> to an <a>array</a> containing only <var>result</var>.</li>
         <li>Return <var>result</var>.</li>
       </ol>
-
-      <p>If, after the above algorithm is run, the result is a
-        <a class="changed">map</a> that contains only an <code>@graph</code> <a>entry</a>, set the
-        result to the value of <code>@graph</code>'s value. Otherwise, if the result
-        is <code>null</code>, set it to an empty <a>array</a>. Finally, if
-        the result is not an <a>array</a>, then set the result to an
-        <a>array</a> containing only the result.</p>
     </section>
   </section> <!-- end of Expansion Algorithm -->
 

--- a/index.html
+++ b/index.html
@@ -2846,14 +2846,14 @@
               set <var>result</var> to the <a data-lt="entry">entry's</a> associated value.</li>
           </ol>
         </li>
-        <li>If <var>result</var> contains only the <a>entry</a>
+        <li>If <var>result</var> is a <a>map</a> that contains only the <a>entry</a>
           <code>@language</code>, set <var>result</var> to <code>null</code>.</li>
         <li>If <var>active property</var> is <code>null</code> or <code>@graph</code>,
           drop free-floating values as follows:
           <ol>
-            <li>If <var>result</var> is an empty <a class="changed">map</a> or contains
-              the <a>entries</a> <code>@value</code> or <code>@list</code>, set <var>result</var> to
-              <code>null</code>.</li>
+            <li>If <var>result</var> is a <a>map</a> which is empty,
+              or contains only the <a>entries</a> <code>@value</code> or <code>@list</code>,
+              set <var>result</var> to <code>null</code>.</li>
             <li>Otherwise, if <var>result</var> is a <a class="changed">map</a> whose only
               <a>entry</a> is <code>@id</code>, set <var>result</var> to <code>null</code>.
               <span class="changed">

--- a/index.html
+++ b/index.html
@@ -2864,7 +2864,7 @@
         <li>If <var>result</var> is a
           <a class="changed">map</a> that contains only an <code>@graph</code> <a>entry</a>,
           set <var>result</var> that value.</li>
-        <li>Otherwise, if <var>result</var> is <code>null</code>,
+        <li>If <var>result</var> is <code>null</code>,
           set <var>result</var> to an empty <a>array</a>.</li>
         <li>If <var>result</var> is not an <a>array</a>,
           set <var>result</var> to an <a>array</a> containing only <var>result</var>.</li>


### PR DESCRIPTION
only apply when _result_ is a map.

Also,  split-up and remove final step of Expansion Algorithm.

Fixes #175 and fixes #183.

cc/ @kasie


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/184.html" title="Last updated on Oct 31, 2019, 10:10 PM UTC (2dc02c1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/184/2f36a51...2dc02c1.html" title="Last updated on Oct 31, 2019, 10:10 PM UTC (2dc02c1)">Diff</a>