### PR TITLE
Terms with colon

### DIFF
--- a/index.html
+++ b/index.html
@@ -1520,14 +1520,12 @@
               return; processors SHOULD generate a warning.</li>
             <li>Otherwise, set the <a>IRI mapping</a> of <var>definition</var> to the
               result of using the <a href="#iri-expansion">IRI Expansion algorithm</a>,
-              passing <var>active context</var>, the value associated with
-              the <code>@reverse</code> <a>entry</a> for <var>value</var>, <code>true</code>
-              for <var>vocab</var>,
-              <var>local context</var>, and <var>defined</var>. If the result
-              is neither an <a>IRI</a> nor a <a>blank node identifier</a>,
-              i.e., it contains no colon (<code>:</code>), an
-              <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
-              error has been detected and processing is aborted.</li>
+              passing <var>active context</var>,
+              the value associated with the <code>@reverse</code> <a>entry</a> for <var>value</var>,
+              `true` for <var>vocab</var>,
+              `true` for <var>document relative</var>,
+              <var>local context</var>,
+              and <var>defined</var>.</li>
             <li>If <var>value</var> contains an <code>@container</code> <a>entry</a>,
               set the <a>container mapping</a> of <var>definition</var>
               to <span class="changed">an <a>array</a> containing</span> its value;
@@ -3049,10 +3047,7 @@
               <span class="changed">having a non-<code>null</code> <a>IRI mapping</a>
                 and the <a>prefix flag</a> of the <a>term definition</a> is <code>true</code></span>,
               return the result of concatenating the <a>IRI mapping</a>
-              associated with <var>prefix</var> and <var>suffix</var>.
-              <p class="ednote">A more conservative change, although more involved,
-                would to restrict looking at the <a>prefix flag</a> if
-                the <a>processing mode</a> is `json-ld-1.0`.</p></li>
+              associated with <var>prefix</var> and <var>suffix</var>.</li>
             <li><span class="changed">If <var>value</var> has the form of an <a>IRI</a></span>,
               return <var>value</var>.</li>
           </ol>

--- a/index.html
+++ b/index.html
@@ -1571,7 +1571,7 @@
               <a data-link-for="JsonLdErrorCode">invalid keyword alias</a>
               error has been detected and processing is aborted.</li>
             <li class="changed">If the <var>term</var> contains a colon (`:`)
-              anywhere but as the last character of <var>term</var>,
+              anywhere but as the first or last character of <var>term</var>,
               or if it contains a slash (`/`) anywhere,
               and for either case, the result of expanding <var>term</var>
               using the <a href="#iri-expansion">IRI Expansion algorithm</a>
@@ -1586,7 +1586,8 @@
           </ol>
         </li>
         <li>
-          Otherwise if the <var>term</var> contains a colon (`:`):
+          Otherwise if the <var>term</var> contains a colon (`:`)
+          <span class="changed">anywhere after the first character</span>:
           <ol>
             <li>If <var>term</var> is a <a>compact IRI</a> with a
               <a>prefix</a> that is an <a>entry</a> in <var>local context</var>
@@ -3020,7 +3021,9 @@
         <li>If <var>vocab</var> is <code>true</code> and the
           <var>active context</var> has a <a>term definition</a> for
           <var>value</var>, return the associated <a>IRI mapping</a>.</li>
-        <li>If <var>value</var> contains a colon (`:`), it is either
+        <li>If <var>value</var> contains a colon (`:`)
+          <span class="changed">anywhere after the first character</span>,
+          it is either
           an <a>IRI</a>, a <a>compact IRI</a>, or a
           <a>blank node identifier</a>:
           <ol>

--- a/index.html
+++ b/index.html
@@ -1523,9 +1523,11 @@
               passing <var>active context</var>,
               the value associated with the <code>@reverse</code> <a>entry</a> for <var>value</var>,
               `true` for <var>vocab</var>,
-              `true` for <var>document relative</var>,
               <var>local context</var>,
-              and <var>defined</var>.</li>
+              and <var>defined</var>.
+              If the result does not have the form of an <a>IRI</a> or a <a>blank node identifier</a>,
+              an <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
+              error has been detected and processing is aborted.</li>
             <li>If <var>value</var> contains an <code>@container</code> <a>entry</a>,
               set the <a>container mapping</a> of <var>definition</var>
               to <span class="changed">an <a>array</a> containing</span> its value;

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -5073,6 +5073,27 @@ invalid term definition
 </dd>
 </dl>
 </dd>
