### PR TITLE
chore: fix link to commits being wrong

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,8 +34,10 @@
       testSuiteURI:         "https://w3c.github.io/json-ld-api/tests/",
       implementationReportURI:"https://w3c.github.io/json-ld-api/reports/",
       crEnd:                "2020-02-17",
-      github:               "https://github.com/w3c/json-ld-api/",
-      issueBase:            "https://github.com/w3c/json-ld-api/issues/",
+      github:               {
+        repoURL: "https://github.com/w3c/json-ld-api",
+        branch: "master",
+      },
 
       // if you want to have extra CSS, append them to this list
       // it is recommended that the respec.css stylesheet be kept


### PR DESCRIPTION
As a fix for https://github.com/w3c/respec/issues/2582

Also, removed `issueBase`, as it's is automatically generated from `github` configuration option.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sidvishnoi/json-ld-api/pull/229.html" title="Last updated on Nov 25, 2019, 11:35 AM UTC (fcf57b3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/229/44bb9c0...sidvishnoi:fcf57b3.html" title="Last updated on Nov 25, 2019, 11:35 AM UTC (fcf57b3)">Diff</a>