### PR TITLE
Algorithm clarifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -2490,7 +2490,7 @@
                       error has been detected and processing is aborted.
                       <span class="changed">
                         When the {{JsonLdOptions/frameExpansion}} flag is set, <var>value</var>
-                        may be an empty <a>map</a>, or an <a>array</a> of one
+                        MAY be an empty <a>map</a>, or an <a>array</a> of one
                         or more <a>strings</a>.</span></li>
                     <li>Otherwise,
                       set <var>expanded value</var> to the result of using the
@@ -2513,7 +2513,7 @@
                       error has been detected and processing is aborted.
                       <span class="changed">
                         When the {{JsonLdOptions/frameExpansion}} flag is set, <var>value</var>
-                        may also be an empty <a>map</a>, or a <a>default object</a>
+                        MAY be an empty <a>map</a>, or a <a>default object</a>
                         where the value of `@default` is restricted to be
                         an <a>IRI</a>.
                         All other values mean that <a data-link-for="JsonLdErrorCode">invalid type value</a>
@@ -2585,7 +2585,7 @@
                       an <a data-link-for="JsonLdErrorCode">invalid value object value</a>
                       error has been detected and processing is aborted.
                       <span class="changed">When the {{JsonLdOptions/frameExpansion}} flag is set, <var>value</var>
-                      may also be an empty <a>map</a> or an array of
+                      MAY be an empty <a>map</a> or an array of
                       <a>scalar</a> values.</span></li>
                     <li>Otherwise, set <var>expanded value</var> to <var>value</var>.
                       <span class="changed">When the {{JsonLdOptions/frameExpansion}} flag is set,
@@ -2607,7 +2607,7 @@
                       <a data-link-for="JsonLdErrorCode">invalid language-tagged string</a>
                       error has been detected and processing is aborted.
                       <span class="changed">When the {{JsonLdOptions/frameExpansion}} flag is set, <var>value</var>
-                        may also be an empty <a>map</a> or an array of zero or
+                        MAY be an empty <a>map</a> or an array of zero or
                         <a>strings</a></span>.</li>
                     <li><span class="changed">
                       Otherwise, set <var>expanded value</var> to <var>value</var>.
@@ -2630,7 +2630,7 @@
                       <a data-link-for="JsonLdErrorCode">invalid base direction</a>
                       error has been detected and processing is aborted.
                       When the {{JsonLdOptions/frameExpansion}} flag is set, <var>value</var>
-                      may also be an empty <a>map</a> or an array of zero or
+                      MAY be an empty <a>map</a> or an array of zero or
                       <a>strings</a>.</li>
                     <li>Otherwise, set <var>expanded value</var> to <var>value</var>.
                       When the {{JsonLdOptions/frameExpansion}} flag is set,

--- a/index.html
+++ b/index.html
@@ -1196,7 +1196,7 @@
                   contains any <a>protected</a> <a>term definitions</a>,
                   an <a data-link-for="JsonLdErrorCode">invalid context nullification</a>
                   has been detected and processing is aborted.</li>
-                <li>Otherwise, set <var>result</var> to a
+                <li>Otherwise, initialize <var>result</var> as a
                   newly-initialized <var>active context</var>,
                   <span class="changed">setting <a>previous context</a> in <var>result</var>
                     to the previous value of <var>result</var> if <var>propagate</var> is <code>false</code></span>.
@@ -1208,7 +1208,7 @@
             </li>
             <li>If <var>context</var> is a <a>string</a>,
               <ol>
-                <li>Set <var>context</var> to the result of resolving <var>context</var> against
+                <li>Initialize <var>context</var> to the result of resolving <var>context</var> against
                   the <a>base IRI</a>
                   of the document containing the <var>local context</var>
                   which is established as specified in
@@ -1274,7 +1274,7 @@
                 <li>Otherwise, if the value of `@import` is not a <a>string</a>,
                   an <a data-link-for="JsonLdErrorCode">invalid @import value</a>
                   error has been detected and processing is aborted.</li>
-                <li>Set <var>import</var> to the result of resolving the value of <code>@import</code> against
+                <li>Initialize <var>import</var> to the result of resolving the value of <code>@import</code> against
                   the base IRI which is established as specified in
                   <a data-cite="RFC3986#section-5.1">section 5.1 Establishing a Base URI</a>
                   of [[RFC3986]]. Only the basic algorithm in
@@ -1511,7 +1511,7 @@
           If <var>term</var> has the form of a keyword
           (i.e., it matches the ABNF rule `"@"1*ALPHA` from [[RFC5234]]),
           return; processors SHOULD generate a warning.</li>
-        <li class="changed">Set <var>previous definition</var> to any existing
+        <li class="changed">Initialize <var>previous definition</var> to any existing
           <a>term definition</a> for <var>term</var> in <var>active context</var>,
           removing that <a>term definition</a> from <var>active context</var>.</li>
         <li class="changed">If <var>value</var> is <code>null</code>,
