### PR TITLE
Update to make terms that have the form of a keyword errors.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1506,8 +1506,8 @@
           been detected and processing is aborted.</li>
         <li><span class="changed">Otherwise</span>, since <a>keywords</a> cannot be overridden,
           <var>term</var> MUST NOT be a <a>keyword</a>,
-          or have the form of a keyword
-          (i.e., it matches the ABNF rule `"@"1*ALPHA` from [[RFC5234]]),
+          or have the form of a <a>keyword</a>
+           (i.e., match the ABNF rule `"@"1*ALPHA` from [[RFC5234]]),
           and a
           <a data-link-for="JsonLdErrorCode">keyword redefinition</a>
           error has been detected and processing is aborted.</li>

--- a/index.html
+++ b/index.html
@@ -1505,12 +1505,12 @@
           <a data-link-for="JsonLdErrorCode">keyword redefinition</a> error has
           been detected and processing is aborted.</li>
         <li><span class="changed">Otherwise</span>, since <a>keywords</a> cannot be overridden,
-          <var>term</var> MUST NOT be a <a>keyword</a> and a
-          <a data-link-for="JsonLdErrorCode">keyword redefinition</a>
-          error has been detected and processing is aborted.
-          If <var>term</var> has the form of a keyword
+          <var>term</var> MUST NOT be a <a>keyword</a>,
+          or have the form of a keyword
           (i.e., it matches the ABNF rule `"@"1*ALPHA` from [[RFC5234]]),
-          return; processors SHOULD generate a warning.</li>
+          and a
+          <a data-link-for="JsonLdErrorCode">keyword redefinition</a>
+          error has been detected and processing is aborted.</li>
         <li class="changed">Initialize <var>previous definition</var> to any existing
           <a>term definition</a> for <var>term</var> in <var>active context</var>,
           removing that <a>term definition</a> from <var>active context</var>.</li>
@@ -6867,7 +6867,8 @@
     <li>The <a>processing mode</a> is now implicitly `json-ld-1.1`, unless set
       explicitly to `json-ld-1.0`.</li>
     <li>Improve notation using <a>IRI</a>, <a>IRI reference</a>, and <a>relative IRI reference</a>.</li>
-    <li>Ignore terms and IRIs that have the form of a keyword (`"@"1*ALPHA`).</li>
+    <li>Ignore IRIs that have the form of a keyword (`"@"1*ALPHA`).</li>
+    <li>Error on terms that have the form of a keyword (`"@"1*ALPHA`).</li>
   </ul>
 </section>
 

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -200,6 +200,13 @@ Test t0005 do not expand aliased @id/@type
 <dd>
 <a href='expand/0005-out.jsonld'>expand/0005-out.jsonld</a>
 </dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.0</dd>
+</dl>
+</dd>
 </dl>
 </dd>
 <dt id='t0006'>
@@ -2877,7 +2884,7 @@ Test t0118 Expanding a value staring with a colon does not treat that value as a
 </dl>
 </dd>
 <dt id='t0119'>
-Test t0119 Ignore some terms with @, allow others.
+Test t0119 Allow some terms with @.
 </dt>
 <dd>
 <dl class='entry'>
@@ -4482,7 +4489,7 @@ invalid IRI mapping
 </dl>
 </dd>
 <dt id='te019'>
-Test te019 Invalid keyword alias
+Test te019 Invalid keyword alias (@context)
 </dt>
 <dd>
 <dl class='entry'>
@@ -5203,6 +5210,34 @@ Test te050 Invalid reverse id
 <dt>expect</dt>
 <dd>
 invalid IRI mapping
+</dd>
+</dl>
+</dd>
+<dt id='te051'>
+Test te051 Error if terms that aren't, but look like keywords are used.
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#te051</dd>
+<dt>Type</dt>
+<dd>jld:NegativeEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>Terms MUST NOT have the form of a keyword.</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/e051-in.jsonld'>expand/e051-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+keyword redefinition
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
 </dd>
 </dl>
 </dd>
