### PR TITLE
Add missing mention of `@json` in create term definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1564,7 +1564,7 @@
               an <a data-link-for="JsonLdErrorCode">invalid type mapping</a>
               error has been detected and processing is aborted.</li>
             <li>Otherwise, if the expanded <var>type</var> is
-              neither <code>@id</code>, nor <code>@vocab</code>,
+              neither <code>@id</code>, nor <code>@vocab</code>, nor <code>@json</code>,
               nor an <a>IRI</a>,
               an <a data-link-for="JsonLdErrorCode">invalid type mapping</a>
               error has been detected and processing is aborted.</li>


### PR DESCRIPTION
This came up for me when working on JSON literal support in jsonld-java: https://github.com/jsonld-java/jsonld-java/pull/265/commits/f990f28e597a0ec6677b1525f99dff45c0861cc7.

13.3. in https://w3c.github.io/json-ld-api/#algorithm-0 specifies `invalid type mapping` for `@json` with processing mode 1.0. In 13.4. it says _otherwise_ (which includes `@json` with 1.1) yield `invalid type mapping`, unless type is  `@id` or `@vocab`. This results in `invalid type mapping` for `@json` here. That is not intended, is it?

See also https://github.com/digitalbazaar/jsonld.js/blob/6cbb389c41d3c589907ce0da4fc1127349aad830/lib/context.js#L503, which has a different structure, but seems to make sure the error is not thrown for `@json`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fsteeg/json-ld-api/pull/232.html" title="Last updated on Dec 2, 2019, 9:59 AM UTC (0070434)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/232/d3f69d4...fsteeg:0070434.html" title="Last updated on Dec 2, 2019, 9:59 AM UTC (0070434)">Diff</a>