@@ -1527,7 +1527,7 @@
           <span class="changed">Set <var>simple term</var> to <code>false</code></span>.</li>
         <li>Create a new <a>term definition</a>, <var>definition</var>.</li>
         <li class="changed">If the <code>@protected</code> entry in <var>value</var>
-          is <code>true</code> set the <a>protected</a> in <var>definition</var> to true.
+          is <code>true</code> set the <a>protected</a> flag in <var>definition</var> to true.
           If the value of `@protected` is not a <a>boolean</a>,
           an <a data-link-for="JsonLdErrorCode">invalid @protected value</a> error has been detected and processing is aborted.
           If <a>processing mode</a> is `json-ld-1.0`,
@@ -2371,9 +2371,9 @@
         <ol>
         <li>If <var>element</var> is <code>null</code>, return <code>null</code>.</li>
         <li class="changed">If <var>active property</var> is <code>@default</code>,
-          set the {{JsonLdOptions/frameExpansion}} flag to <code>false</code>.</li>
+          initialize the {{JsonLdOptions/frameExpansion}} flag to <code>false</code>.</li>
         <li class="changed">If <var>active property</var> has a <a>term definition</a> in <var>active context</var>
-          with a <a>local context</a>, set <var>property scoped context</var> to that <a>local context</a>.</li>
+          with a <a>local context</a>, initialize <var>property scoped context</var> to that <a>local context</a>.</li>
         <li>If <var>element</var> is a <a>scalar</a>,
           <ol>
             <li>If <var>active property</var> is <code>null</code> or <code>@graph</code>,
@@ -2431,7 +2431,7 @@
           <a href="#context-processing-algorithm">Context Processing algorithm</a>,
           passing <var>active context</var> and the value of the
           <code>@context</code> <a>entry</a> as <var>local context</var>.</li>
-        <li class="changed">Set <var>type-scoped context</var> to <var>active context</var>.
+        <li class="changed">Initialize <var>type-scoped context</var> to <var>active context</var>.
           This is used for expanding values that may be relevant to any previous
           <a>type-scoped context</a>.</li>
         <li class="changed">For each <var>key</var> and <var>value</var> in <var>element</var>
@@ -2455,7 +2455,7 @@
         </li>
         <li>Initialize two empty <a class="changed">maps</a>, <var>result</var>
           <span class="changed">and <var>nests</var>.
-            Set <var>input type</var> to the last value of the first <a>entry</a> in <var>element</var>
+            Initialize <var>input type</var> to the last value of the first <a>entry</a> in <var>element</var>
             expanding to <code>@type</code>, ordering <a>entries</a> lexicographically by key</span>.
         </li>
         <li id="alg-expand-each-key-value">
@@ -2464,7 +2464,7 @@
           <ol>
             <li>If <var>key</var> is <code>@context</code>, continue to
               the next <var>key</var>.</li>
-            <li>Set <var>expanded property</var> to the result of
+            <li>Initialize <var>expanded property</var> to the result of
               using the <a href="#iri-expansion">IRI Expansion algorithm</a>,
               passing <var>active context</var>, <var>key</var> for
               <var>value</var>, and <code>true</code> for <var>vocab</var>.</li>
@@ -2714,7 +2714,7 @@
                 <li>Continue with the next <var>key</var> from <var>element</var>.</li>
               </ol>
             </li>
-            <li>Set <var>container mapping</var> to <var>key</var>'s <a>container mapping</a> in
+            <li>Initialize <var>container mapping</var> to <var>key</var>'s <a>container mapping</a> in
               <var>active context</var>.</li>
             <li class="changed">If <var>key</var>'s <a>term definition</a> in <var>active context</var>
               has a <a>type mapping</a> of <code>@json</code>,
@@ -2781,7 +2781,7 @@
                   <span class="changed">if {{JsonLdOptions/ordered}} is <code>true</code></span>:
                   <ol>
                     <li class="changed">If <var>container mapping</var> includes `@id` or `@type`,
-                      set <var>map context</var> to the <a>previous context</a>
+                      initialize <var>map context</var> to the <a>previous context</a>
                       from <var>active context</var> if it exists,
                       otherwise, set <var>map context</var> to <var>active context</var>.</li>
                     <li class="changed">If <var>container mapping</var> includes <code>@type</code>
@@ -2793,7 +2793,7 @@
                       and the value of the <var>index</var>'s <a>local context</a>
                       as <var>local context</var>.</li>
                       <li>Otherwise, set <var>map context</var> to <var>active context</var>.</li>
-                    <li>Set <var>expanded index</var> to the result of using the
+                    <li>Initialize <var>expanded index</var> to the result of using the
                       <a href="#iri-expansion">IRI Expansion algorithm</a>,
                       passing <var>active context</var>, <var>index</var>, and <code>true</code>
                       for <var>vocab</var>.</li>
@@ -2817,7 +2817,7 @@
                           <var>index key</var> is not <code>@index</code>,
                           <var>item</var> does not have an <a>entry</a> <code>@index</code>
                           and <var>expanded index</var> is not <code>@none</code>,
