### PR TITLE
Keyword space

### DIFF
--- a/index.html
+++ b/index.html
@@ -1458,7 +1458,8 @@
           <var>term</var> MUST NOT be a <a>keyword</a> and a
           <a data-link-for="JsonLdErrorCode">keyword redefinition</a>
           error has been detected and processing is aborted.
-          If <var>term</var> has the form of a keyword (i.e., it begins with `"@"`),
+          If <var>term</var> has the form of a keyword
+          (i.e., it matches the ABNF rule `"@"1*ALPHA` from [[RFC5234]]),
           return; processors SHOULD generate a warning.</li>
         <li class="changed">Set <var>previous definition</var> to any existing
           <a>term definition</a> for <var>term</var> in <var>active context</var>,
@@ -1516,7 +1517,8 @@
               <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
               error has been detected and processing is aborted.</li>
             <li>If the value associated with the `@reverse` <a>entry</a> is a string
-              having the form of a keyword (i.e., it begins with `"@"`),
+              having the form of a keyword
+              (i.e., it matches the ABNF rule `"@"1*ALPHA` from [[RFC5234]]),
               return; processors SHOULD generate a warning.</li>
             <li>Otherwise, set the <a>IRI mapping</a> of <var>definition</var> to the
               result of using the <a href="#iri-expansion">IRI Expansion algorithm</a>,
@@ -1557,7 +1559,8 @@
               error has been detected and processing is aborted.</li>
             <li>If the value associated with the `@id` <a>entry</a>
               is not a <a>keyword</a>, but
-              has the form of a <a>keyword</a> (i.e., it begins with `"@"`),
+              has the form of a <a>keyword</a>
+              (i.e., it matches the ABNF rule `"@"1*ALPHA` from [[RFC5234]]),
               return; processors SHOULD generate a warning.</li>
             <li>Otherwise, set the <a>IRI mapping</a> of <var>definition</var> to the
               result of using the <a href="#iri-expansion">IRI Expansion algorithm</a>, passing
@@ -3004,7 +3007,8 @@
         <li>If <var>value</var> is a <a>keyword</a> or <code>null</code>,
           return <var>value</var> as is.</li>
         <li class="changed">
-          If <var>value</var> has the form of a keyword (i.e., it begins with `"@"`),
+          If <var>value</var> has the form of a keyword
+          (i.e., it matches the ABNF rule `"@"1*ALPHA` from [[RFC5234]]),
           a processor SHOULD generate a warning and return `null`.</li>
         <li>If <var>local context</var> is not <code>null</code>, it contains
           an <a>entry</a> with a key that equals <var>value</var>, and the value of the <a>entry</a>

--- a/index.html
+++ b/index.html
@@ -6786,6 +6786,7 @@
     <li>The <a>processing mode</a> is now implicitly `json-ld-1.1`, unless set
       explicitly to `json-ld-1.0`.</li>
     <li>Improve notation using <a>IRI</a>, <a>IRI reference</a>, and <a>relative IRI reference</a>.</li>
+    <li>Ignore terms and IRIs that have the form of a keyword (`"@"1*ALPHA`).</li>
   </ul>
 </section>
 

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -2820,24 +2820,24 @@ invalid vocab mapping
 </dd>
 </dl>
 </dd>
-<dt id='t0117'>
-Test t0117 A term starting with a colon can expand to a different IRI
+<dt id='t0119'>
+Test t0119 Ignore some terms with @, allow others.
 </dt>
 <dd>
 <dl class='entry'>
 <dt>id</dt>
-<dd>#t0117</dd>
+<dd>#t0119</dd>
 <dt>Type</dt>
 <dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
 <dt>Purpose</dt>
-<dd>Terms may begin with a colon and not be treated as IRIs.</dd>
+<dd>Processors SHOULD generate a warning and MUST ignore terms having the form of a keyword.</dd>
 <dt>input</dt>
 <dd>
-<a href='expand/0117-in.jsonld'>expand/0117-in.jsonld</a>
+<a href='expand/0119-in.jsonld'>expand/0119-in.jsonld</a>
 </dd>
 <dt>expect</dt>
 <dd>
-<a href='expand/0117-out.jsonld'>expand/0117-out.jsonld</a>
+<a href='expand/0119-out.jsonld'>expand/0119-out.jsonld</a>
 </dd>
 <dt>Options</dt>
 <dd>
@@ -2848,24 +2848,80 @@ Test t0117 A term starting with a colon can expand to a different IRI
 </dd>
 </dl>
 </dd>
