### PR TITLE
Kasei updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -2483,8 +2483,6 @@
                   (unless <a>processing mode</a> is `json-ld-1.0`)</span>,
                   a <a data-link-for="JsonLdErrorCode">colliding keywords</a>
                   error has been detected and processing is aborted.</li>
-                <li class="changed">If <var>result</var> already has an <var>expanded property</var> <a>entry</a>,
-                  for `@included` or `@type`.</li>
                 <li>If <var>expanded property</var> is <code>@id</code>:
                   <ol>
                     <li>If <var>value</var> is not a <a>string</a>, an

--- a/index.html
+++ b/index.html
@@ -2375,7 +2375,7 @@
         <li class="changed">If <var>active property</var> is <code>@default</code>,
           initialize the {{JsonLdOptions/frameExpansion}} flag to <code>false</code>.</li>
         <li class="changed">If <var>active property</var> has a <a>term definition</a> in <var>active context</var>
-          with a <a>local context</a>, initialize <var>property scoped context</var> to that <a>local context</a>.</li>
+          with a <a>local context</a>, initialize <var>property-scoped context</var> to that <a>local context</a>.</li>
         <li>If <var>element</var> is a <a>scalar</a>,
           <ol>
             <li>If <var>active property</var> is <code>null</code> or <code>@graph</code>,

--- a/index.html
+++ b/index.html
@@ -2458,7 +2458,7 @@
         <li>Initialize two empty <a class="changed">maps</a>, <var>result</var>
           <span class="changed">and <var>nests</var>.
             Initialize <var>input type</var> to the last value of the first <a>entry</a> in <var>element</var>
-            expanding to <code>@type</code>, ordering <a>entries</a> lexicographically by key</span>.
+            expanding to <code>@type</code> (if any), ordering <a>entries</a> lexicographically by key</span>.
         </li>
         <li id="alg-expand-each-key-value">
           For each <var>key</var> and <var>value</var> in <var>element</var>,


### PR DESCRIPTION
* Remove pointless step in expansion algorithm. Fixes #213.
* Add missing hyphen to "property-scoped context" variable in expansion algorithm. Fixes #214. 
* Clarify when input does not have `@type` when setting "input type" variable. Fixes #215.

cc/ @kasei


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/217.html" title="Last updated on Nov 20, 2019, 10:08 PM UTC (a3a664e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/217/0090f01...a3a664e.html" title="Last updated on Nov 20, 2019, 10:08 PM UTC (a3a664e)">Diff</a>