@@ -8547,23 +8582,23 @@ invalid term definition
 </dl>
 </dd>
 <dt id='tpr34'>
-Test tpr34 Ignores a non-keyword term starting with '@'
+Test tpr34 Errors on a non-keyword term starting with '@'
 </dt>
 <dd>
 <dl class='entry'>
 <dt>id</dt>
 <dd>#tpr34</dd>
 <dt>Type</dt>
-<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+<dd>jld:NegativeEvaluationTest, jld:ExpandTest</dd>
 <dt>Purpose</dt>
-<dd>Terms in the form of a keyword, which are not keywords, are ignored.</dd>
+<dd>Terms in the form of a keyword, which are not keywords, are errors.</dd>
 <dt>input</dt>
 <dd>
 <a href='expand/pr34-in.jsonld'>expand/pr34-in.jsonld</a>
 </dd>
 <dt>expect</dt>
 <dd>
-<a href='expand/pr34-out.jsonld'>expand/pr34-out.jsonld</a>
+keyword redefinition
 </dd>
 <dt>Options</dt>
 <dd>
@@ -8575,23 +8610,23 @@ Test tpr34 Ignores a non-keyword term starting with '@'
 </dl>
 </dd>
 <dt id='tpr35'>
-Test tpr35 Ignores a non-keyword term starting with '@' (with @vocab)
+Test tpr35 Errors on a non-keyword term starting with '@' (with @vocab)
 </dt>
 <dd>
 <dl class='entry'>
 <dt>id</dt>
 <dd>#tpr35</dd>
 <dt>Type</dt>
-<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+<dd>jld:NegativeEvaluationTest, jld:ExpandTest</dd>
 <dt>Purpose</dt>
-<dd>Terms in the form of a keyword, which are not keywords, are ignored.</dd>
+<dd>Terms in the form of a keyword, which are not keywords, are errors.</dd>
 <dt>input</dt>
 <dd>
 <a href='expand/pr35-in.jsonld'>expand/pr35-in.jsonld</a>
 </dd>
 <dt>expect</dt>
 <dd>
-<a href='expand/pr35-out.jsonld'>expand/pr35-out.jsonld</a>
+keyword redefinition
 </dd>
 <dt>Options</dt>
 <dd>

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -40,7 +40,8 @@
       "name": "do not expand aliased @id/@type",
       "purpose": "If a keyword is aliased, it is not used when expanding",
       "input": "expand/0005-in.jsonld",
