### PR TITLE
Remove unused _propagate_ argument to Create Term Definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -1433,9 +1433,8 @@
               <var>context</var> for <var>local context</var>, <var>key</var>,
               <var>defined</var>,
               <span class="changed">
-                the value of the <code>@protected</code>
-                entry from <var>context</var>, if any, for <var>protected</var>,
-                and <var>propagate</var>
+                and the value of the <code>@protected</code>
+                entry from <var>context</var>, if any, for <var>protected</var>
               </span>.
             </li>
           </ol>
@@ -1483,15 +1482,14 @@
     <section class="algorithm">
       <h3>Algorithm</h3>
 
-      <p>The algorithm has four required <span class="changed">and three optional</span> inputs.
+      <p>The algorithm has four required <span class="changed">and two optional</span> inputs.
         The required inputs are
         an <var>active context</var>, a <var>local context</var>,
         a <var>term</var>, and a map <var>defined</var>.
         <span class="changed">The optional inputs are
           <var>protected</var> which defaults to <code>false</code>,
-          <var>override protected</var>, defaulting to <code>false</code>,
-          which is used to allow changes to protected terms,
-          and <var>propagate</var>, defaulting to <code>true</code>.</span>.
+          and <var>override protected</var>, defaulting to <code>false</code>,
+          which is used to allow changes to protected terms.</span>.
         </p>
       <ol>
         <li>If <var>defined</var> contains the <a>entry</a> <var>term</var> and the associated
@@ -2461,9 +2459,8 @@
               has a <a>local context</a>, set <var>active context</var> to the result
               to the result of the
               <a href="#context-processing-algorithm">Context Processing algorithm</a>,
-              passing <var>active context</var>, the value of the
-              <var>term</var>'s <a>local context</a> as <var>local context</var>,
-              <span class="changed">and <code>true</code> for <var>propagate</var></span>.</li>
+              passing <var>active context</var>, and the value of the
+              <var>term</var>'s <a>local context</a> as <var>local context</var>.</li>
           </ol>
         </li>
         <li>Initialize two empty <a class="changed">maps</a>, <var>result</var>
@@ -3419,8 +3416,8 @@
           by transforming each <var>expanded type</var> of that <a>entry</a>
           into its compacted form using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
           passing <var>active context</var>, <var>inverse context</var>,
-          <var>expanded type</var> for <var>var</var>, <code>true</code> for <var>vocab</var>,
-          and <code>false</code> for <var>propagate</var>.
+          <var>expanded type</var> for <var>var</var>,
+          and <code>true</code> for <var>vocab</var>.
           Then, for each <var>term</var>
           in <var>compacted types</var> ordered lexicographically:
           <ol>


### PR DESCRIPTION
and errant use in a call to IRI Compaction.

Fixes #233.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/236.html" title="Last updated on Dec 6, 2019, 11:34 PM UTC (c2fb0ab)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/236/a1060cd...c2fb0ab.html" title="Last updated on Dec 6, 2019, 11:34 PM UTC (c2fb0ab)">Diff</a>