-                          set <var>index property values</var> to the concatenation of
+                          initialize <var>index property values</var> to the concatenation of
                           <var>expanded index</var> with any existing values of
                           <var>index key</var> in <var>item</var>.
                           Add the key-value pair (<var>expanded index</var>-<var>index property values</var>) to <var>item</var>.
@@ -2838,7 +2838,7 @@
                           passing <var>active context</var>, <var>index</var>, and <code>true</code>
                           for <var>document relative</var>.</li>
                         <li>Otherwise, if <var>container mapping</var> includes <code>@type</code>
-                          set <var>types</var> to the concatenation of <var>expanded index</var>
+                          initialize <var>types</var> to the concatenation of <var>expanded index</var>
                           with any existing values of <code>@type</code> in <var>item</var>.
                           If <var>expanded index</var> is <code>@none</code>,
                           do not concatenate <var>expanded index</var> to <var>types</var>.
@@ -2908,7 +2908,7 @@
             </li>
             <li class="changed">For each key <var>nesting-key</var> in <var>nests</var>
               <ol>
-                <li>Set <var>nested values</var> to the value of <var>nesting-key</var>
+                <li>Initialize <var>nested values</var> to the value of <var>nesting-key</var>
                   in <var>element</var>, ensuring that it is an <a>array</a>.</li>
                 <li>For each <var>nested value</var> in <var>nested values</var>:
                   <ol>
@@ -3306,7 +3306,7 @@
         <span class="changed">If not passed, the both flags are set to <code>false</code></span>.</p>
 
       <ol>
-        <li class="changed">Set <var>type-scoped context</var> to <var>active context</var>.
+        <li class="changed">Initialize <var>type-scoped context</var> to <var>active context</var>.
           This is used for compacting values that may be relevant to any previous
           <a>type-scoped context</a>.</li>
         <li>If <var>element</var> is a <a>scalar</a>, it is already in its most
@@ -3770,13 +3770,13 @@
                       <var class="changed">nest result</var>, initialize it to an empty <a class="changed">map</a>.
                       Initialize <var>map object</var> to the value of <var>item active property</var>
                       in <var class="changed">nest result</var>.</li>
-                    <li>Set <var>container key</var> to the result of calling the
+                    <li>Initialize <var>container key</var> to the result of calling the
                       <a href="#iri-compaction">IRI Compaction algorithm</a>
                       passing <var>active context</var>, <var>inverse context</var>,
                       either <code>@language</code>, <code>@index</code>, <code>@id</code>, or <code>@type</code>
                       based on the contents of <var>container</var>, as <var>var</var>, and <code>true</code>
                       for <var>vocab</var>.</li>
-                    <li class="changed">Set <var>index key</var> to the value of <a>index mapping</a> in
+                    <li class="changed">Initialize <var>index key</var> to the value of <a>index mapping</a> in
                       the <a>term definition</a> associated with <var>item active property</var> in <var>active context</var>,
                       or <code>@index</code>, if no such value exists.</li>
                     <li>If <var>container</var> includes <code>@language</code> and
@@ -4605,7 +4605,7 @@
               <ol>
                 <li>Create a <a class="changed">map</a> <var>referenced node</var> with a single <a>entry</a> <code>@id</code> whose
                   value is <var>id</var>.</li>
-                <li>Set <var>reverse map</var> to the value of the <code>@reverse</code> <a>entry</a> of
+                <li>Initialize <var>reverse map</var> to the value of the <code>@reverse</code> <a>entry</a> of
                   <var>element</var>.</li>
                 <li>For each key-value pair <var>property</var>-<var>values</var> in <var>reverse map</var>:
                   <ol>
@@ -4664,7 +4664,7 @@
       <li>For each <var>graph name</var> and <var>node map</var> in <var>graph map</var>
         and for each <var>id</var> and <var>node</var> in <var>node map</var>:
         <ol>
-          <li>Set <var>merged node</var> to the value for <var>id</var> in <var>result</var>, initializing it
+          <li>Initialize <var>merged node</var> to the value for <var>id</var> in <var>result</var>, initializing it
             with a new <a>map</a> consisting of a single <a>entry</a> <code>@id</code> whose value is <var>id</var>, if it does not exist.</li>
           <li>For each <var>property</var> and <var>values</var> in <var>node</var>:
             <ol>
@@ -4820,8 +4820,8 @@
             <li>If <var>graph name</var> is
               <span class="changed">not <a>well-formed</a></span>, continue
               with the next <var>graph name</var>-<var>graph</var> pair.</li>
-            <li class="changed">If <var>graph name</var> is <code>@default</code>, set
-              set <var>triples</var> to the value of the <a data-link-for="RdfDataset">defaultGraph</a>
+            <li class="changed">If <var>graph name</var> is <code>@default</code>,
+              initialize <var>triples</var> to the value of the <a data-link-for="RdfDataset">defaultGraph</a>
               attribute of <var>dataset</var>.
               Otherwise, initialize <var>graph</var> as an empty <a>RdfGraph</a>
               and add to <var>dataset</var> using its