-<dt id='t0118'>
-Test t0118 Expanding a value staring with a colon does not treat that value as an IRI
+<dt id='t0120'>
+Test t0120 Ignore some values of @id with @, allow others.
 </dt>
 <dd>
 <dl class='entry'>
 <dt>id</dt>
-<dd>#t0118</dd>
+<dd>#t0120</dd>
 <dt>Type</dt>
 <dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
 <dt>Purpose</dt>
-<dd>Terms may begin with a colon and not be treated as IRIs.</dd>
+<dd>Processors SHOULD generate a warning and MUST ignore values of @id having the form of a keyword.</dd>
 <dt>input</dt>
 <dd>
-<a href='expand/0118-in.jsonld'>expand/0118-in.jsonld</a>
+<a href='expand/0120-in.jsonld'>expand/0120-in.jsonld</a>
 </dd>
 <dt>expect</dt>
 <dd>
-<a href='expand/0118-out.jsonld'>expand/0118-out.jsonld</a>
+<a href='expand/0120-out.jsonld'>expand/0120-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='t0121'>
+Test t0121 Ignore some values of @reverse with @, allow others.
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#t0121</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>Processors SHOULD generate a warning and MUST ignore values of @reverse having the form of a keyword.</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/0121-in.jsonld'>expand/0121-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='expand/0121-out.jsonld'>expand/0121-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='t0122'>
+Test t0122 Ignore some IRIs when that start with @ when expanding.
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#t0122</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>Processors SHOULD generate a warning and MUST ignore IRIs having the form of a keyword.</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/0122-in.jsonld'>expand/0122-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='expand/0122-out.jsonld'>expand/0122-out.jsonld</a>
 </dd>
 <dt>Options</dt>
 <dd>

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -2820,6 +2820,62 @@ invalid vocab mapping
 </dd>
 </dl>
 </dd>
+<dt id='t0117'>
+Test t0117 A term starting with a colon can expand to a different IRI
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#t0117</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>Terms may begin with a colon and not be treated as IRIs.</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/0117-in.jsonld'>expand/0117-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='expand/0117-out.jsonld'>expand/0117-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='t0118'>
+Test t0118 Expanding a value staring with a colon does not treat that value as an IRI
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#t0118</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>Terms may begin with a colon and not be treated as IRIs.</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/0118-in.jsonld'>expand/0118-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='expand/0118-out.jsonld'>expand/0118-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
 <dt id='t0119'>
 Test t0119 Ignore some terms with @, allow others.
 </dt>

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -885,6 +885,38 @@
       "expect": "expand/0118-out.jsonld",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#t0119",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Ignore some terms with @, allow others.",
+      "purpose": "Processors SHOULD generate a warning and MUST ignore terms having the form of a keyword.",
+      "input": "expand/0119-in.jsonld",
+      "expect": "expand/0119-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#t0120",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Ignore some values of @id with @, allow others.",
+      "purpose": "Processors SHOULD generate a warning and MUST ignore values of @id having the form of a keyword.",
+      "input": "expand/0120-in.jsonld",
+      "expect": "expand/0120-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#t0121",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Ignore some values of @reverse with @, allow others.",
+      "purpose": "Processors SHOULD generate a warning and MUST ignore values of @reverse having the form of a keyword.",
+      "input": "expand/0121-in.jsonld",
+      "expect": "expand/0121-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#t0122",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Ignore some IRIs when that start with @ when expanding.",
+      "purpose": "Processors SHOULD generate a warning and MUST ignore IRIs having the form of a keyword.",
+      "input": "expand/0122-in.jsonld",
+      "expect": "expand/0122-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tc001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "adding new term",

--- a/tests/expand/0119-in.jsonld
+++ b/tests/expand/0119-in.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@": "http://example.org/vocab/at",
+    "@foo.bar": "http://example.org/vocab/foo.bar",
+    "@ignoreMe": "http://example.org/vocab/ignoreMe"
+  },
+  "@": "allowed",
+  "@foo.bar": "allowed",
+  "@ignoreMe": "ignored"
+}

--- a/tests/expand/0119-out.jsonld
+++ b/tests/expand/0119-out.jsonld
@@ -1,0 +1,4 @@
+[{
+  "http://example.org/vocab/at": [{"@value": "allowed"}],
+  "http://example.org/vocab/foo.bar": [{"@value": "allowed"}]
+}]

