### PR TITLE
Clarify that `@graph` may be used with `@set` …

### DIFF
--- a/index.html
+++ b/index.html
@@ -1704,7 +1704,7 @@
           error been detected and processing is aborted.</li>
         <li>If <var>value</var> contains the <a>entry</a> <code>@container</code>:
           <ol>
-            <li>Initialize <var>container</var> to the value associated with the
+            <li id="ctd-container">Initialize <var>container</var> to the value associated with the
               <code>@container</code> <a>entry</a>, which MUST be either
               <code class="changed">@graph</code>,
               <code class="changed">@id</code>,
@@ -1714,12 +1714,13 @@
               <code>@set</code>,
               <code class="changed">@type</code>,
               <span class="changed">
-                or an <a>array</a> containing exactly any one of those
-                keywords, an <a>array</a> containing <code>@graph</code> and
+                or an <a>array</a> containing exactly any one of those keywords,
+                an <a>array</a> containing <code>@graph</code> and
                 either <code>@id</code> or <code>@index</code> optionally
-                including <code>@set</code>, or an <a>array</a> containing a
-                combination of <code>@set</code> and any of
-                <code>@index</code>, <code>@id</code>, <code>@type</code>,
+                including <code>@set</code>,
+                or an <a>array</a> containing a combination of <code>@set</code> and any of
+                <code>@index</code>, <code>@graph</code>,
+                <code>@id</code>, <code>@type</code>,
                 <code>@language</code> in any order
               </span>.
               Otherwise, an
@@ -6895,6 +6896,10 @@
       <a href="#create-term-definition">Create Term Definition algorithm</a>
       that remaining steps are skipped if the value of `@id` is `null`.
       This is in response to <a href="https://github.com/w3c/json-ld-api/issues/241">Issue 241</a>.</li>
+    <li>Clarified step <a href="#ctd-container">21.1</a> of the
+      <a href="#create-term-definition">Create Term Definition algorithm</a>
+      that `@graph` may be used with `@set`.
+      This is in response to <a href="https://github.com/w3c/json-ld-api/issues/242">Issue 242</a>.</li>
   </ul>
 </section>
 


### PR DESCRIPTION
in Create Term Definition step 21.1.

@kasei, please indicate if this change satisfies the issue you raised in #242.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/248.html" title="Last updated on Dec 18, 2019, 6:13 PM UTC (98cc8a7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/248/abdff28...98cc8a7.html" title="Last updated on Dec 18, 2019, 6:13 PM UTC (98cc8a7)">Diff</a>