### PR TITLE
Add toRdf JSON literal alias tests.

### DIFF
--- a/tests/toRdf-manifest.html
+++ b/tests/toRdf-manifest.html
@@ -6000,6 +6000,62 @@ Test tjs15 Tests transforming property with @type @json to a JSON literal (null)
 </dd>
 </dl>
 </dd>
+<dt id='tjs16'>
+Test tjs16 Transform JSON literal with aliased @type
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tjs16</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Tests transforming JSON literal with aliased @type.</dd>
+<dt>input</dt>
+<dd>
+<a href='toRdf/js16-in.jsonld'>toRdf/js16-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='toRdf/js16-out.nq'>toRdf/js16-out.nq</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='tjs17'>
+Test tjs17 Transform JSON literal with aliased @value
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tjs17</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Tests transforming JSON literal with aliased @value.</dd>
+<dt>input</dt>
+<dd>
+<a href='toRdf/js17-in.jsonld'>toRdf/js17-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='toRdf/js17-out.nq'>toRdf/js17-out.nq</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
 <dt id='tli01'>
 Test tli01 @list containing @list
 </dt>

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -1837,6 +1837,22 @@
       "expect": "toRdf/js15-out.nq",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tjs16",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Transform JSON literal with aliased @type",
+      "purpose": "Tests transforming JSON literal with aliased @type.",
+      "input": "toRdf/js16-in.jsonld",
+      "expect": "toRdf/js16-out.nq",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tjs17",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Transform JSON literal with aliased @value",
+      "purpose": "Tests transforming JSON literal with aliased @value.",
+      "input": "toRdf/js17-in.jsonld",
+      "expect": "toRdf/js17-out.nq",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tli01",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
       "name": "@list containing @list",

--- a/tests/toRdf/js16-in.jsonld
+++ b/tests/toRdf/js16-in.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "type": "@type"
+  },
+  "ex:foo": {
+    "type": "@json",
+    "@value": {
+      "test": 1
+    }
+  }
+}

--- a/tests/toRdf/js16-out.nq
+++ b/tests/toRdf/js16-out.nq
@@ -1,0 +1,1 @@
+_:b0 <ex:foo> "{\"test\":1}"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON> .

--- a/tests/toRdf/js17-in.jsonld
+++ b/tests/toRdf/js17-in.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "value": "@value"
+  },
+  "ex:foo": {
+    "@type": "@json",
+    "value": {
+      "test": 1
+    }
+  }
+}

--- a/tests/toRdf/js17-out.nq
+++ b/tests/toRdf/js17-out.nq
@@ -1,0 +1,1 @@
+_:b0 <ex:foo> "{\"test\":1}"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON> .


### PR DESCRIPTION
This goes along with https://github.com/w3c/json-ld-api/pull/238.
Note that the added `js#` ids do not line up with expand tests due to some extra tests in the toRdf namespace.  We might need to realign and/or sync them to avoid confusion.