--- a/tests/expand/0120-in.jsonld
+++ b/tests/expand/0120-in.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "@vocab": "http://example.orb/vocab/",
+    "at": {"@id": "@"},
+    "foo.bar": {"@id": "@foo.bar"},
+    "ignoreMe": {"@id": "@ignoreMe"}
+  },
+  "at": "allowed",
+  "foo.bar": "allowed",
+  "ignoreMe": "resolves to @vocab"
+}

--- a/tests/expand/0120-out.jsonld
+++ b/tests/expand/0120-out.jsonld
@@ -1,0 +1,5 @@
+[{
+  "http://example.orb/vocab/@": [{"@value": "allowed"}],
+  "http://example.orb/vocab/@foo.bar": [{"@value": "allowed"}],
+  "http://example.orb/vocab/ignoreMe": [{"@value": "resolves to @vocab"}]
+}]

--- a/tests/expand/0121-in.jsonld
+++ b/tests/expand/0121-in.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "@base": "http://example.org/",
+    "@vocab": "http://example.org/vocab/",
+    "at": {"@reverse": "@"},
+    "foo.bar": {"@reverse": "@foo.bar"}
+  },
+  "@id": "foo",
+  "at": {"@id": "allowed"},
+  "foo.bar": {"@id": "allowed"}
+}

--- a/tests/expand/0121-out.jsonld
+++ b/tests/expand/0121-out.jsonld
@@ -1,0 +1,7 @@
+[{
+  "@id": "http://example.org/foo",
+  "@reverse": {
+    "http://example.org/vocab/@": [{"@id": "http://example.org/allowed"}],
+    "http://example.org/vocab/@foo.bar": [{"@id": "http://example.org/allowed"}]
+  }
+}]

--- a/tests/expand/0122-in.jsonld
+++ b/tests/expand/0122-in.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "@base": "http://example.org/"
+  },
+  "http://example.org/vocab/at": {"@id": "@"},
+  "http://example.org/vocab/foo.bar": {"@id": "@foo.bar"},
+  "http://example.org/vocab/ignoreme": {"@id": "@ignoreMe"}
+}

--- a/tests/expand/0122-out.jsonld
+++ b/tests/expand/0122-out.jsonld
@@ -1,0 +1,5 @@
+[{
+  "http://example.org/vocab/at": [{"@id": "http://example.org/@"}],
+  "http://example.org/vocab/foo.bar": [{"@id": "http://example.org/@foo.bar"}],
+  "http://example.org/vocab/ignoreme": [{"@id": ""}]
+}]

--- a/tests/toRdf-manifest.html
+++ b/tests/toRdf-manifest.html
@@ -4409,6 +4409,118 @@ Test te118 Expanding a value staring with a colon does not treat that value as a
 </dd>
 </dl>
 </dd>
+<dt id='te119'>
+Test te119 Ignore some terms with @, allow others.
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#te119</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Processors SHOULD generate a warning and MUST ignore terms having the form of a keyword.</dd>
+<dt>input</dt>
+<dd>
+<a href='toRdf/e119-in.jsonld'>toRdf/e119-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='toRdf/e119-out.nq'>toRdf/e119-out.nq</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='te120'>
+Test te120 Ignore some values of @id with @, allow others.
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#te120</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Processors SHOULD generate a warning and MUST ignore values of @id having the form of a keyword.</dd>
+<dt>input</dt>
+<dd>
+<a href='toRdf/e120-in.jsonld'>toRdf/e120-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='toRdf/e120-out.nq'>toRdf/e120-out.nq</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='te121'>
+Test te121 Ignore some values of @reverse with @, allow others.
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#te121</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Processors SHOULD generate a warning and MUST ignore values of @reverse having the form of a keyword.</dd>
+<dt>input</dt>
+<dd>
+<a href='toRdf/e121-in.jsonld'>toRdf/e121-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='toRdf/e121-out.nq'>toRdf/e121-out.nq</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='te122'>
+Test te122 Ignore some IRIs when that start with @ when expanding.
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#te122</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Processors SHOULD generate a warning and MUST ignore IRIs having the form of a keyword.</dd>
+<dt>input</dt>
+<dd>
+<a href='toRdf/e122-in.jsonld'>toRdf/e122-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='toRdf/e122-out.nq'>toRdf/e122-out.nq</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
 <dt id='tin01'>
 Test tin01 Basic Included array
 </dt>

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -1382,6 +1382,38 @@
       "expect": "toRdf/e118-out.nq",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#te119",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Ignore some terms with @, allow others.",