+<dt id='te050'>
+Test te050 Invalid reverse id
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#te050</dd>
+<dt>Type</dt>
+<dd>jld:NegativeEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>Verifies that an exception is raised in Expansion when an invalid IRI is used for @reverse.</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/e050-in.jsonld'>expand/e050-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+invalid IRI mapping
+</dd>
+</dl>
+</dd>
 <dt id='tec01'>
 Test tec01 Invalid keyword in term definition
 </dt>

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -2820,6 +2820,62 @@ invalid vocab mapping
 </dd>
 </dl>
 </dd>
+<dt id='t0117'>
+Test t0117 A term starting with a colon can expand to a different IRI
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#t0117</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>Terms may begin with a colon and not be treated as IRIs.</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/0117-in.jsonld'>expand/0117-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='expand/0117-out.jsonld'>expand/0117-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='t0118'>
+Test t0118 Expanding a value staring with a colon does not treat that value as an IRI
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#t0118</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>Terms may begin with a colon and not be treated as IRIs.</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/0118-in.jsonld'>expand/0118-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='expand/0118-out.jsonld'>expand/0118-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
 <dt id='tc001'>
 Test tc001 adding new term
 </dt>

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -869,6 +869,22 @@
       "expectErrorCode": "invalid vocab mapping",
       "option": {"specVersion": "json-ld-1.0"}
     }, {
+      "@id": "#t0117",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "A term starting with a colon can expand to a different IRI",
+      "purpose": "Terms may begin with a colon and not be treated as IRIs.",
+      "input": "expand/0117-in.jsonld",
+      "expect": "expand/0117-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#t0118",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Expanding a value staring with a colon does not treat that value as an IRI",
+      "purpose": "Terms may begin with a colon and not be treated as IRIs.",
+      "input": "expand/0118-in.jsonld",
+      "expect": "expand/0118-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tc001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "adding new term",

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -1546,6 +1546,13 @@
       "expectErrorCode": "invalid term definition",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#te050",
+      "@type": [ "jld:NegativeEvaluationTest", "jld:ExpandTest" ],
+      "name": "Invalid reverse id",
+      "purpose": "Verifies that an exception is raised in Expansion when an invalid IRI is used for @reverse.",
+      "input": "expand/e050-in.jsonld",
+      "expectErrorCode": "invalid IRI mapping"
+    }, {
       "@id": "#tec01",
       "@type": [ "jld:NegativeEvaluationTest", "jld:ExpandTest" ],
       "name": "Invalid keyword in term definition",

--- a/tests/expand/0117-in.jsonld
+++ b/tests/expand/0117-in.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/vocab",
+    ":term": {"@type": "@id"}
+  },
+  ":term": "http://example.org/base"
+}

--- a/tests/expand/0117-out.jsonld
+++ b/tests/expand/0117-out.jsonld
@@ -1,0 +1,3 @@
+[{
+  "http://example.org/vocab:term": [{"@id": "http://example.org/base"}]
+}]

--- a/tests/expand/0118-in.jsonld
+++ b/tests/expand/0118-in.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {"@vocab": "http://schema.org/"},
+  "@id": "foo:bar-id",
+  "@type": "foo:bar-type",
+  "foo:bar": "is an absolute iri property",
+  "term": "is schema.org/term",
+  ":fish": "is schema.org/:fish"
+}

--- a/tests/expand/0118-out.jsonld
+++ b/tests/expand/0118-out.jsonld
@@ -1,0 +1,7 @@
+[{
+  "@id": "foo:bar-id",
+  "@type": ["foo:bar-type"],
+  "foo:bar": [{"@value": "is an absolute iri property"}],
+  "http://schema.org/term": [{"@value": "is schema.org/term"}],
+  "http://schema.org/:fish": [{"@value": "is schema.org/:fish"}]
+}]

--- a/tests/expand/e050-in.jsonld
+++ b/tests/expand/e050-in.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "rev": {"@reverse": "not an IRI"}
+  },
+  "@id": "http://example.org/foo",
+  "rev": {"@id": "http://example.org/bar"}
+}

--- a/tests/toRdf-manifest.html
+++ b/tests/toRdf-manifest.html
@@ -2671,6 +2671,27 @@ Test te050 Term definitions with prefix separate from prefix definitions
 </dd>
 </dl>
 </dd>
+<dt id='tee50'>
+Test tee50 Invalid reverse id
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tee50</dd>
+<dt>Type</dt>
+<dd>jld:NegativeEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Verifies that an exception is raised in Expansion when an invalid IRI is used for @reverse.</dd>
+<dt>input</dt>
+<dd>
+<a href='toRdf/ee50-in.jsonld'>toRdf/ee50-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+invalid IRI mapping
+</dd>
+</dl>
+</dd>
 <dt id='te051'>
 Test te051 Expansion of keyword aliases in term definitions
 </dt>