@@ -5064,7 +5064,7 @@
             <li>Unless <var>object</var> is <code>null</code>, append a <a>triple</a>
               composed of <var>subject</var>, <code>rdf:first</code>, and <var>object</var>
               to <var>list triples</var>.</li>
-            <li>Set <var>rest</var> as the next entry in <var>bnodes</var>, or if that
+            <li>Initialize <var>rest</var> as the next entry in <var>bnodes</var>, or if that
               does not exist, <code>rdf:nil</code>. Append a
               <a>triple</a> composed of <var>subject</var>,
               <code>rdf:rest</code>, and <var>rest</var> to <var>list triples</var>.</li>
@@ -5149,7 +5149,7 @@
         <li>For each <var>graph</var> in  <var>dataset</var>:
           <ol>
             <li>If <var>graph</var> is the <a>default graph</a>,
-              set <var>name</var> to <code>@default</code>, otherwise to the
+              initialize <var>name</var> to <code>@default</code>, otherwise to the
               <a>graph name</a> associated with <var>graph</var>.</li>
             <li>If <var>graph map</var> has no <var>name</var> <a>entry</a>, create one and set
               its value to an empty <a class="changed">map</a>.</li>
@@ -5190,7 +5190,7 @@
                   and initialize it to an <a>array</a> whose only item is
                   <var>object</var>. Finally, continue to the next
                   <a>triple</a>.</li>
-                <li>Set <var>value</var> to the result of using the
+                <li>Initialize <var>value</var> to the result of using the
                   <a href="#rdf-to-object-conversion">RDF to Object Conversion algorithm</a>,
                   passing <var>object</var>,
                   <span class="changed">{{JsonLdOptions/rdfDirection}}</span>,

--- a/index.html
+++ b/index.html
@@ -1166,8 +1166,10 @@
             </li>
             <li>If <var>context</var> is a <a>string</a>,
               <ol>
-                <li>Set <var>context</var> to the result of resolving <var>value</var> against
-                  the base IRI which is established as specified in
+                <li>Set <var>context</var> to the result of resolving <var>context</var> against
+                  the <a>base IRI</a>
+                  of the document containing the <var>local context</var>
+                  which is established as specified in
                   <a data-cite="RFC3986#section-5.1">section 5.1 Establishing a Base URI</a>
                   of [[RFC3986]]. Only the basic algorithm in
                   <a data-cite="RFC3986#section-5.2">section 5.2</a>

--- a/index.html
+++ b/index.html
@@ -1013,26 +1013,31 @@
       using information provided by the <a>active context</a>. This
       section describes how to produce an <a>active context</a>.</p>
 
-    <p>The <a>active context</a> contains the active
-      <a>term definitions</a> which specify how
-      keys and values have to be interpreted as well as the current <a>base IRI</a>,
-      the <a>vocabulary mapping</a>, the <a>default language</a>,
-      <span class="changed">the <a>default base direction</a>,
-        and an optional <dfn>previous context</dfn>,
-        used when a non-propagated <a>context</a> is defined</span>.
-      Each <a>term definition</a> consists of:</p>
+    <p>The <a>active context</a> consists of:</p>
     <ul>
-      <li>an <dfn>IRI mapping</dfn>,</li>
-      <li>a boolean flag <dfn>reverse property</dfn>,</li>
-       <li>an optional <dfn>type mapping</dfn>,</li>
-       <li>an optional <dfn>language mapping</dfn>,</li>
-      <li class="changed">an optional <dfn>direction mapping</dfn>,</li>
-      <li class="changed">an optional <a>context</a>,</li>
-      <li class="changed">an optional <dfn>nest value</dfn>,</li>
-      <li class="changed">an optional <dfn>prefix flag</dfn>,</li>
-      <li class="changed">an optional <dfn>index mapping</dfn>,</li>
-      <li class="changed">a <dfn>protected</dfn> flag, used to mark this as a protected term,</li>
-      <li>and an optional <dfn>container mapping</dfn>.</li>
+      <li>the active <a>term definitions</a> which specify how
+        keys and values have to be interpreted (<a>array</a> of <a>term definitions</a>),</li>
+      <li>the current <a>base IRI</a> (<a>IRI</a>),</li>
+      <li>an optional <a>vocabulary mapping</a> (<a>IRI</a>),</li>
+      <li>an optional <a>default language</a> (<a>string</a>),</li>
+      <li class="changed">an optional <a>default base direction</a>  (`"ltr"` or `"rtl"`),</li>
+      <li class="changed">and an optional <dfn>previous context</dfn> (<a>context</a>),
+        used when a non-propagated <a>context</a> is defined</span>.</li>
+    </ul>
+
+    <p>Each <a>term definition</a> consists of:</p>
+    <ul>
+      <li>an <dfn>IRI mapping</dfn> (<a>IRI</a>),</li>
+      <li>a flag <dfn>reverse property</dfn> (<a>boolean</a>),</li>
+       <li>an optional <dfn>type mapping</dfn> (<a>IRI</a>),</li>
+       <li>an optional <dfn>language mapping</dfn> (<a>string</a>),</li>
+      <li class="changed">an optional <dfn>direction mapping</dfn> (`"ltr"` or `"rtl"`),</li>
+      <li class="changed">an optional <a>context</a> (<a>context</a>),</li>
+      <li class="changed">an optional <dfn>nest value</dfn> (<a>string</a>),</li>
+      <li class="changed">an optional <dfn>prefix flag</dfn> (<a>boolean</a>),</li>
+      <li class="changed">an optional <dfn>index mapping</dfn> (<a>string</a>),</li>
+      <li class="changed">a <dfn>protected</dfn> flag (<a>boolean</a>),</li>
+      <li>and an optional <dfn>container mapping</dfn> (<a>array</a> of <a>strings</a>).</li>
     </ul>
 
     <p>A <a>term definition</a> can not only be used to map a <a>term</a>