-      "expect": "expand/0005-out.jsonld"
+      "expect": "expand/0005-out.jsonld",
+      "option": {"specVersion": "json-ld-1.0"}
     }, {
       "@id": "#t0006",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -887,7 +888,7 @@
     }, {
       "@id": "#t0119",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "Ignore some terms with @, allow others.",
+      "name": "Allow some terms with @.",
       "purpose": "Processors SHOULD generate a warning and MUST ignore terms having the form of a keyword.",
       "input": "expand/0119-in.jsonld",
       "expect": "expand/0119-out.jsonld",
@@ -1586,11 +1587,12 @@
       "expectErrorCode": "invalid IRI mapping"
     }, {
       "@id": "#te051",
-      "@type": [ "jld:NegativeEvaluationTest", "jld:ExpandTest" ],
-      "name": "Invalid keyword alias (@base)",
-      "purpose": "Verifies that an exception is raised on expansion when a invalid keyword alias is found",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "Error if terms that aren't, but look like keywords are used.",
+      "purpose": "Terms MUST NOT have the form of a keyword.",
       "input": "expand/e051-in.jsonld",
-      "expectErrorCode": "invalid keyword alias"
+      "expectErrorCode": "keyword redefinition",
+      "option": {"specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tec01",
       "@type": [ "jld:NegativeEvaluationTest", "jld:ExpandTest" ],
@@ -2545,20 +2547,20 @@
       "expectErrorCode": "invalid term definition"
     }, {
       "@id": "#tpr34",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "Ignores a non-keyword term starting with '@'",
-      "purpose": "Terms in the form of a keyword, which are not keywords, are ignored.",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "Errors on a non-keyword term starting with '@'",
+      "purpose": "Terms in the form of a keyword, which are not keywords, are errors.",
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr34-in.jsonld",
-      "expect": "expand/pr34-out.jsonld"
+      "expectErrorCode": "keyword redefinition"
     }, {
       "@id": "#tpr35",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "Ignores a non-keyword term starting with '@' (with @vocab)",
-      "purpose": "Terms in the form of a keyword, which are not keywords, are ignored.",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "Errors on a non-keyword term starting with '@' (with @vocab)",
+      "purpose": "Terms in the form of a keyword, which are not keywords, are errors.",
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr35-in.jsonld",
-      "expect": "expand/pr35-out.jsonld"
+      "expectErrorCode": "keyword redefinition"
     }, {
       "@id": "#tpr36",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],

--- a/tests/expand/0119-in.jsonld
+++ b/tests/expand/0119-in.jsonld
@@ -1,8 +1,7 @@
 {
   "@context": {
     "@": "http://example.org/vocab/at",
-    "@foo.bar": "http://example.org/vocab/foo.bar",
-    "@ignoreMe": "http://example.org/vocab/ignoreMe"
+    "@foo.bar": "http://example.org/vocab/foo.bar"
   },
   "@": "allowed",
   "@foo.bar": "allowed",

--- a/tests/expand/e051-in.jsonld
+++ b/tests/expand/e051-in.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@iri": "http://example/cant-be-used-as-a-term"
+  },
+  "@iri": "http://example.org/iri"
+}

--- a/tests/expand/pr34-out.jsonld
+++ b/tests/expand/pr34-out.jsonld
@@ -1,3 +1,0 @@
-[{
-  "@type": ["http://example.com/IgnoreTest"]
-}]

--- a/tests/expand/pr35-out.jsonld
+++ b/tests/expand/pr35-out.jsonld
@@ -1,3 +1,0 @@
-[{
-  "@type": ["http://example.com/IgnoreTest"]
-}]

--- a/tests/flatten-manifest.html
+++ b/tests/flatten-manifest.html
@@ -200,6 +200,13 @@ Test t0005 do not expand aliased @id/@type
 <dd>
 <a href='flatten/0005-out.jsonld'>flatten/0005-out.jsonld</a>
 </dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.0</dd>
+</dl>
+</dd>
 </dl>
 </dd>
 <dt id='t0006'>

--- a/tests/flatten-manifest.jsonld
+++ b/tests/flatten-manifest.jsonld
@@ -40,7 +40,8 @@
       "name": "do not expand aliased @id/@type",
       "purpose": "If a keyword is aliased, it is not used when flattening",
       "input": "flatten/0005-in.jsonld",