@@ -4328,6 +4349,62 @@ invalid vocab mapping
 <dl class='options'>
 <dt>specVersion</dt>
 <dd>json-ld-1.0</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='te117'>
+Test te117 A term starting with a colon can expand to a different IRI
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#te117</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Terms may begin with a colon and not be treated as IRIs.</dd>
+<dt>input</dt>
+<dd>
+<a href='toRdf/e117-in.jsonld'>toRdf/e117-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='toRdf/e117-out.nq'>toRdf/e117-out.nq</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='te118'>
+Test te118 Expanding a value staring with a colon does not treat that value as an IRI
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#te118</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Terms may begin with a colon and not be treated as IRIs.</dd>
+<dt>input</dt>
+<dd>
+<a href='toRdf/e118-in.jsonld'>toRdf/e118-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='toRdf/e118-out.nq'>toRdf/e118-out.nq</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
 </dl>
 </dd>
 </dl>

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -845,6 +845,13 @@
       "input": "toRdf/e050-in.jsonld",
       "expect": "toRdf/e050-out.nq"
     }, {
+      "@id": "#tee50",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
+      "name": "Invalid reverse id",
+      "purpose": "Verifies that an exception is raised in Expansion when an invalid IRI is used for @reverse.",
+      "input": "toRdf/ee50-in.jsonld",
+      "expectErrorCode": "invalid IRI mapping"
+    }, {
       "@id": "#te051",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
       "name": "Expansion of keyword aliases in term definitions",
@@ -1358,6 +1365,22 @@
       "input": "toRdf/e116-in.jsonld",
       "expectErrorCode": "invalid vocab mapping",
       "option": {"specVersion": "json-ld-1.0"}
+    }, {
+      "@id": "#te117",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "A term starting with a colon can expand to a different IRI",
+      "purpose": "Terms may begin with a colon and not be treated as IRIs.",
+      "input": "toRdf/e117-in.jsonld",
+      "expect": "toRdf/e117-out.nq",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#te118",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Expanding a value staring with a colon does not treat that value as an IRI",
+      "purpose": "Terms may begin with a colon and not be treated as IRIs.",
+      "input": "toRdf/e118-in.jsonld",
+      "expect": "toRdf/e118-out.nq",
+      "option": {"specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tin01",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],

--- a/tests/toRdf/e117-in.jsonld
+++ b/tests/toRdf/e117-in.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/vocab",
+    ":term": {"@type": "@id"}
+  },
+  ":term": "http://example.org/base"
+}

--- a/tests/toRdf/e117-out.nq
+++ b/tests/toRdf/e117-out.nq
@@ -1,0 +1,1 @@
+_:b0 <http://example.org/vocab:term> <http://example.org/base> .

--- a/tests/toRdf/e118-in.jsonld
+++ b/tests/toRdf/e118-in.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {"@vocab": "http://schema.org/"},
+  "@id": "foo:bar-id",
+  "@type": "foo:bar-type",
+  "foo:bar": "is an absolute iri property",
+  "term": "is schema.org/term",
+  ":fish": "is schema.org/:fish"
+}

--- a/tests/toRdf/e118-out.nq
+++ b/tests/toRdf/e118-out.nq
@@ -1,0 +1,4 @@
+<foo:bar-id> <http://schema.org/term> "is schema.org/term" .
+<foo:bar-id> <foo:bar> "is an absolute iri property" .
+<foo:bar-id> <http://schema.org/:fish> "is schema.org/:fish" .
+<foo:bar-id> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <foo:bar-type> .

--- a/tests/toRdf/ee50-in.jsonld
+++ b/tests/toRdf/ee50-in.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "rev": {"@reverse": "not an IRI"}
+  },
+  "@id": "http://example.org/foo",
+  "rev": {"@id": "http://example.org/bar"}
+}


### PR DESCRIPTION
* Allow terms starting with a colon to not be treated as IRIs. For #189
* Add "document relative" when expanding values of `@reverse` in term creation.
  Remove the check for IRI or blank node after calling IRI expansion, as if it were a native value, it would have been detected, and otherwise, strings will be percent-encoded to create IRIs.
  For #195.

cc/ @azaroth42 @kasei @lo48576


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/203.html" title="Last updated on Nov 7, 2019, 9:23 PM UTC (356e4f4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/203/0d787f2...356e4f4.html" title="Last updated on Nov 7, 2019, 9:23 PM UTC (356e4f4)">Diff</a>