### PR TITLE
Add paragraph to abstract on 1.0 compatibility.

### DIFF
--- a/common/jsonld.js
+++ b/common/jsonld.js
@@ -15,6 +15,31 @@ const jsonld = {
         "Marcus Langhaler"
       ]
     },
+    "JSON-LD10-API": {
+      title: "JSON-LD 1.0 Processing Algorithms And API",
+      href: "https://www.w3.org/TR/2014/REC-json-ld-api-20140116/",
+      publisher: "W3C",
+      date: "16 January 2014",
+      status: "W3C Recommendation",
+      authors: [
+        "Marcus Langhaler",
+        "Gregg Kellogg",
+        "Manu Sporny"
+      ]
+    },
+    "JSON-LD10-FRAMING": {
+      title: "JSON-LD Framing 1.0",
+      href: "https://json-ld.org/spec/ED/json-ld-framing/20120830/",
+      publisher: "W3C",
+      date: "30 August 2012",
+      status: "Unofficial Draft",
+      authors: [
+        "Manu Sporny",
+        "Gregg Kellogg",
+        "David Longley",
+        "Marcus Langhaler"
+      ]
+    },
     "IEEE-754-2008": {
       title: "IEEE 754-2008 Standard for Floating-Point Arithmetic",
       href: "http://standards.ieee.org/findstds/standard/754-2008.html",

--- a/index.html
+++ b/index.html
@@ -308,6 +308,12 @@
     often dramatically simplifies its usage. Furthermore, this document proposes
     an Application Programming Interface (API) for developers implementing the
     specified algorithms.</p>
+
+  <p>This specification describes a superset of the features defined in
+    [[[JSON-LD10-API]]] [[JSON-LD10-API]]
+    and, except where noted,
+    the algorithms described in this specification are fully compatible
+    with documents created using [[[JSON-LD10]]] [[JSON-LD10]]</p>
 </section>
 
 <section id="sotd">

--- a/index.html
+++ b/index.html
@@ -313,7 +313,7 @@
     [[[JSON-LD10-API]]] [[JSON-LD10-API]]
     and, except where noted,
     the algorithms described in this specification are fully compatible
-    with documents created using [[[JSON-LD10]]] [[JSON-LD10]]</p>
+    with documents created using [[[JSON-LD10]]] [[JSON-LD10]].</p>
 </section>
 
 <section id="sotd">


### PR DESCRIPTION
For w3c/transitions#194.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/235.html" title="Last updated on Dec 6, 2019, 11:11 PM UTC (89d9efa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/235/28ee1e3...89d9efa.html" title="Last updated on Dec 6, 2019, 11:11 PM UTC (89d9efa)">Diff</a>