--- a/index.html
+++ b/index.html
@@ -937,8 +937,11 @@
          data-from-rdf
          title="Sample Turtle document">
     <!--
-    <http://me.markus-lanthaler.com/> <http://xmlns.com/foaf/0.1/name> "Markus Lanthaler" .
-    <http://me.markus-lanthaler.com/> <http://xmlns.com/foaf/0.1/homepage> <http://www.markus-lanthaler.com/> .
+    @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+    <http://me.markus-lanthaler.com/>
+      foaf:name "Markus Lanthaler" ;
+      foaf:homepage <http://www.markus-lanthaler.com/> .
     -->
     </pre>
 

--- a/index.html
+++ b/index.html
@@ -1137,7 +1137,8 @@
           <var>active context</var>.</li>
         <li class="changed">If <var>local context</var> is an object containing the member <code>@propagate</code>,
           its value MUST be <a>boolean</a> <code>true</code> or <code>false</code>,
-          set <var>propagate</var> to that value.</li>
+          set <var>propagate</var> to that value.
+          <span class="note">Error handling is performed in <a href="#step-propagate-entry">step 5.11</a>.</span></li>
         <li class="changed">If <var>propagate</var> is <code>false</code>, and <var>result</var>
           does not have a <a>previous context</a>, set <a>previous context</a>
           in <var>result</var> to <var>active context</var>.</li>
@@ -1344,7 +1345,7 @@
                   error has been detected and processing is aborted.</li>
               </ol>
             </li>
-            <li class="changed">If <var>context</var> has an <code>@propagate</code> <a>entry</a>:
+            <li id="step-propagate-entry" class="changed">If <var>context</var> has an <code>@propagate</code> <a>entry</a>:
               <ol>
                 <li>If <a>processing mode</a> is `json-ld-1.0`,
                   an <a data-link-for="JsonLdErrorCode">invalid context entry</a>

--- a/index.html
+++ b/index.html
@@ -579,12 +579,16 @@
     </aside>
 
     <p>The next input example uses one <a>IRI</a> to express a <a>property</a>
-    and an <a>array</a> to encapsulate another, but
+    and a <a>map</a> to encapsulate a value, but
     leaves the rest of the information untouched.</p>
 
     <aside class="example ds-selector-tabs"
            title="Sample JSON-LD document using an IRI instead of a term to express a property">
       <div class="selectors">
+        <button class="selected input" data-selects="compacted">Compacted (Input)</button>
+        <button data-selects="expanded">Expanded (Result)</button>
+        <button data-selects="statements">Statements</button>
+        <button data-selects="turtle">Turtle</button>
         <a class="playground" target="_blank"></a>
       </div>
       <pre class="compacted input selected nohighlight" data-transform="updateExample">
@@ -597,6 +601,41 @@
         "****http://xmlns.com/foaf/0.1/name****": "Markus Lanthaler",
         ****"website"****: ****{ "@id":**** "http://www.markus-lanthaler.com/" ****}****
       }
+      -->
+      </pre>
+      <pre class="expanded result"
+           data-result-for="Sample JSON-LD document using an IRI instead of a term to express a property-compacted"
+           data-transform="updateExample">
+      <!--
+      [{
+        "@id": "http://me.markus-lanthaler.com/",
+        "http://xmlns.com/foaf/0.1/name": [
+          {"@value": "Markus Lanthaler"}
+        ],
+        "http://xmlns.com/foaf/0.1/homepage": [
+          {"@id": "http://www.markus-lanthaler.com/"}
+        ]
+      }]
+      -->
+      </pre>
+      <table class="statements"
+             data-result-for="Sample JSON-LD document using an IRI instead of a term to express a property-expanded">
+        <thead><tr><th>Subject</th><th>Property</th><th>Value</th></tr></thead>
+        <tbody>
+          <tr><td>http://me.markus-lanthaler.com/</td><td>foaf:name</td><td>Markus Lanthaler</td></tr>
+          <tr><td>http://me.markus-lanthaler.com/</td><td>http://xmlns.com/foaf/0.1/homepage</td><td>http://www.markus-lanthaler.com/</td></tr>
+        </tbody>
+      </table>
+      <pre class="turtle"
+           data-content-type="text/turtle"
+           data-result-for="Sample JSON-LD document using an IRI instead of a term to express a property-expanded"
+           data-transform="updateExample"
+           data-to-rdf>
+      <!--
+      @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+      <http://me.markus-lanthaler.com/> foaf:name "Markus Lanthaler";
+        foaf:homepage <http://www.markus-lanthaler.com/> .
       -->
       </pre>
     </aside>
