### PR TITLE
Clarifications on _container mapping_

### DIFF
--- a/index.html
+++ b/index.html
@@ -1490,7 +1490,8 @@
               error has been detected and processing is aborted.</li>
             <li>If <var>value</var> contains an <code>@container</code> <a>entry</a>,
               set the <a>container mapping</a> of <var>definition</var>
-              to its value; if its value is neither <code>@set</code>, nor
+              to <span class="changed">an <a>array</a> containing</span> its value;
+              if its value is neither <code>@set</code>, nor
               <code>@index</code>, nor <code>null</code>, an
               <a data-link-for="JsonLdErrorCode">invalid reverse property</a>
               error has been detected (reverse properties only support set- and
@@ -1613,8 +1614,9 @@
               generate an <a data-link-for="JsonLdErrorCode">invalid container mapping</a>
               error and abort processing if <a>processing mode</a> is `json-ld-1.0`.</li>
             <li>Set the <a>container mapping</a> of <var>definition</var> to
-              <var>container</var>.</li>
-            <li class="changed">If <a>container mapping</a> is `@type`:
+              <var>container</var>
+              <span class="changed">coercing to an <a>array</a>, if necessary</span>.</li>
+            <li class="changed">If the <a>container mapping</a> of <var>definition</var> includes `@type`:
               <ol>
                 <li>If <var>type mapping</var> in <var>definition</var> is undefined, set it to `@id`.</li>
                 <li>If <var>type mapping</var> in <var>definition</var> is neither `@id` nor `@vocab`,
@@ -3268,7 +3270,7 @@
           return that result.</li>
         <li class="changed">If <var>element</var> is a
           <a>list object</a>, and the <a>container mapping</a> for
-          <var>active property</var> in <var>active context</var> is <code>@list</code>,
+          <var>active property</var> in <var>active context</var> <span class="changed">includes</span> <code>@list</code>,
           return the result of using this algorithm recursively, passing
           <var>active context</var>, <var>inverse context</var>,
           <var>active property</var>, value of <code>@list</code>


### PR DESCRIPTION
Now it is always represented as an array in a term definition.

Fixes #181.

cc/ @kasei


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/186.html" title="Last updated on Oct 31, 2019, 11:39 PM UTC (62d07f1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/186/d930363...62d07f1.html" title="Last updated on Oct 31, 2019, 11:39 PM UTC (62d07f1)">Diff</a>