-      "expect": "flatten/0005-out.jsonld"
+      "expect": "flatten/0005-out.jsonld",
+      "option": {"specVersion": "json-ld-1.0"}
     }, {
       "@id": "#t0006",
       "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],

--- a/tests/toRdf-manifest.html
+++ b/tests/toRdf-manifest.html
@@ -1703,6 +1703,13 @@ Test te005 do not expand aliased @id/@type
 <dd>
 <a href='toRdf/e005-out.nq'>toRdf/e005-out.nq</a>
 </dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.0</dd>
+</dl>
+</dd>
 </dl>
 </dd>
 <dt id='te006'>
@@ -2693,23 +2700,30 @@ invalid IRI mapping
 </dl>
 </dd>
 <dt id='te051'>
-Test te051 Expansion of keyword aliases in term definitions
+Test te051 Error if terms that aren't, but look like keywords are used.
 </dt>
 <dd>
 <dl class='entry'>
 <dt>id</dt>
 <dd>#te051</dd>
 <dt>Type</dt>
-<dd>jld:PositiveEvaluationTest, jld:ToRDFTest</dd>
+<dd>jld:NegativeEvaluationTest, jld:ToRDFTest</dd>
 <dt>Purpose</dt>
-<dd>RDF version of expand-0051</dd>
+<dd>Terms MUST NOT have the form of a keyword.</dd>
 <dt>input</dt>
 <dd>
-<a href='toRdf/e051-in.jsonld'>toRdf/e051-in.jsonld</a>
+<a href='expand/e051-in.jsonld'>expand/e051-in.jsonld</a>
 </dd>
 <dt>expect</dt>
 <dd>
-<a href='toRdf/e051-out.nq'>toRdf/e051-out.nq</a>
+keyword redefinition
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
 </dd>
 </dl>
 </dd>
@@ -4410,7 +4424,7 @@ Test te118 Expanding a value staring with a colon does not treat that value as a
 </dl>
 </dd>
 <dt id='te119'>
-Test te119 Ignore some terms with @, allow others.
+Test te119 Allow some terms with @.
 </dt>
 <dd>
 <dl class='entry'>
@@ -7606,23 +7620,23 @@ invalid term definition
 </dl>
 </dd>
 <dt id='tpr34'>
-Test tpr34 Ignores a non-keyword term starting with '@'
+Test tpr34 Errors on a non-keyword term starting with '@'
 </dt>
 <dd>
 <dl class='entry'>
 <dt>id</dt>
 <dd>#tpr34</dd>
 <dt>Type</dt>
-<dd>jld:PositiveEvaluationTest, jld:ToRDFTest</dd>
+<dd>jld:NegativeEvaluationTest, jld:ToRDFTest</dd>
 <dt>Purpose</dt>
-<dd>Terms in the form of a keyword, which are not keywords, are ignored.</dd>
+<dd>Terms in the form of a keyword, which are not keywords, are errors.</dd>
 <dt>input</dt>
 <dd>
 <a href='toRdf/pr34-in.jsonld'>toRdf/pr34-in.jsonld</a>
 </dd>
 <dt>expect</dt>
 <dd>
-<a href='toRdf/pr34-out.nq'>toRdf/pr34-out.nq</a>
+keyword redefinition
 </dd>
 <dt>Options</dt>
 <dd>
@@ -7634,23 +7648,23 @@ Test tpr34 Ignores a non-keyword term starting with '@'
 </dl>
 </dd>
 <dt id='tpr35'>
-Test tpr35 Ignores a non-keyword term starting with '@' (with @vocab)
+Test tpr35 Errors on a non-keyword term starting with '@' (with @vocab)
 </dt>
 <dd>
 <dl class='entry'>
 <dt>id</dt>
 <dd>#tpr35</dd>
 <dt>Type</dt>
-<dd>jld:PositiveEvaluationTest, jld:ToRDFTest</dd>
+<dd>jld:NegativeEvaluationTest, jld:ToRDFTest</dd>
 <dt>Purpose</dt>
-<dd>Terms in the form of a keyword, which are not keywords, are ignored.</dd>
+<dd>Terms in the form of a keyword, which are not keywords, are errors.</dd>
 <dt>input</dt>
 <dd>
 <a href='toRdf/pr35-in.jsonld'>toRdf/pr35-in.jsonld</a>
 </dd>
 <dt>expect</dt>
 <dd>
-<a href='toRdf/pr35-out.nq'>toRdf/pr35-out.nq</a>
+keyword redefinition
 </dd>
 <dt>Options</dt>
 <dd>

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -525,7 +525,8 @@
       "name": "do not expand aliased @id/@type",
       "purpose": "RDF version of expand-0005",
       "input": "toRdf/e005-in.jsonld",
-      "expect": "toRdf/e005-out.nq"
+      "expect": "toRdf/e005-out.nq",
+      "option": {"specVersion": "json-ld-1.0"}
     }, {
       "@id": "#te006",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -853,11 +854,12 @@
       "expectErrorCode": "invalid IRI mapping"
     }, {
       "@id": "#te051",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
-      "name": "Expansion of keyword aliases in term definitions",
-      "purpose": "RDF version of expand-0051",
-      "input": "toRdf/e051-in.jsonld",
-      "expect": "toRdf/e051-out.nq"
+      "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
+      "name": "Error if terms that aren't, but look like keywords are used.",
+      "purpose": "Terms MUST NOT have the form of a keyword.",
+      "input": "expand/e051-in.jsonld",
+      "expectErrorCode": "keyword redefinition",
+      "option": {"specVersion": "json-ld-1.1"}
     }, {
       "@id": "#te052",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
@@ -1384,7 +1386,7 @@
     }, {
       "@id": "#te119",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
-      "name": "Ignore some terms with @, allow others.",
+      "name": "Allow some terms with @.",
       "purpose": "Processors SHOULD generate a warning and MUST ignore terms having the form of a keyword.",
       "input": "toRdf/e119-in.jsonld",
       "expect": "toRdf/e119-out.nq",
@@ -2295,20 +2297,20 @@
       "expectErrorCode": "invalid term definition"
     }, {
       "@id": "#tpr34",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
-      "name": "Ignores a non-keyword term starting with '@'",
-      "purpose": "Terms in the form of a keyword, which are not keywords, are ignored.",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
+      "name": "Errors on a non-keyword term starting with '@'",
+      "purpose": "Terms in the form of a keyword, which are not keywords, are errors.",
       "option": {"specVersion": "json-ld-1.1"},
       "input": "toRdf/pr34-in.jsonld",
-      "expect": "toRdf/pr34-out.nq"
+      "expectErrorCode": "keyword redefinition"
     }, {
       "@id": "#tpr35",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
-      "name": "Ignores a non-keyword term starting with '@' (with @vocab)",
-      "purpose": "Terms in the form of a keyword, which are not keywords, are ignored.",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
+      "name": "Errors on a non-keyword term starting with '@' (with @vocab)",
+      "purpose": "Terms in the form of a keyword, which are not keywords, are errors.",
       "option": {"specVersion": "json-ld-1.1"},
       "input": "toRdf/pr35-in.jsonld",
-      "expect": "toRdf/pr35-out.nq"
+      "expectErrorCode": "keyword redefinition"
     }, {
       "@id": "#tpr36",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],

--- a/tests/toRdf/e119-in.jsonld
+++ b/tests/toRdf/e119-in.jsonld
@@ -1,8 +1,7 @@
 {
   "@context": {
     "@": "http://example.org/vocab/at",
-    "@foo.bar": "http://example.org/vocab/foo.bar",
-    "@ignoreMe": "http://example.org/vocab/ignoreMe"
+    "@foo.bar": "http://example.org/vocab/foo.bar"
   },
   "@": "allowed",
   "@foo.bar": "allowed",

--- a/tests/toRdf/pr34-out.nq
+++ b/tests/toRdf/pr34-out.nq
@@ -1,1 +1,0 @@
-_:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/IgnoreTest> .

--- a/tests/toRdf/pr35-out.nq
+++ b/tests/toRdf/pr35-out.nq
@@ -1,1 +1,0 @@
-_:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/IgnoreTest> .


### PR DESCRIPTION
If we decide we want to make keyword-like terms an error, this PR does that for the API.

For w3c/json-ld-syntax#297.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/209.html" title="Last updated on Nov 14, 2019, 3:20 PM UTC (6d80258)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/209/15edb03...6d80258.html" title="Last updated on Nov 14, 2019, 3:20 PM UTC (6d80258)">Diff</a>