@@ -1022,7 +1061,7 @@
       <li>an optional <a>default language</a> (<a>string</a>),</li>
       <li class="changed">an optional <a>default base direction</a>  (`"ltr"` or `"rtl"`),</li>
       <li class="changed">and an optional <dfn>previous context</dfn> (<a>context</a>),
-        used when a non-propagated <a>context</a> is defined</span>.</li>
+        used when a non-propagated <a>context</a> is defined.</li>
     </ul>
 
     <p>Each <a>term definition</a> consists of:</p>

--- a/index.html
+++ b/index.html
@@ -2487,19 +2487,21 @@
                   <ol>
                     <li>If <var>value</var> is not a <a>string</a>, an
                       <a data-link-for="JsonLdErrorCode">invalid @id value</a>
-                      error has been detected and processing is aborted.</li>
+                      error has been detected and processing is aborted.
+                      <span class="changed">
+                        When the {{JsonLdOptions/frameExpansion}} flag is set, <var>value</var>
+                        may be an empty <a>map</a>, or an <a>array</a> of one
+                        or more <a>strings</a>.</span></li>
                     <li>Otherwise,
                       set <var>expanded value</var> to the result of using the
                       <a href="#iri-expansion">IRI Expansion algorithm</a>,
                       passing <var>active context</var>, <var>value</var>, and <code>true</code>
                       for <var>document relative</var>.
                       <span class="changed">
-                        When the {{JsonLdOptions/frameExpansion}} flag is set, <var>value</var>
-                        may be an empty <a>map</a>, or an <a>array</a> of one
-                        or more <a>strings</a>. <var>expanded value</var> will be
-                        an <a>array</a> of one or more of these, with <a>string</a>
+                        When the {{JsonLdOptions/frameExpansion}} flag is set, <var>expanded value</var> will be
+                        an <a>array</a> of one or more of the values, with <a>string</a>
                         values expanded using the <a
-                        href="#iri-expansion">IRI Expansion Algorithm</a>.</span></li>
+                        href="#iri-expansion">IRI Expansion Algorithm</a> as above.</span></li>
                   </ol>
                 </li>
                 <li>If <var>expanded property</var> is <code>@type</code>:
@@ -2508,7 +2510,24 @@
                       is neither a <a>string</a> nor an <a>array</a> of
                       <a>strings</a>, an
                       <a data-link-for="JsonLdErrorCode">invalid type value</a>
-                      error has been detected and processing is aborted.</li>
+                      error has been detected and processing is aborted.
+                      <span class="changed">
+                        When the {{JsonLdOptions/frameExpansion}} flag is set, <var>value</var>
+                        may also be an empty <a>map</a>, or a <a>default object</a>
+                        where the value of `@default` is restricted to be
+                        an <a>IRI</a>.
+                        All other values mean that <a data-link-for="JsonLdErrorCode">invalid type value</a>
+                        error has been detected and processing is aborted.</span></li>
+                    <li class="changed">If <var>value</var>
+                      is an empty <a>map</a>, set <var>expanded value</var> to <var>value</var>.</li>
+                    <li class="changed">Otherwise, if <var>value</var>
+                      is a <a>default object</a>, set <var>expanded value</var> to
+                      a new <a>default object</a> with the value of `@default` set
+                      to the result of using the
+                      <a href="#iri-expansion">IRI Expansion algorithm</a>, passing
+                      <var class="changed">type-scoped context</var> for <var>active context</var>,
+                      <code>true</code> for <var>vocab</var>,
+                      and <code>true</code> for <var>document relative</var> to expand that value.</li>
                     <li>Otherwise,
                       set <var>expanded value</var> to the result of using the
                       <a href="#iri-expansion">IRI Expansion algorithm</a>, passing
@@ -2519,12 +2538,7 @@
                       <span class="changed">If <var>result</var> already has an entry for `@type`,
                         prepend the value of `@type` in <var>result</var> to <var>expanded value</var>,
                         transforming it into an <a>array</a>, if necessary.</span>
-                      <span class="changed">
-                        When the {{JsonLdOptions/frameExpansion}} flag is set, <var>value</var>
-                        may also be an empty <a>map</a>, or a <a>default object</a>.
-                        For a <a>default object</a>, the value of `@default` is restricted to be
-                        an <a>IRI</a>, which is expanded as above.
-                      </span></li>
+                      </li>
                     <li><span class="changed">If <var>result</var> already has an entry for `@type`,
                       prepend the value of `@type` in <var>result</var> to <var>expanded value</var>,
                       transforming it into an <a>array</a>, if necessary.</span>
@@ -2569,35 +2583,41 @@
                       error has been detected and processing is aborted.</li>
                     <li>Otherwise, if <var>value</var> is not a <a>scalar</a> or <code>null</code>,
                       an <a data-link-for="JsonLdErrorCode">invalid value object value</a>
