### PR TITLE
Add note on `@version` being `1.1` not being semantic versioning.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1266,8 +1266,9 @@
                   create a value that would cause a JSON-LD 1.0 processor to stop processing.
                   Although it is clearly meant to be related to JSON-LD 1.1, it does not
                   otherwise adhere to the requirements for <a href="https://semver.org/">Semantic Versioning</a>.
-                  Implementations may require special consideration when comparing
-                  the values of <a>numbers</a> with a non-zero fractional part.</div>
+                  Implementations may require
+                  <a href="https://en.wikipedia.org/wiki/Floating-point_arithmetic#Minimizing_the_effect_of_accuracy_problems">special consideration</a>
+                  when comparing the values of <a>numbers</a> with a non-zero fractional part.</div>
                 </li>
                 <li>If <a>processing mode</a>
                   is set to `json-ld-1.0`,

--- a/index.html
+++ b/index.html
@@ -1261,7 +1261,14 @@
               <ol>
                 <li>If the associated value is not <code>1.1</code>,
                   an <a data-link-for="JsonLdErrorCode">invalid @version value</a>
-                  has been detected, and processing is aborted.</li>
+                  has been detected, and processing is aborted.
+                <div class="note">The use of `1.1` for the value of `@version` is used to
+                  create a value that would cause a JSON-LD 1.0 processor to stop processing.
+                  Although it is clearly meant to be related to JSON-LD 1.1, it does not
+                  otherwise adhere to the requirements for <a href="https://semver.org/">Semantic Versioning</a>.
+                  Implementations may require special consideration when comparing
+                  the values of <a>numbers</a> with a non-zero fractional part.</div>
+                </li>
                 <li>If <a>processing mode</a>
                   is set to `json-ld-1.0`,
                   a <a data-link-for="JsonLdErrorCode">processing mode conflict</a>


### PR DESCRIPTION
Also describes considerations for implementations to compare values.

For w3c/json-ld-syntax#296.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/218.html" title="Last updated on Nov 22, 2019, 7:13 PM UTC (d5c404b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/218/5622471...d5c404b.html" title="Last updated on Nov 22, 2019, 7:13 PM UTC (d5c404b)">Diff</a>