### PR TITLE
@context resolution respects relative URLs

### DIFF
--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -1157,6 +1157,14 @@
       "expectErrorCode": "invalid @propagate value",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tc031",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "@context resolutions respects relative URLs.",
+      "purpose": "URL resolution follows RFC3986",
+      "input": "expand/c031-in.jsonld",
+      "expect": "expand/c031-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tdi01",
       "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Expand string using default and term directions",

--- a/tests/expand/c031-b.jsonld
+++ b/tests/expand/c031-b.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "inner": {
+      "@id": "http://a.example/in"
+    }
+  }
+}

--- a/tests/expand/c031-in.jsonld
+++ b/tests/expand/c031-in.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": "subdir/c031-a.jsonld",
+  "outer": {
+    "inner": "ab"
+  }
+}

--- a/tests/expand/c031-out.jsonld
+++ b/tests/expand/c031-out.jsonld
@@ -1,0 +1,9 @@
+[
+  {
+    "http://a.example/out": [{
+      "http://a.example/in": [{
+        "@value":"ab"
+      }]
+    }]
+  }
+]

--- a/tests/expand/subdir/c031-a.jsonld
+++ b/tests/expand/subdir/c031-a.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "outer": {
+      "@id": "http://a.example/out",
+      "@context": "../c031-b.jsonld"
+    }
+  }
+}


### PR DESCRIPTION
This tests that a relative @context URL is relative to the document that referenced it.

Test `c031` includes three input files in this tree:

tests/expand/c031-in.jsonld
└┬ tests/expand/subdir/c031-a.jsonld referenced as `subdir/c031-a.jsonld`
  └─ tests/expand/c031-b.jsonld referenced as `../c031-b.jsonld`

This addresses  w3c/json-ld-syntax#311