-                      error has been detected and processing is aborted.</li>
-                    <li>Otherwise, set <var>expanded value</var> to <var>value</var>.</li>
+                      error has been detected and processing is aborted.
+                      <span class="changed">When the {{JsonLdOptions/frameExpansion}} flag is set, <var>value</var>
+                      may also be an empty <a>map</a> or an array of
+                      <a>scalar</a> values.</span></li>
+                    <li>Otherwise, set <var>expanded value</var> to <var>value</var>.
+                      <span class="changed">When the {{JsonLdOptions/frameExpansion}} flag is set,
+                      <var>expanded value</var> will be an
+                      <a>array</a> of one or more <a>string</a> values
+                      or an <a>array</a> containing an empty <a>map</a>.</span>
+                    </li>
                     <li>If <var>expanded value</var>
                       is <code>null</code>, set the <code>@value</code>
                       <a>entry</a> of <var>result</var> to <code>null</code> and continue with the
                       next <var>key</var> from <var>element</var>. Null values need to be preserved
                       in this case as the meaning of an <code>@type</code> <a>entry</a> depends
                       on the existence of an <code>@value</code> <a>entry</a>.</li>
-                    <li class="changed">
-                      When the {{JsonLdOptions/frameExpansion}} flag is set, <var>value</var>
-                      may also be an empty <a>map</a> or an array of
-                      <a>scalar</a> values. <var>expanded value</var> will be <a>null</a>, or an
-                      <a>array</a> of one or more <a>scalar</a> values.</li>
                   </ol>
                 </li>
                 <li>If <var>expanded property</var> is <code>@language</code>:
                   <ol>
                     <li>If <var>value</var> is not a <a>string</a>, an
                       <a data-link-for="JsonLdErrorCode">invalid language-tagged string</a>
-                      error has been detected and processing is aborted.</li>
+                      error has been detected and processing is aborted.
+                      <span class="changed">When the {{JsonLdOptions/frameExpansion}} flag is set, <var>value</var>
+                        may also be an empty <a>map</a> or an array of zero or
+                        <a>strings</a></span>.</li>
                     <li><span class="changed">
                       Otherwise, set <var>expanded value</var> to <var>value</var>.
                       If <var>value</var> is not <a>well-formed</a> according to
                       <a data-cite="BCP47#section-2.2.9">section 2.2.9</a> of [[BCP47]],
                       processors SHOULD issue a warning.
-                      When the {{JsonLdOptions/frameExpansion}} flag is set, <var>value</var>
-                      may also be an empty <a>map</a> or an array of zero or
-                      <a>strings</a>. <var>expanded value</var> will be an
-                      <a>array</a> of one or more <a>string</a> values.</span>
+                      When the {{JsonLdOptions/frameExpansion}} flag is set,
+                       <var>expanded value</var> will be an
+                      <a>array</a> of one or more <a>string</a> values
+                      or an <a>array</a> containing an empty <a>map</a>.</span>
                       <div class="changed note">Processors MAY normalize <a>language tags</a> to lower case.</div>
                       </li>
                     </ol>
@@ -2608,12 +2628,15 @@
                       continue with the next <var>key</var> from <var>element</var>.</li>
                     <li>If <var>value</var> is neither `"ltr"` nor `"rtl"`, an
                       <a data-link-for="JsonLdErrorCode">invalid base direction</a>
-                      error has been detected and processing is aborted.</li>
-                    <li>Otherwise, set <var>expanded value</var> to <var>value</var>.</li>
-                    <li>When the {{JsonLdOptions/frameExpansion}} flag is set, <var>value</var>
+                      error has been detected and processing is aborted.
+                      When the {{JsonLdOptions/frameExpansion}} flag is set, <var>value</var>
                       may also be an empty <a>map</a> or an array of zero or
-                      <a>strings</a>. <var>expanded value</var> will be an
-                      <a>array</a> of one or more <a>string</a> values.</li>
+                      <a>strings</a>.</li>
+                    <li>Otherwise, set <var>expanded value</var> to <var>value</var>.
+                      When the {{JsonLdOptions/frameExpansion}} flag is set,
+                      <var>expanded value</var> will be an
+                      <a>array</a> of one or more <a>string</a> values
+                      or an <a>array</a> containing an empty <a>map</a>.</li>
                   </ol>
                 </li>
                 <li>If <var>expanded property</var> is <code>@index</code>:

--- a/index.html
+++ b/index.html
@@ -808,9 +808,9 @@
       <dfn data-lt="flattened">flattening</dfn> goes a step further to ensure that the shape of the data
       is deterministic. In expanded documents, the <a>properties</a> of a single
       <a>node</a> may be spread across a number of different
-      <a class="changed">maps</a>. By flattening a
+      <a class="changed">node objects</a>. By flattening a
       document, all <a>properties</a> of a <a>node</a> are collected in a single
-      <a class="changed">map</a> and all <a>blank nodes</a>
+      <a class="changed">node object</a> and all <a>blank nodes</a>
       are labeled with a <a>blank node identifier</a>. This may drastically
       simplify the code required to process JSON-LD data in certain applications.</p>
 