+      "purpose": "Processors SHOULD generate a warning and MUST ignore terms having the form of a keyword.",
+      "input": "toRdf/e119-in.jsonld",
+      "expect": "toRdf/e119-out.nq",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#te120",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Ignore some values of @id with @, allow others.",
+      "purpose": "Processors SHOULD generate a warning and MUST ignore values of @id having the form of a keyword.",
+      "input": "toRdf/e120-in.jsonld",
+      "expect": "toRdf/e120-out.nq",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#te121",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Ignore some values of @reverse with @, allow others.",
+      "purpose": "Processors SHOULD generate a warning and MUST ignore values of @reverse having the form of a keyword.",
+      "input": "toRdf/e121-in.jsonld",
+      "expect": "toRdf/e121-out.nq",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#te122",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Ignore some IRIs when that start with @ when expanding.",
+      "purpose": "Processors SHOULD generate a warning and MUST ignore IRIs having the form of a keyword.",
+      "input": "toRdf/e122-in.jsonld",
+      "expect": "toRdf/e122-out.nq",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tin01",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
       "name": "Basic Included array",

--- a/tests/toRdf/e119-in.jsonld
+++ b/tests/toRdf/e119-in.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@": "http://example.org/vocab/at",
+    "@foo.bar": "http://example.org/vocab/foo.bar",
+    "@ignoreMe": "http://example.org/vocab/ignoreMe"
+  },
+  "@": "allowed",
+  "@foo.bar": "allowed",
+  "@ignoreMe": "ignored"
+}

--- a/tests/toRdf/e119-out.nq
+++ b/tests/toRdf/e119-out.nq
@@ -1,0 +1,2 @@
+_:b0 <http://example.org/vocab/at> "allowed" .
+_:b0 <http://example.org/vocab/foo.bar> "allowed" .

--- a/tests/toRdf/e120-in.jsonld
+++ b/tests/toRdf/e120-in.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "@vocab": "http://example.orb/vocab/",
+    "at": {"@id": "@"},
+    "foo.bar": {"@id": "@foo.bar"},
+    "ignoreMe": {"@id": "@ignoreMe"}
+  },
+  "at": "allowed",
+  "foo.bar": "allowed",
+  "ignoreMe": "resolves to @vocab"
+}

--- a/tests/toRdf/e120-out.nq
+++ b/tests/toRdf/e120-out.nq
@@ -1,0 +1,3 @@
+_:b0 <http://example.orb/vocab/@> "allowed" .
+_:b0 <http://example.orb/vocab/@foo.bar> "allowed" .
+_:b0 <http://example.orb/vocab/ignoreMe> "resolves to @vocab" .

--- a/tests/toRdf/e121-in.jsonld
+++ b/tests/toRdf/e121-in.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "@base": "http://example.org/",
+    "@vocab": "http://example.org/vocab/",
+    "at": {"@reverse": "@"},
+    "foo.bar": {"@reverse": "@foo.bar"}
+  },
+  "@id": "foo",
+  "at": {"@id": "allowed"},
+  "foo.bar": {"@id": "allowed"}
+}

--- a/tests/toRdf/e121-out.nq
+++ b/tests/toRdf/e121-out.nq
@@ -1,0 +1,2 @@
+<http://example.org/allowed> <http://example.org/vocab/@foo.bar> <http://example.org/foo> .
+<http://example.org/allowed> <http://example.org/vocab/@> <http://example.org/foo> .

--- a/tests/toRdf/e122-in.jsonld
+++ b/tests/toRdf/e122-in.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "@base": "http://example.org/"
+  },
+  "http://example.org/vocab/at": {"@id": "@"},
+  "http://example.org/vocab/foo.bar": {"@id": "@foo.bar"},
+  "http://example.org/vocab/ignoreme": {"@id": "@ignoreMe"}
+}

--- a/tests/toRdf/e122-out.nq
+++ b/tests/toRdf/e122-out.nq
@@ -1,0 +1,2 @@
+_:b0 <http://example.org/vocab/at> <http://example.org/@> .
+_:b0 <http://example.org/vocab/foo.bar> <http://example.org/@foo.bar> .


### PR DESCRIPTION
Add text with ABNF for recognizing, warning and ignoring keyword-like strings and add expansion and toRdf tests.

For #191 

Still requires changes to syntax.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/204.html" title="Last updated on Nov 8, 2019, 11:02 PM UTC (3b18c05)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/204/d98d011...3b18c05.html" title="Last updated on Nov 8, 2019, 11:02 PM UTC (3b18c05)">Diff</a>