### PR TITLE
Clarify that IRI expansion uses _base IRI_ from _active context_

### DIFF
--- a/index.html
+++ b/index.html
@@ -3017,7 +3017,7 @@
           with <var>value</var>.</li>
         <li>Otherwise, if <var>document relative</var> is <code>true</code>
           set <var>value</var> to the result of resolving <var>value</var> against
-          the <a>base IRI</a>. Only the basic algorithm in
+          the <a>base IRI</a> from <var>active context</var>. Only the basic algorithm in
           <a data-cite="RFC3986#section-5.2">section 5.2</a>
           of [[RFC3986]] is used; neither
           <a data-cite="RFC3986#section-6.2.2">Syntax-Based Normalization</a> nor


### PR DESCRIPTION
for _document relative_.

Fixes #180.

cc/ @kasie


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/187.html" title="Last updated on Oct 30, 2019, 11:33 PM UTC (43b17f9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/187/6b43cf6...43b17f9.html" title="Last updated on Oct 30, 2019, 11:33 PM UTC (43b17f9)">Diff</a>