@@ -874,7 +874,7 @@
       where the algorithm's use of <a>maps</a> are replaced with <a>JSON objects</a>.</p>
 
     <p>Note how in the output above all <a>properties</a> of a <a>node</a> are collected in a
-      single <a class="changed">map</a> and how the <a>blank node</a> representing
+      single <a class="changed">node object</a> and how the <a>blank node</a> representing
       &quot;Dave Longley&quot; has been assigned the <a>blank node identifier</a>
       <code>_:b0</code>.</p>
 

--- a/index.html
+++ b/index.html
@@ -1587,7 +1587,9 @@
               anywhere but as the first or last character of <var>term</var>,
               or if it contains a slash (`/`) anywhere,
               and for either case, the result of expanding <var>term</var>
-              using the <a href="#iri-expansion">IRI Expansion algorithm</a>
+              using the <a href="#iri-expansion">IRI Expansion algorithm</a>, passing
+              <var>active context</var>, <var>term</var> for <var>value</var>, <code>true</code> for <var>vocab</var>,
+              <var>local context</var>, and <var>defined</var>,
               is not the same as the <a>IRI mapping</a> of <var>definition</var>,
               an <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
               error has been detected and processing is aborted.</li>

--- a/index.html
+++ b/index.html
@@ -1486,9 +1486,11 @@
         <li>Create a new <a>term definition</a>, <var>definition</var>.</li>
         <li class="changed">If the <code>@protected</code> entry in <var>value</var>
           is <code>true</code> set the <a>protected</a> in <var>definition</var> to true.
+          If the value of `@protected` is not a <a>boolean</a>,
+          an <a data-link-for="JsonLdErrorCode">invalid @protected value</a> error has been detected and processing is aborted.
           If <a>processing mode</a> is `json-ld-1.0`,
           an <a data-link-for="JsonLdErrorCode">invalid term definition</a>
-          has been detected and processing is aborted. </li>
+          has been detected and processing is aborted.</li>
         <li class="changed">Otherwise, if there is no <code>@protected</code> entry in <var>value</var>
           and the <var>protected</var> parameter is <code>true</code>,
           set the <a>protected</a> in <var>definition</var> to true.</li>
@@ -6453,6 +6455,7 @@
             "invalid @nest value",
             "invalid @prefix value",
             "invalid @propagate value",
+            "invalid @protected value",
             "invalid @reverse value",
             "invalid @import value",
             "invalid @version value",
@@ -6517,6 +6520,8 @@
         <dd class="changed">An invalid value for <code>@prefix</code> has been found.</dd>
         <dt class="changed"><dfn>invalid @propagate value</dfn></dt>
         <dd class="changed">An invalid value for <code>@propagate</code> has been found.</dd>
+        <dt class="changed">invalid @protected value</dt>
+        <dd class="changed">An invalid value for `@protected` has been found.</dd>
         <dt><dfn>invalid @reverse value</dfn></dt>
         <dd>An invalid value for an <code>@reverse</code> <a>entry</a> has been detected,
           i.e., the value was not a <a class="changed">map</a>.</dd>

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -1360,7 +1360,7 @@
     }, {
       "@id": "#te019",
       "@type": [ "jld:NegativeEvaluationTest", "jld:ExpandTest" ],
-      "name": "Invalid keyword alias",
+      "name": "Invalid keyword alias (@context)",
       "purpose": "Verifies that an exception is raised on expansion when a invalid keyword alias is found",
       "input": "expand/e019-in.jsonld",
       "expectErrorCode": "invalid keyword alias"
@@ -1584,6 +1584,13 @@
       "purpose": "Verifies that an exception is raised in Expansion when an invalid IRI is used for @reverse.",
       "input": "expand/e050-in.jsonld",
       "expectErrorCode": "invalid IRI mapping"
+    }, {
+      "@id": "#te051",
+      "@type": [ "jld:NegativeEvaluationTest", "jld:ExpandTest" ],
+      "name": "Invalid keyword alias (@base)",
+      "purpose": "Verifies that an exception is raised on expansion when a invalid keyword alias is found",
+      "input": "expand/e051-in.jsonld",
+      "expectErrorCode": "invalid keyword alias"
     }, {
       "@id": "#tec01",
       "@type": [ "jld:NegativeEvaluationTest", "jld:ExpandTest" ],


### PR DESCRIPTION
* Type entries in a term definition and describe the properties of the active context.
* Add note to step on error handling for `@propagate`.
* Change _value_ to _context_ in context processing, and clarify that the base IRI used for resolving relative IRIs is that of the document containing the _local context_.
* Describe and use **invalid `@protected` value**.
* Be more explicit about parameters passed to IRI expansion.

Fixes #206.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/208.html" title="Last updated on Nov 11, 2019, 11:58 PM UTC (45f27b5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/208/c6147ce...45f27b5.html" title="Last updated on Nov 11, 2019, 11:58 PM UTC (45f27b5)">Diff</a>