### PR TITLE
Add text on handling application/xhtml+xml.

### DIFF
--- a/index.html
+++ b/index.html
@@ -6314,8 +6314,8 @@
             the <var>promise</var> is rejected with a <a>JsonLdError</a> whose code is set to <a data-link-for="JsonLdErrorCode">multiple context link headers</a>
             and processing is terminated.</p>
           <p>Processors MAY transform <var>document</var> to the <a>internal representation</a>.</p>
-          <p class="note">The HTTP Link Header is ignored for documents served as <code>application/ld+json</code>
-            or <code>text/html</code>.</p>
+          <p class="note">The HTTP Link Header is ignored for documents served as <code>application/ld+json</code>,
+            <code>text/html</code>, or <code>application/xhtml+xml</code>.</p>
         </li>
         <li>Otherwise, the retrieved document's <a>Content-Type</a> is neither
           <code>application/json</code>,
@@ -6357,7 +6357,8 @@
           unless a specific <a data-cite="RFC3986#section-3.5">fragment identifier</a> is targeted,
           extracts all encountered <a>JSON-LD script elements</a> using an <a>array</a> form, if necessary.</dd>
         <dt><dfn data-dfn-for="LoadDocumentOptions">profile</dfn></dt>
-        <dd>When the resulting <a data-link-for="RemoteDocument">contentType</a> is <code>text/html</code>,
+        <dd>When the resulting <a data-link-for="RemoteDocument">contentType</a> is <code>text/html</code>
+          or <code>application/xhtml+xml</code>,
           this option determines the profile to use for selecting a <a>JSON-LD script elements</a>.</dd>
         <dt><dfn data-dfn-for="LoadDocumentOptions">requestProfile</dfn></dt>
         <dd>One or more IRIs to use in the request as a <code>profile</code> parameter.
@@ -6419,11 +6420,13 @@
       <p>This sections describe an extension to the algorithm specified
         in <a>LoadDocumentCallback</a> to support extracting JSON-LD from HTML.</p>
 
-      <p><a href="#LoadDocumentCallback-step-2">Step 2</a> is updated to add the following: A processor supporting <a>HTML script extraction</a> MUST include <code>text/html</code> at any preference level,
+      <p><a href="#LoadDocumentCallback-step-2">Step 2</a> is updated to add the following: A processor supporting <a>HTML script extraction</a> MUST include <code>text/html</code> at any preference level
+        and MAY include <code>application/xhtml+xml</code> at any preference level,
         unless <a data-link-for="LoadDocumentOptions">requestProfile</a> is `http://www.w3.org/ns/json-ld#context`.</p>
 
       <p>After <a href="#LoadDocumentCallback-step-5">step 5</a>, add the following processing step:
-        Otherwise, if the retrieved resource's <a>Content-Type</a> is <code>text/html</code>:</p>
+        Otherwise, if the retrieved resource's <a>Content-Type</a> is either <code>text/html</code>
+        or <code>application/xhtml+xml</code>:</p>
       <ol>
         <li>Set <var>documentUrl</var> to the <a data-cite="HTML/urls-and-fetching.html#document-base-url">Document Base URL</a>
           of <a data-link-for="LoadDocumentCallback">url</a>, as defined in [[HTML]],
@@ -6909,6 +6912,10 @@
       <a href="#expansion-algorithm">Expansion algorithm</a>
       that duplicate the following step.
       This is in response to <a href="https://github.com/w3c/json-ld-api/issues/243">Issue 243</a>.</li>
+    <li>Add `application/xhtml+xml` as an allowed media type in <a href="#process-html" class="sectionRef"></a>,
+      in the note in <a href="#loaddocumentcallback" class="sectionRef"></a>,
+      and as a use of the {{LoadDocumentOptions/profile}} API option.
+      This is in response to <a href="https://github.com/w3c/json-ld-api/issues/244">Issue 244</a>.</li>
     <li>Updated step <a href="#ctd-contains-colon">16.5</a> of the
       <a href="#create-term-definition">Create Term Definition algorithm</a>
       to prevent an issue where <var>term</var> might not be defined at the time it is expanded.

--- a/index.html
+++ b/index.html
@@ -6359,7 +6359,7 @@
         <dt><dfn data-dfn-for="LoadDocumentOptions">profile</dfn></dt>
         <dd>When the resulting <a data-link-for="RemoteDocument">contentType</a> is <code>text/html</code>
           or <code>application/xhtml+xml</code>,
-          this option determines the profile to use for selecting a <a>JSON-LD script elements</a>.</dd>
+           this option determines the profile to use for selecting <a>JSON-LD script elements</a>.</dd>
         <dt><dfn data-dfn-for="LoadDocumentOptions">requestProfile</dfn></dt>
         <dd>One or more IRIs to use in the request as a <code>profile</code> parameter.
           (See <a data-cite="JSON-LD11#iana-considerations">IANA Considerations</a> in [[JSON-LD11]]).</dd>

--- a/tests/README.md
+++ b/tests/README.md
@@ -66,9 +66,15 @@ Note that some tests require re-expansion and comparison, as list values may exi
 # Running tests
 
 The top-level [manifest](manifest.jsonld) references the specific test manifests, which in turn reference each test associated with a particular type of behavior.
+
 Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:
 
 * _remote-doc_ tests will likely not return expected HTTP headers, so the _options_ should be used to determine what headers are associated with the input document.
+* Test case properties identifying a file (_input_, _output_, _context_, _expectContext_, and _frame_) are presumed to have a media type appropriate for the file extension.
+  * `application/ld+json` for `.jsonld`
+  * `text/html` for `.html`
+  * `application/n-quads` for `.nq`
+* The media type for the file associated with the _input_ property can be overridden using the `contentType` option.
 * Some algorithms, particularly _fromRdf_, may not preserve the order of statements listed in the input document, and provision should be taken for performing unordered array comparison, for arrays other than values of `@list`. (This may be difficult for compacted results, where array value ordering is dependent on the associated term definition).
 * When comparing documents after flattening, framing or generating RDF, blank node identifiers may not be predictable. Implementations using the JSON-LD 1.0 algorithm, where output is always sorted and blank node identifiers are generated sequentially from `_:b0` may continue to use a simple object comparison. Otherwise, implementations should take this into consideration. (One way to do this may be to reduce both results and _expected_ to datsets to extract a bijective mapping of blank node labels between the two datasets as described in [RDF Dataset Isomorphism](https://www.w3.org/TR/rdf11-concepts/#dfn-dataset-isomorphism)).
 

--- a/tests/compact-manifest.html
+++ b/tests/compact-manifest.html
@@ -56,11 +56,20 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 
 <h1>Running tests</h1>
 
-<p>The top-level <a href="manifest.jsonld">manifest</a> references the specific test manifests, which in turn reference each test associated with a particular type of behavior.
-Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:</p>
+<p>The top-level <a href="manifest.jsonld">manifest</a> references the specific test manifests, which in turn reference each test associated with a particular type of behavior.</p>
+
+<p>Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:</p>
 
 <ul>
 <li><em>remote-doc</em> tests will likely not return expected HTTP headers, so the <em>options</em> should be used to determine what headers are associated with the input document.</li>
+<li>Test case properties identifying a file (<em>input</em>, <em>output</em>, <em>context</em>, <em>expectContext</em>, and <em>frame</em>) are presumed to have a media type appropriate for the file extension.
+
+<ul>
+<li><code>application/ld+json</code> for <code>.jsonld</code></li>
+<li><code>text/html</code> for <code>.html</code></li>
+<li><code>application/n-quads</code> for <code>.nq</code></li>
+</ul></li>
+<li>The media type for the file associated with the <em>input</em> property can be overridden using the <code>contentType</code> option.</li>
 <li>Some algorithms, particularly <em>fromRdf</em>, may not preserve the order of statements listed in the input document, and provision should be taken for performing unordered array comparison, for arrays other than values of <code>@list</code>. (This may be difficult for compacted results, where array value ordering is dependent on the associated term definition).</li>
 <li>When comparing documents after flattening, framing or generating RDF, blank node identifiers may not be predictable. Implementations using the JSON-LD 1.0 algorithm, where output is always sorted and blank node identifiers are generated sequentially from <code>_:b0</code> may continue to use a simple object comparison. Otherwise, implementations should take this into consideration. (One way to do this may be to reduce both results and <em>expected</em> to datsets to extract a bijective mapping of blank node labels between the two datasets as described in <a href="https://www.w3.org/TR/rdf11-concepts/#dfn-dataset-isomorphism">RDF Dataset Isomorphism</a>).</li>
 </ul>

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -56,11 +56,20 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 
 <h1>Running tests</h1>
 
-<p>The top-level <a href="manifest.jsonld">manifest</a> references the specific test manifests, which in turn reference each test associated with a particular type of behavior.
-Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:</p>
+<p>The top-level <a href="manifest.jsonld">manifest</a> references the specific test manifests, which in turn reference each test associated with a particular type of behavior.</p>
+
+<p>Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:</p>
 
 <ul>
 <li><em>remote-doc</em> tests will likely not return expected HTTP headers, so the <em>options</em> should be used to determine what headers are associated with the input document.</li>
+<li>Test case properties identifying a file (<em>input</em>, <em>output</em>, <em>context</em>, <em>expectContext</em>, and <em>frame</em>) are presumed to have a media type appropriate for the file extension.
+
+<ul>
+<li><code>application/ld+json</code> for <code>.jsonld</code></li>
+<li><code>text/html</code> for <code>.html</code></li>
+<li><code>application/n-quads</code> for <code>.nq</code></li>
+</ul></li>
+<li>The media type for the file associated with the <em>input</em> property can be overridden using the <code>contentType</code> option.</li>
 <li>Some algorithms, particularly <em>fromRdf</em>, may not preserve the order of statements listed in the input document, and provision should be taken for performing unordered array comparison, for arrays other than values of <code>@list</code>. (This may be difficult for compacted results, where array value ordering is dependent on the associated term definition).</li>
 <li>When comparing documents after flattening, framing or generating RDF, blank node identifiers may not be predictable. Implementations using the JSON-LD 1.0 algorithm, where output is always sorted and blank node identifiers are generated sequentially from <code>_:b0</code> may continue to use a simple object comparison. Otherwise, implementations should take this into consideration. (One way to do this may be to reduce both results and <em>expected</em> to datsets to extract a bijective mapping of blank node labels between the two datasets as described in <a href="https://www.w3.org/TR/rdf11-concepts/#dfn-dataset-isomorphism">RDF Dataset Isomorphism</a>).</li>
 </ul>
@@ -6397,6 +6406,62 @@ Test tjs20 Expand JSON literal with aliased @value
 <dt>expect</dt>
 <dd>
 <a href='expand/js20-out.jsonld'>expand/js20-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='tjs13'>
+Test tjs13 Expand JSON literal with aliased @type
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tjs13</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>Tests expanding JSON literal with aliased @type.</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/js13-in.jsonld'>expand/js13-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='expand/js13-out.jsonld'>expand/js13-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='tjs14'>
+Test tjs14 Expand JSON literal with aliased @value
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tjs14</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>Tests expanding JSON literal with aliased @value.</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/js14-in.jsonld'>expand/js14-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='expand/js14-out.jsonld'>expand/js14-out.jsonld</a>
 </dd>
 <dt>Options</dt>
 <dd>

--- a/tests/flatten-manifest.html
+++ b/tests/flatten-manifest.html
@@ -56,11 +56,20 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 
 <h1>Running tests</h1>
 
-<p>The top-level <a href="manifest.jsonld">manifest</a> references the specific test manifests, which in turn reference each test associated with a particular type of behavior.
-Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:</p>
+<p>The top-level <a href="manifest.jsonld">manifest</a> references the specific test manifests, which in turn reference each test associated with a particular type of behavior.</p>
+
+<p>Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:</p>
 
 <ul>
 <li><em>remote-doc</em> tests will likely not return expected HTTP headers, so the <em>options</em> should be used to determine what headers are associated with the input document.</li>
+<li>Test case properties identifying a file (<em>input</em>, <em>output</em>, <em>context</em>, <em>expectContext</em>, and <em>frame</em>) are presumed to have a media type appropriate for the file extension.
+
+<ul>
+<li><code>application/ld+json</code> for <code>.jsonld</code></li>
+<li><code>text/html</code> for <code>.html</code></li>
+<li><code>application/n-quads</code> for <code>.nq</code></li>
+</ul></li>
+<li>The media type for the file associated with the <em>input</em> property can be overridden using the <code>contentType</code> option.</li>
 <li>Some algorithms, particularly <em>fromRdf</em>, may not preserve the order of statements listed in the input document, and provision should be taken for performing unordered array comparison, for arrays other than values of <code>@list</code>. (This may be difficult for compacted results, where array value ordering is dependent on the associated term definition).</li>
 <li>When comparing documents after flattening, framing or generating RDF, blank node identifiers may not be predictable. Implementations using the JSON-LD 1.0 algorithm, where output is always sorted and blank node identifiers are generated sequentially from <code>_:b0</code> may continue to use a simple object comparison. Otherwise, implementations should take this into consideration. (One way to do this may be to reduce both results and <em>expected</em> to datsets to extract a bijective mapping of blank node labels between the two datasets as described in <a href="https://www.w3.org/TR/rdf11-concepts/#dfn-dataset-isomorphism">RDF Dataset Isomorphism</a>).</li>
 </ul>

--- a/tests/fromRdf-manifest.html
+++ b/tests/fromRdf-manifest.html
@@ -51,11 +51,20 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 
 <h1>Running tests</h1>
 
-<p>The top-level <a href="manifest.jsonld">manifest</a> references the specific test manifests, which in turn reference each test associated with a particular type of behavior.
-Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:</p>
+<p>The top-level <a href="manifest.jsonld">manifest</a> references the specific test manifests, which in turn reference each test associated with a particular type of behavior.</p>
+
+<p>Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:</p>
 
 <ul>
 <li><em>remote-doc</em> tests will likely not return expected HTTP headers, so the <em>options</em> should be used to determine what headers are associated with the input document.</li>
+<li>Test case properties identifying a file (<em>input</em>, <em>output</em>, <em>context</em>, <em>expectContext</em>, and <em>frame</em>) are presumed to have a media type appropriate for the file extension.
+
+<ul>
+<li><code>application/ld+json</code> for <code>.jsonld</code></li>
+<li><code>text/html</code> for <code>.html</code></li>
+<li><code>application/n-quads</code> for <code>.nq</code></li>
+</ul></li>
+<li>The media type for the file associated with the <em>input</em> property can be overridden using the <code>contentType</code> option.</li>
 <li>Some algorithms, particularly <em>fromRdf</em>, may not preserve the order of statements listed in the input document, and provision should be taken for performing unordered array comparison, for arrays other than values of <code>@list</code>. (This may be difficult for compacted results, where array value ordering is dependent on the associated term definition).</li>
 <li>When comparing documents after flattening, framing or generating RDF, blank node identifiers may not be predictable. Implementations using the JSON-LD 1.0 algorithm, where output is always sorted and blank node identifiers are generated sequentially from <code>_:b0</code> may continue to use a simple object comparison. Otherwise, implementations should take this into consideration. (One way to do this may be to reduce both results and <em>expected</em> to datsets to extract a bijective mapping of blank node labels between the two datasets as described in <a href="https://www.w3.org/TR/rdf11-concepts/#dfn-dataset-isomorphism">RDF Dataset Isomorphism</a>).</li>
 </ul>

--- a/tests/html-manifest.html
+++ b/tests/html-manifest.html
@@ -71,11 +71,20 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 
 <h1>Running tests</h1>
 
-<p>The top-level <a href="manifest.jsonld">manifest</a> references the specific test manifests, which in turn reference each test associated with a particular type of behavior.
-Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:</p>
+<p>The top-level <a href="manifest.jsonld">manifest</a> references the specific test manifests, which in turn reference each test associated with a particular type of behavior.</p>
+
+<p>Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:</p>
 
 <ul>
 <li><em>remote-doc</em> tests will likely not return expected HTTP headers, so the <em>options</em> should be used to determine what headers are associated with the input document.</li>
+<li>Test case properties identifying a file (<em>input</em>, <em>output</em>, <em>context</em>, <em>expectContext</em>, and <em>frame</em>) are presumed to have a media type appropriate for the file extension.
+
+<ul>
+<li><code>application/ld+json</code> for <code>.jsonld</code></li>
+<li><code>text/html</code> for <code>.html</code></li>
+<li><code>application/n-quads</code> for <code>.nq</code></li>
+</ul></li>
+<li>The media type for the file associated with the <em>input</em> property can be overridden using the <code>contentType</code> option.</li>
 <li>Some algorithms, particularly <em>fromRdf</em>, may not preserve the order of statements listed in the input document, and provision should be taken for performing unordered array comparison, for arrays other than values of <code>@list</code>. (This may be difficult for compacted results, where array value ordering is dependent on the associated term definition).</li>
 <li>When comparing documents after flattening, framing or generating RDF, blank node identifiers may not be predictable. Implementations using the JSON-LD 1.0 algorithm, where output is always sorted and blank node identifiers are generated sequentially from <code>_:b0</code> may continue to use a simple object comparison. Otherwise, implementations should take this into consideration. (One way to do this may be to reduce both results and <em>expected</em> to datsets to extract a bijective mapping of blank node labels between the two datasets as described in <a href="https://www.w3.org/TR/rdf11-concepts/#dfn-dataset-isomorphism">RDF Dataset Isomorphism</a>).</li>
 </ul>
@@ -136,6 +145,36 @@ Test te001 Expands embedded JSON-LD script element
 <dl class='options'>
 <dt>specVersion</dt>
 <dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='tex01'>
+Test tex01 Expands embedded JSON-LD script element (xhtml)
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tex01</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ExpandTest, jld:HtmlTest</dd>
+<dt>Purpose</dt>
+<dd>Tests embedded JSON-LD in XHTML</dd>
+<dt>input</dt>
+<dd>
+<a href='html/e001-in.html'>html/e001-in.html</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='html/e001-out.jsonld'>html/e001-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+<dt>contentType</dt>
+<dd>application/xhtml+xml</dd>
 </dl>
 </dd>
 </dl>

--- a/tests/html-manifest.jsonld
+++ b/tests/html-manifest.jsonld
@@ -14,6 +14,14 @@
     "expect": "html/e001-out.jsonld",
     "option": {"specVersion": "json-ld-1.1"}
   }, {
+    "@id": "#tex01",
+    "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest", "jld:HtmlTest"],
+    "name": "Expands embedded JSON-LD script element (xhtml)",
+    "purpose": "Tests embedded JSON-LD in XHTML",
+    "input": "html/e001-in.html",
+    "expect": "html/e001-out.jsonld",
+    "option": {"specVersion": "json-ld-1.1", "contentType": "application/xhtml+xml"}
+  }, {
     "@id": "#te002",
     "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest", "jld:HtmlTest"],
     "name": "Expands first embedded JSON-LD script element",

--- a/tests/manifest.html
+++ b/tests/manifest.html
@@ -91,11 +91,20 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 
 <h1>Running tests</h1>
 
-<p>The top-level <a href="manifest.jsonld">manifest</a> references the specific test manifests, which in turn reference each test associated with a particular type of behavior.
-Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:</p>
+<p>The top-level <a href="manifest.jsonld">manifest</a> references the specific test manifests, which in turn reference each test associated with a particular type of behavior.</p>
+
+<p>Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:</p>
 
 <ul>
 <li><em>remote-doc</em> tests will likely not return expected HTTP headers, so the <em>options</em> should be used to determine what headers are associated with the input document.</li>
+<li>Test case properties identifying a file (<em>input</em>, <em>output</em>, <em>context</em>, <em>expectContext</em>, and <em>frame</em>) are presumed to have a media type appropriate for the file extension.
+
+<ul>
+<li><code>application/ld+json</code> for <code>.jsonld</code></li>
+<li><code>text/html</code> for <code>.html</code></li>
+<li><code>application/n-quads</code> for <code>.nq</code></li>
+</ul></li>
+<li>The media type for the file associated with the <em>input</em> property can be overridden using the <code>contentType</code> option.</li>
 <li>Some algorithms, particularly <em>fromRdf</em>, may not preserve the order of statements listed in the input document, and provision should be taken for performing unordered array comparison, for arrays other than values of <code>@list</code>. (This may be difficult for compacted results, where array value ordering is dependent on the associated term definition).</li>
 <li>When comparing documents after flattening, framing or generating RDF, blank node identifiers may not be predictable. Implementations using the JSON-LD 1.0 algorithm, where output is always sorted and blank node identifiers are generated sequentially from <code>_:b0</code> may continue to use a simple object comparison. Otherwise, implementations should take this into consideration. (One way to do this may be to reduce both results and <em>expected</em> to datsets to extract a bijective mapping of blank node labels between the two datasets as described in <a href="https://www.w3.org/TR/rdf11-concepts/#dfn-dataset-isomorphism">RDF Dataset Isomorphism</a>).</li>
 </ul>

--- a/tests/remote-doc-manifest.html
+++ b/tests/remote-doc-manifest.html
@@ -70,11 +70,20 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 
 <h1>Running tests</h1>
 
-<p>The top-level <a href="manifest.jsonld">manifest</a> references the specific test manifests, which in turn reference each test associated with a particular type of behavior.
-Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:</p>
+<p>The top-level <a href="manifest.jsonld">manifest</a> references the specific test manifests, which in turn reference each test associated with a particular type of behavior.</p>
+
+<p>Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:</p>
 
 <ul>
 <li><em>remote-doc</em> tests will likely not return expected HTTP headers, so the <em>options</em> should be used to determine what headers are associated with the input document.</li>
+<li>Test case properties identifying a file (<em>input</em>, <em>output</em>, <em>context</em>, <em>expectContext</em>, and <em>frame</em>) are presumed to have a media type appropriate for the file extension.
+
+<ul>
+<li><code>application/ld+json</code> for <code>.jsonld</code></li>
+<li><code>text/html</code> for <code>.html</code></li>
+<li><code>application/n-quads</code> for <code>.nq</code></li>
+</ul></li>
+<li>The media type for the file associated with the <em>input</em> property can be overridden using the <code>contentType</code> option.</li>
 <li>Some algorithms, particularly <em>fromRdf</em>, may not preserve the order of statements listed in the input document, and provision should be taken for performing unordered array comparison, for arrays other than values of <code>@list</code>. (This may be difficult for compacted results, where array value ordering is dependent on the associated term definition).</li>
 <li>When comparing documents after flattening, framing or generating RDF, blank node identifiers may not be predictable. Implementations using the JSON-LD 1.0 algorithm, where output is always sorted and blank node identifiers are generated sequentially from <code>_:b0</code> may continue to use a simple object comparison. Otherwise, implementations should take this into consideration. (One way to do this may be to reduce both results and <em>expected</em> to datsets to extract a bijective mapping of blank node labels between the two datasets as described in <a href="https://www.w3.org/TR/rdf11-concepts/#dfn-dataset-isomorphism">RDF Dataset Isomorphism</a>).</li>
 </ul>

--- a/tests/template.haml
+++ b/tests/template.haml
@@ -110,9 +110,15 @@
       # Running tests
 
       The top-level [manifest](manifest.jsonld) references the specific test manifests, which in turn reference each test associated with a particular type of behavior.
+
       Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:
 
       * _remote-doc_ tests will likely not return expected HTTP headers, so the _options_ should be used to determine what headers are associated with the input document.
+      * Test case properties identifying a file (_input_, _output_, _context_, _expectContext_, and _frame_) are presumed to have a media type appropriate for the file extension.
+        * `application/ld+json` for `.jsonld`
+        * `text/html` for `.html`
+        * `application/n-quads` for `.nq`
+      * The media type for the file associated with the _input_ property can be overridden using the `contentType` option.
       * Some algorithms, particularly _fromRdf_, may not preserve the order of statements listed in the input document, and provision should be taken for performing unordered array comparison, for arrays other than values of `@list`. (This may be difficult for compacted results, where array value ordering is dependent on the associated term definition).
       * When comparing documents after flattening, framing or generating RDF, blank node identifiers may not be predictable. Implementations using the JSON-LD 1.0 algorithm, where output is always sorted and blank node identifiers are generated sequentially from `_:b0` may continue to use a simple object comparison. Otherwise, implementations should take this into consideration. (One way to do this may be to reduce both results and _expected_ to datsets to extract a bijective mapping of blank node labels between the two datasets as described in [RDF Dataset Isomorphism](https://www.w3.org/TR/rdf11-concepts/#dfn-dataset-isomorphism)).
 

--- a/tests/toRdf-manifest.html
+++ b/tests/toRdf-manifest.html
@@ -51,11 +51,20 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 
 <h1>Running tests</h1>
 
-<p>The top-level <a href="manifest.jsonld">manifest</a> references the specific test manifests, which in turn reference each test associated with a particular type of behavior.
-Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:</p>
+<p>The top-level <a href="manifest.jsonld">manifest</a> references the specific test manifests, which in turn reference each test associated with a particular type of behavior.</p>
+
+<p>Implementations create their own infrastructure for running the test suite. In particular, the following should be considered:</p>
 
 <ul>
 <li><em>remote-doc</em> tests will likely not return expected HTTP headers, so the <em>options</em> should be used to determine what headers are associated with the input document.</li>
+<li>Test case properties identifying a file (<em>input</em>, <em>output</em>, <em>context</em>, <em>expectContext</em>, and <em>frame</em>) are presumed to have a media type appropriate for the file extension.
+
+<ul>
+<li><code>application/ld+json</code> for <code>.jsonld</code></li>
+<li><code>text/html</code> for <code>.html</code></li>
+<li><code>application/n-quads</code> for <code>.nq</code></li>
+</ul></li>
+<li>The media type for the file associated with the <em>input</em> property can be overridden using the <code>contentType</code> option.</li>
 <li>Some algorithms, particularly <em>fromRdf</em>, may not preserve the order of statements listed in the input document, and provision should be taken for performing unordered array comparison, for arrays other than values of <code>@list</code>. (This may be difficult for compacted results, where array value ordering is dependent on the associated term definition).</li>
 <li>When comparing documents after flattening, framing or generating RDF, blank node identifiers may not be predictable. Implementations using the JSON-LD 1.0 algorithm, where output is always sorted and blank node identifiers are generated sequentially from <code>_:b0</code> may continue to use a simple object comparison. Otherwise, implementations should take this into consideration. (One way to do this may be to reduce both results and <em>expected</em> to datsets to extract a bijective mapping of blank node labels between the two datasets as described in <a href="https://www.w3.org/TR/rdf11-concepts/#dfn-dataset-isomorphism">RDF Dataset Isomorphism</a>).</li>
 </ul>

--- a/tests/vocab.html
+++ b/tests/vocab.html
@@ -30,253 +30,253 @@
   },
   "@graph": [
     {
-      "@id": "jld:compactArrays",
-      "rdfs:label": "compact arrays",
+      "@id": "jld:contentType",
+      "rdfs:comment": "The HTTP Content-Type used for the input file, in case it is a non-registered type.",
+      "rdfs:label": "content type",
       "rdfs:range": "xsd:boolean",
       "@type": "rdf:Property",
-      "rdfs:comment": "If set to `true`, the JSON-LD processor replaces arrays with just one element with that element during compaction. If set to false, all arrays will remain arrays even if they have just one element.",
       "rdfs:domain": "jld:Option"
     },
     {
       "@id": "jld:Option",
+      "rdfs:comment": "Options passed to the test runner to affect invocation of the appropriate API method.",
       "rdfs:label": "Processor Options",
-      "@type": "rdfs:Class",
-      "rdfs:comment": "Options passed to the test runner to affect invocation of the appropriate API method."
+      "@type": "rdfs:Class"
     },
     {
-      "@id": "jld:redirectTo",
-      "rdfs:label": "redirect to",
+      "@id": "jld:CompactTest",
+      "rdfs:comment": "A `CompactTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`.",
+      "rdfs:label": "Compact Evaluation Test",
+      "@type": "rdfs:Class",
+      "rdfs:subClassOf": "jld:Test"
+    },
+    {
+      "@id": "jld:Test",
+      "rdfs:comment": "All JSON-LD tests have an input file referenced using `mf:action` (aliased as \"input\" in test manifest). Positive and Negative Evaluation Tests also have a result file referenced using `mf:result` (aliased as \"expect\" and \"expectErrorCode\" for respectively Positive and Negative Evaluation Tests in test manifest). Other tests may take different inputs and options as defined for each test class. Tests should be run with the processingMode option set to \"json-ld-1.1\", unless specified explicitly as a test option.",
+      "rdfs:label": "Superclass of all JSON-LD tests",
+      "@type": "rdfs:Class"
+    },
+    {
+      "@id": "jld:httpAccept",
+      "rdfs:comment": "An HTTP Accept header.",
+      "rdfs:label": "HTTP Accept",
       "rdfs:range": "xsd:boolean",
       "@type": "rdf:Property",
-      "rdfs:comment": "The location of a URL for redirection. A request made of the input file must be redirected to the designated URL.",
+      "rdfs:domain": "jld:Option"
+    },
+    {
+      "@id": "jld:frame",
+      "rdfs:comment": "A frame that is used for transforming the input document.",
+      "rdfs:label": "input",
+      "rdfs:range": "rdfs:Resource",
+      "@type": "rdf:Property",
+      "rdfs:domain": "jld:Test"
+    },
+    {
+      "@id": "jld:FrameTest",
+      "rdfs:comment": "A `FrameTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`.",
+      "rdfs:label": "Frame Evaluation Test",
+      "@type": "rdfs:Class",
+      "rdfs:subClassOf": "jld:Test"
+    },
+    {
+      "@id": "jld:produceGeneralizedRdf",
+      "rdfs:comment": "Unless the produce generalized RDF flag is set to true, RDF triples containing a blank node predicate are excluded from output.",
+      "rdfs:label": "produce generalized RDF",
+      "rdfs:range": "xsd:boolean",
+      "@type": "rdf:Property",
+      "rdfs:domain": "jld:Option"
+    },
+    {
+      "@id": "jld:FromRDFTest",
+      "rdfs:comment": "A `FromRDFTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`.",
+      "rdfs:label": "From RDF Evaluation Test",
+      "@type": "rdfs:Class",
+      "rdfs:subClassOf": "jld:Test"
+    },
+    {
+      "@id": "jld:PositiveSyntaxTest",
+      "rdfs:comment": "A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action.",
+      "rdfs:label": "Positive Syntax Test",
+      "@type": "rdfs:Class",
+      "rdfs:subClassOf": "jld:Test"
+    },
+    {
+      "@id": "jld:ExpandTest",
+      "rdfs:comment": "A `ExpandTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`.",
+      "rdfs:label": "Expand Evaluation Test",
+      "@type": "rdfs:Class",
+      "rdfs:subClassOf": "jld:Test"
+    },
+    {
+      "@id": "jld:PositiveEvaluationTest",
+      "rdfs:comment": "A Positive Evaluation test is successful when the result of processing the input file specified as `mf:action` (aliased as \"input\" in test manifest) exactly matches the output file specified as `mf:result` (aliased as \"expect\" in test manifest) using the comparison defined in another class. The specifics of invoking test, including the interpretation of options (`:option`) and other input files are specified through another class.",
+      "rdfs:label": "Positive Evaluation Test",
+      "@type": "rdfs:Class",
+      "rdfs:subClassOf": "jld:Test"
+    },
+    {
+      "@id": "jld:option",
+      "rdfs:comment": "Options affecting processing",
+      "rdfs:label": "option",
+      "rdfs:range": "jld:Option",
+      "@type": "rdf:Property",
+      "rdfs:domain": "jld:Test"
+    },
+    {
+      "@id": "jld:NegativeEvaluationTest",
+      "rdfs:comment": "A Negative Evaluation test is successful when the result of processing the input file specified as `mf:action` (aliased as \"input\" in test manifest) results in the error identified by the literal value of `mf:result` (aliased as \"expectErrorCode\" in test manifest). The specifics of invoking test, including the interpretation of options (`:option`) and other input files are specified through another class. See the [README](https://w3c.github.io/json-ld-api/tests/) for more details on running tests.",
+      "rdfs:label": "Negative Evaluation Test",
+      "@type": "rdfs:Class",
+      "rdfs:subClassOf": "jld:Test"
+    },
+    {
+      "@id": "jld:base",
+      "rdfs:comment": "The base IRI to use when expanding or compacting the document. If set, this overrides the input document's IRI.",
+      "rdfs:label": "base",
+      "rdfs:range": "rdfs:Resource",
+      "@type": "rdf:Property",
       "rdfs:domain": "jld:Option"
     },
     {
       "@id": "jld:NegativeSyntaxTest",
+      "rdfs:comment": "A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action. Negative syntax tests are tests of which the result should be a parser error.",
       "rdfs:label": "Negative Syntax Test",
       "@type": "rdfs:Class",
-      "rdfs:subClassOf": "jld:Test",
-      "rdfs:comment": "A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action. Negative syntax tests are tests of which the result should be a parser error."
+      "rdfs:subClassOf": "jld:Test"
     },
     {
-      "@id": "jld:Test",
-      "rdfs:label": "Superclass of all JSON-LD tests",
-      "@type": "rdfs:Class",
-      "rdfs:comment": "All JSON-LD tests have an input file referenced using `mf:action` (aliased as \"input\" in test manifest). Positive and Negative Evaluation Tests also have a result file referenced using `mf:result` (aliased as \"expect\" and \"expectErrorCode\" for respectively Positive and Negative Evaluation Tests in test manifest). Other tests may take different inputs and options as defined for each test class. Tests should be run with the processingMode option set to \"json-ld-1.1\", unless specified explicitly as a test option."
-    },
-    {
-      "@id": "jld:useNativeTypes",
-      "rdfs:label": "use native types",
+      "@id": "jld:compactArrays",
+      "rdfs:comment": "If set to `true`, the JSON-LD processor replaces arrays with just one element with that element during compaction. If set to false, all arrays will remain arrays even if they have just one element.",
+      "rdfs:label": "compact arrays",
       "rdfs:range": "xsd:boolean",
       "@type": "rdf:Property",
-      "rdfs:comment": "If the _use native types_ flag is set to `true`, RDF literals with a datatype IRI that equal `xsd:integer` or `xsd:double` are converted to a JSON numbers and RDF literals with a datatype IRI that equals `xsd:boolean` are converted to `true` or `false` based on their lexical form.",
       "rdfs:domain": "jld:Option"
     },
     {
+      "@id": "https://w3c.github.io/json-ld-api/tests/vocab#",
+      "rdfs:comment": "Manifest vocabulary for JSON-LD test cases",
+      "dc11:publisher": "W3C Linked JSON Community Group",
+      "dc11:description": "Test case manifest vocabulary extensions",
+      "dc11:identifier": "https://w3c.github.io/json-ld-api/tests/vocab#",
+      "dc11:title": "Test case manifest vocabulary extensions",
+      "dc11:date": "2013-09-23",
+      "dc11:creator": "Gregg Kellogg"
+    },
+    {
       "@id": "jld:context",
+      "rdfs:comment": "A context that is used for transforming the input document.",
       "rdfs:label": "context",
       "rdfs:range": "rdfs:Resource",
       "@type": "rdf:Property",
-      "rdfs:comment": "A context that is used for transforming the input document.",
       "rdfs:domain": "jld:Test"
     },
     {
-      "@id": "jld:FromRDFTest",
-      "rdfs:label": "From RDF Evaluation Test",
-      "@type": "rdfs:Class",
-      "rdfs:subClassOf": "jld:Test",
-      "rdfs:comment": "A `FromRDFTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`."
-    },
-    {
       "@id": "jld:httpStatus",
+      "rdfs:comment": "The HTTP status code that must be returned when the input file is requested. This is typically used along with the `redirectTo` property.",
       "rdfs:label": "HTTP status",
       "rdfs:range": "xsd:boolean",
       "@type": "rdf:Property",
-      "rdfs:comment": "The HTTP status code that must be returned when the input file is requested. This is typically used along with the `redirectTo` property.",
+      "rdfs:domain": "jld:Option"
+    },
+    {
+      "@id": "jld:ToRDFTest",
+      "rdfs:comment": "A `ToRDFTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`.",
+      "rdfs:label": "To RDF Evaluation Test",
+      "@type": "rdfs:Class",
+      "rdfs:subClassOf": "jld:Test"
+    },
+    {
+      "@id": "jld:httpLink",
+      "rdfs:comment": "An HTTP Link header to be added to the result of requesting the input file.",
+      "rdfs:label": "HTTP link",
+      "rdfs:range": "xsd:boolean",
+      "@type": "rdf:Property",
+      "rdfs:domain": "jld:Option"
+    },
+    {
+      "@id": "jld:input",
+      "rdfs:comment": "Secondary input file",
+      "rdfs:label": "input",
+      "rdfs:range": "rdfs:Resource",
+      "@type": "rdf:Property",
+      "rdfs:domain": "jld:Test"
+    },
+    {
+      "@id": "jld:HtmlTest",
+      "rdfs:comment": "An `HtmlTest` modifies either a `PositiveEvaluationTest` or `NegativeEvaluationTest` indicating that the source is of type text/html, which requires optional _HTML script extraction_ support.",
+      "rdfs:label": "HTML Evaluation Test",
+      "@type": "rdfs:Class",
+      "rdfs:subClassOf": "jld:Test"
+    },
+    {
+      "@id": "jld:HttpTest",
+      "rdfs:comment": "An `HttpTest` modifies either a `PositiveEvaluationTest` or `NegativeEvaluationTest`.",
+      "rdfs:label": "HTTP Evaluation Test",
+      "@type": "rdfs:Class",
+      "rdfs:subClassOf": "jld:Test"
+    },
+    {
+      "@id": "jld:processingMode",
+      "rdfs:comment": "If set to \"json-ld-1.1\", the JSON-LD processor must produce exactly the same results as the algorithms defined in this specification. If set to another value, the JSON-LD processor is allowed to extend or modify the algorithms defined in this specification to enable application-specific optimizations. The definition of such optimizations is beyond the scope of this specification and thus not defined. Consequently, different implementations may implement different optimizations. Developers must not define modes beginning with json-ld as they are reserved for future versions of this specification.",
+      "rdfs:label": "processing mode",
+      "rdfs:range": "xsd:string",
+      "@type": "rdf:Property",
+      "rdfs:domain": "jld:Option"
+    },
+    {
+      "@id": "jld:useNativeTypes",
+      "rdfs:comment": "If the _use native types_ flag is set to `true`, RDF literals with a datatype IRI that equal `xsd:integer` or `xsd:double` are converted to a JSON numbers and RDF literals with a datatype IRI that equals `xsd:boolean` are converted to `true` or `false` based on their lexical form.",
+      "rdfs:label": "use native types",
+      "rdfs:range": "xsd:boolean",
+      "@type": "rdf:Property",
+      "rdfs:domain": "jld:Option"
+    },
+    {
+      "@id": "jld:expandContext",
+      "rdfs:comment": "A context that is used to initialize the active context when expanding a document.",
+      "rdfs:label": "expand context",
+      "rdfs:range": "rdfs:Resource",
+      "@type": "rdf:Property",
       "rdfs:domain": "jld:Option"
     },
     {
       "@id": "jld:useRdfType",
+      "rdfs:comment": "If the _use rdf type_ flag is set to `true`, statements with an `rdf:type` predicate will not use `@type`, but will be transformed as a normal property.",
       "rdfs:label": "use RDF types",
       "rdfs:range": "xsd:boolean",
       "@type": "rdf:Property",
-      "rdfs:comment": "If the _use rdf type_ flag is set to `true`, statements with an `rdf:type` predicate will not use `@type`, but will be transformed as a normal property.",
       "rdfs:domain": "jld:Option"
-    },
-    {
-      "@id": "jld:NegativeEvaluationTest",
-      "rdfs:label": "Positive Evaluation Test",
-      "@type": "rdfs:Class",
-      "rdfs:subClassOf": "jld:Test",
-      "rdfs:comment": "A Negative Evaluation test is successful when the result of processing the input file specified as `mf:action` (aliased as \"input\" in test manifest) results in the error identified by the literal value of `mf:result` (aliased as \"expectErrorCode\" in test manifest). The specifics of invoking test, including the interpretation of options (`:option`) and other input files are specified through another class. See the [README](https://w3c.github.io/json-ld-api/tests/) for more details on running tests."
-    },
-    {
-      "@id": "jld:HtmlTest",
-      "rdfs:label": "HTML Evaluation Test",
-      "@type": "rdfs:Class",
-      "rdfs:subClassOf": "jld:Test",
-      "rdfs:comment": "An `HtmlTest` modifies either a `PositiveEvaluationTest` or `NegativeEvaluationTest` indicating that the source is of type text/html, which requires optional _HTML script extraction_ support."
-    },
-    {
-      "@id": "jld:compactToRelative",
-      "rdfs:label": "compact to relative",
-      "rdfs:range": "xsd:boolean",
-      "@type": "rdf:Property",
-      "rdfs:comment": "If set to `false`, the JSON-LD processor will not attempt to compact using document-relative IRIs.",
-      "rdfs:domain": "jld:Option"
-    },
-    {
-      "@id": "jld:PositiveSyntaxTest",
-      "rdfs:label": "Positive Syntax Test",
-      "@type": "rdfs:Class",
-      "rdfs:subClassOf": "jld:Test",
-      "rdfs:comment": "A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action."
-    },
-    {
-      "@id": "jld:ToRDFTest",
-      "rdfs:label": "To RDF Evaluation Test",
-      "@type": "rdfs:Class",
-      "rdfs:subClassOf": "jld:Test",
-      "rdfs:comment": "A `ToRDFTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`."
-    },
-    {
-      "@id": "jld:ExpandTest",
-      "rdfs:label": "Expand Evaluation Test",
-      "@type": "rdfs:Class",
-      "rdfs:subClassOf": "jld:Test",
-      "rdfs:comment": "A `ExpandTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`."
-    },
-    {
-      "@id": "jld:HttpTest",
-      "rdfs:label": "HTTP Evaluation Test",
-      "@type": "rdfs:Class",
-      "rdfs:subClassOf": "jld:Test",
-      "rdfs:comment": "An `HttpTest` modifies either a `PositiveEvaluationTest` or `NegativeEvaluationTest`."
-    },
-    {
-      "@id": "jld:PositiveEvaluationTest",
-      "rdfs:label": "Positive Evaluation Test",
-      "@type": "rdfs:Class",
-      "rdfs:subClassOf": "jld:Test",
-      "rdfs:comment": "A Positive Evaluation test is successful when the result of processing the input file specified as `mf:action` (aliased as \"input\" in test manifest) exactly matches the output file specified as `mf:result` (aliased as \"expect\" in test manifest) using the comparison defined in another class. The specifics of invoking test, including the interpretation of options (`:option`) and other input files are specified through another class."
-    },
-    {
-      "@id": "jld:expandContext",
-      "rdfs:label": "expand context",
-      "rdfs:range": "rdfs:Resource",
-      "@type": "rdf:Property",
-      "rdfs:comment": "A context that is used to initialize the active context when expanding a document.",
-      "rdfs:domain": "jld:Option"
-    },
-    {
-      "@id": "jld:FrameTest",
-      "rdfs:label": "Frame Evaluation Test",
-      "@type": "rdfs:Class",
-      "rdfs:subClassOf": "jld:Test",
-      "rdfs:comment": "A `FrameTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`."
-    },
-    {
-      "@id": "jld:CompactTest",
-      "rdfs:label": "Compact Evaluation Test",
-      "@type": "rdfs:Class",
-      "rdfs:subClassOf": "jld:Test",
-      "rdfs:comment": "A `CompactTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`."
-    },
-    {
-      "@id": "https://w3c.github.io/json-ld-api/tests/vocab#",
-      "dc11:description": "Test case manifest vocabulary extensions",
-      "dc11:identifier": "https://w3c.github.io/json-ld-api/tests/vocab#",
-      "dc11:title": "Test case manifest vocabulary extensions",
-      "dc11:creator": "Gregg Kellogg",
-      "dc11:date": "2013-09-23",
-      "rdfs:comment": "Manifest vocabulary for JSON-LD test cases",
-      "dc11:publisher": "W3C Linked JSON Community Group"
-    },
-    {
-      "@id": "jld:input",
-      "rdfs:label": "input",
-      "rdfs:range": "rdfs:Resource",
-      "@type": "rdf:Property",
-      "rdfs:comment": "Secondary input file",
-      "rdfs:domain": "jld:Test"
-    },
-    {
-      "@id": "jld:frame",
-      "rdfs:label": "input",
-      "rdfs:range": "rdfs:Resource",
-      "@type": "rdf:Property",
-      "rdfs:comment": "A frame that is used for transforming the input document.",
-      "rdfs:domain": "jld:Test"
-    },
-    {
-      "@id": "jld:base",
-      "rdfs:label": "base",
-      "rdfs:range": "rdfs:Resource",
-      "@type": "rdf:Property",
-      "rdfs:comment": "The base IRI to use when expanding or compacting the document. If set, this overrides the input document's IRI.",
-      "rdfs:domain": "jld:Option"
-    },
-    {
-      "@id": "jld:option",
-      "rdfs:label": "option",
-      "rdfs:range": "jld:Option",
-      "@type": "rdf:Property",
-      "rdfs:comment": "Options affecting processing",
-      "rdfs:domain": "jld:Test"
     },
     {
       "@id": "jld:FlattenTest",
+      "rdfs:comment": "A `FlattenTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`.",
       "rdfs:label": "Flatten Evaluation Test",
       "@type": "rdfs:Class",
-      "rdfs:subClassOf": "jld:Test",
-      "rdfs:comment": "A `FlattenTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`."
+      "rdfs:subClassOf": "jld:Test"
+    },
+    {
+      "@id": "jld:redirectTo",
+      "rdfs:comment": "The location of a URL for redirection. A request made of the input file must be redirected to the designated URL.",
+      "rdfs:label": "redirect to",
+      "rdfs:range": "xsd:boolean",
+      "@type": "rdf:Property",
+      "rdfs:domain": "jld:Option"
+    },
+    {
+      "@id": "jld:compactToRelative",
+      "rdfs:comment": "If set to `false`, the JSON-LD processor will not attempt to compact using document-relative IRIs.",
+      "rdfs:label": "compact to relative",
+      "rdfs:range": "xsd:boolean",
+      "@type": "rdf:Property",
+      "rdfs:domain": "jld:Option"
     },
     {
       "@id": "jld:specVersion",
+      "rdfs:comment": "Indicates the JSON-LD version to which the test applies, rather than the specific processing mode. Values are \"json-ld-1.0\", and \"json-ld-1.1\". If not set, the test is presumed to be valid for all versions of JSON-LD. In cases where results differ between spec versions for the same test, the test will have both a \"1.0\" and \"1.1\" version, for example.",
       "rdfs:label": "spec version",
       "rdfs:range": "xsd:string",
       "@type": "rdf:Property",
-      "rdfs:comment": "Indicates the JSON-LD version to which the test applies, rather than the specific processing mode. Values are \"json-ld-1.0\", and \"json-ld-1.1\". If not set, the test is presumed to be valid for all versions of JSON-LD. In cases where results differ between spec versions for the same test, the test will have both a \"1.0\" and \"1.1\" version, for example.",
-      "rdfs:domain": "jld:Option"
-    },
-    {
-      "@id": "jld:produceGeneralizedRdf",
-      "rdfs:label": "produce generalized RDF",
-      "rdfs:range": "xsd:boolean",
-      "@type": "rdf:Property",
-      "rdfs:comment": "Unless the produce generalized RDF flag is set to true, RDF triples containing a blank node predicate are excluded from output.",
-      "rdfs:domain": "jld:Option"
-    },
-    {
-      "@id": "jld:processingMode",
-      "rdfs:label": "processing mode",
-      "rdfs:range": "xsd:string",
-      "@type": "rdf:Property",
-      "rdfs:comment": "If set to \"json-ld-1.1\", the JSON-LD processor must produce exactly the same results as the algorithms defined in this specification. If set to another value, the JSON-LD processor is allowed to extend or modify the algorithms defined in this specification to enable application-specific optimizations. The definition of such optimizations is beyond the scope of this specification and thus not defined. Consequently, different implementations may implement different optimizations. Developers must not define modes beginning with json-ld as they are reserved for future versions of this specification.",
-      "rdfs:domain": "jld:Option"
-    },
-    {
-      "@id": "jld:httpLink",
-      "rdfs:label": "HTTP link",
-      "rdfs:range": "xsd:boolean",
-      "@type": "rdf:Property",
-      "rdfs:comment": "An HTTP Link header to be added to the result of requesting the input file.",
-      "rdfs:domain": "jld:Option"
-    },
-    {
-      "@id": "jld:contentType",
-      "rdfs:label": "content type",
-      "rdfs:range": "xsd:boolean",
-      "@type": "rdf:Property",
-      "rdfs:comment": "The HTTP Content-Type used for the input file, in case it is a non-registered type.",
-      "rdfs:domain": "jld:Option"
-    },
-    {
-      "@id": "jld:httpAccept",
-      "rdfs:label": "HTTP Accept",
-      "rdfs:range": "xsd:boolean",
-      "@type": "rdf:Property",
-      "rdfs:comment": "An HTTP Accept header.",
       "rdfs:domain": "jld:Option"
     }
   ]
@@ -294,46 +294,60 @@ and <a href='vocab.jsonld' rel='alternate'>JSON-LD</a>.
 <section>
 <h2>Test Case Classes</h2>
 <dl>
-<dt><strong>Compact Evaluation Test</strong></dt>
+<dt><strong>Compact Evaluation Test</strong>
+(<strong>jld:CompactTest</strong>)</dt>
 <dd><p>A <code>CompactTest</code> modifies either a <code>PositiveEvaluationTest</code>, <code>NegativeEvaluationTest</code>, <code>PositiveSyntaxTest</code> or <code>NegativeSyntaxTest</code>.</p>
 </dd>
-<dt><strong>Expand Evaluation Test</strong></dt>
+<dt><strong>Expand Evaluation Test</strong>
+(<strong>jld:ExpandTest</strong>)</dt>
 <dd><p>A <code>ExpandTest</code> modifies either a <code>PositiveEvaluationTest</code>, <code>NegativeEvaluationTest</code>, <code>PositiveSyntaxTest</code> or <code>NegativeSyntaxTest</code>.</p>
 </dd>
-<dt><strong>Flatten Evaluation Test</strong></dt>
+<dt><strong>Flatten Evaluation Test</strong>
+(<strong>jld:FlattenTest</strong>)</dt>
 <dd><p>A <code>FlattenTest</code> modifies either a <code>PositiveEvaluationTest</code>, <code>NegativeEvaluationTest</code>, <code>PositiveSyntaxTest</code> or <code>NegativeSyntaxTest</code>.</p>
 </dd>
-<dt><strong>Frame Evaluation Test</strong></dt>
+<dt><strong>Frame Evaluation Test</strong>
+(<strong>jld:FrameTest</strong>)</dt>
 <dd><p>A <code>FrameTest</code> modifies either a <code>PositiveEvaluationTest</code>, <code>NegativeEvaluationTest</code>, <code>PositiveSyntaxTest</code> or <code>NegativeSyntaxTest</code>.</p>
 </dd>
-<dt><strong>From RDF Evaluation Test</strong></dt>
+<dt><strong>From RDF Evaluation Test</strong>
+(<strong>jld:FromRDFTest</strong>)</dt>
 <dd><p>A <code>FromRDFTest</code> modifies either a <code>PositiveEvaluationTest</code>, <code>NegativeEvaluationTest</code>, <code>PositiveSyntaxTest</code> or <code>NegativeSyntaxTest</code>.</p>
 </dd>
-<dt><strong>HTML Evaluation Test</strong></dt>
+<dt><strong>HTML Evaluation Test</strong>
+(<strong>jld:HtmlTest</strong>)</dt>
 <dd><p>An <code>HtmlTest</code> modifies either a <code>PositiveEvaluationTest</code> or <code>NegativeEvaluationTest</code> indicating that the source is of type text/html, which requires optional <em>HTML script extraction</em> support.</p>
 </dd>
-<dt><strong>HTTP Evaluation Test</strong></dt>
+<dt><strong>HTTP Evaluation Test</strong>
+(<strong>jld:HttpTest</strong>)</dt>
 <dd><p>An <code>HttpTest</code> modifies either a <code>PositiveEvaluationTest</code> or <code>NegativeEvaluationTest</code>.</p>
 </dd>
-<dt><strong>Negative Syntax Test</strong></dt>
-<dd><p>A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action. Negative syntax tests are tests of which the result should be a parser error.</p>
-</dd>
-<dt><strong>Negative Evaluation Test</strong></dt>
+<dt><strong>Negative Evaluation Test</strong>
+(<strong>jld:NegativeEvaluationTest</strong>)</dt>
 <dd><p>A Negative Evaluation test is successful when the result of processing the input file specified as <code>mf:action</code> (aliased as &quot;input&quot; in test manifest) results in the error identified by the literal value of <code>mf:result</code> (aliased as &quot;expectErrorCode&quot; in test manifest). The specifics of invoking test, including the interpretation of options (<code>:option</code>) and other input files are specified through another class. See the <a href="https://w3c.github.io/json-ld-api/tests/">README</a> for more details on running tests.</p>
 </dd>
-<dt><strong>Positive Evaluation Test</strong></dt>
+<dt><strong>Negative Syntax Test</strong>
+(<strong>jld:NegativeSyntaxTest</strong>)</dt>
+<dd><p>A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action. Negative syntax tests are tests of which the result should be a parser error.</p>
+</dd>
+<dt><strong>Positive Evaluation Test</strong>
+(<strong>jld:PositiveEvaluationTest</strong>)</dt>
 <dd><p>A Positive Evaluation test is successful when the result of processing the input file specified as <code>mf:action</code> (aliased as &quot;input&quot; in test manifest) exactly matches the output file specified as <code>mf:result</code> (aliased as &quot;expect&quot; in test manifest) using the comparison defined in another class. The specifics of invoking test, including the interpretation of options (<code>:option</code>) and other input files are specified through another class.</p>
 </dd>
-<dt><strong>Positive Syntax Test</strong></dt>
+<dt><strong>Positive Syntax Test</strong>
+(<strong>jld:PositiveSyntaxTest</strong>)</dt>
 <dd><p>A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action.</p>
 </dd>
-<dt><strong>Processor Options</strong></dt>
+<dt><strong>Processor Options</strong>
+(<strong>jld:Option</strong>)</dt>
 <dd><p>Options passed to the test runner to affect invocation of the appropriate API method.</p>
 </dd>
-<dt><strong>Superclass of all JSON-LD tests</strong></dt>
+<dt><strong>Superclass of all JSON-LD tests</strong>
+(<strong>jld:Test</strong>)</dt>
 <dd><p>All JSON-LD tests have an input file referenced using <code>mf:action</code> (aliased as &quot;input&quot; in test manifest). Positive and Negative Evaluation Tests also have a result file referenced using <code>mf:result</code> (aliased as &quot;expect&quot; and &quot;expectErrorCode&quot; for respectively Positive and Negative Evaluation Tests in test manifest). Other tests may take different inputs and options as defined for each test class. Tests should be run with the processingMode option set to &quot;json-ld-1.1&quot;, unless specified explicitly as a test option.</p>
 </dd>
-<dt><strong>To RDF Evaluation Test</strong></dt>
+<dt><strong>To RDF Evaluation Test</strong>
+(<strong>jld:ToRDFTest</strong>)</dt>
 <dd><p>A <code>ToRDFTest</code> modifies either a <code>PositiveEvaluationTest</code>, <code>NegativeEvaluationTest</code>, <code>PositiveSyntaxTest</code> or <code>NegativeSyntaxTest</code>.</p>
 </dd>
 </dl>
@@ -341,60 +355,186 @@ and <a href='vocab.jsonld' rel='alternate'>JSON-LD</a>.
 <section>
 <h2>Test Case Properties</h2>
 <dl>
-<dt><strong>HTTP Accept</strong></dt>
+<dt><strong>HTTP Accept</strong>
+(<strong>jld:httpAccept</strong>)</dt>
 <dd><p>An HTTP Accept header.</p>
-</dd>
-<dt><strong>HTTP link</strong></dt>
+
+<dl>
+<dt>Domain</dt>
+<dd><strong>jld:Option</strong></dd>
+<dt>Range</dt>
+<dd><strong>xsd:boolean</strong></dd>
+</dl></dd>
+<dt><strong>HTTP link</strong>
+(<strong>jld:httpLink</strong>)</dt>
 <dd><p>An HTTP Link header to be added to the result of requesting the input file.</p>
-</dd>
-<dt><strong>HTTP status</strong></dt>
+
+<dl>
+<dt>Domain</dt>
+<dd><strong>jld:Option</strong></dd>
+<dt>Range</dt>
+<dd><strong>xsd:boolean</strong></dd>
+</dl></dd>
+<dt><strong>HTTP status</strong>
+(<strong>jld:httpStatus</strong>)</dt>
 <dd><p>The HTTP status code that must be returned when the input file is requested. This is typically used along with the <code>redirectTo</code> property.</p>
-</dd>
-<dt><strong>base</strong></dt>
-<dd><p>The base IRI to use when expanding or compacting the document. If set, this overrides the input document's IRI.</p>
-</dd>
-<dt><strong>compact arrays</strong></dt>
+
+<dl>
+<dt>Domain</dt>
+<dd><strong>jld:Option</strong></dd>
+<dt>Range</dt>
+<dd><strong>xsd:boolean</strong></dd>
+</dl></dd>
+<dt><strong>base</strong>
+(<strong>jld:base</strong>)</dt>
+<dd><p>The base IRI to use when expanding or compacting the document. If set, this overrides the input document&#39;s IRI.</p>
+
+<dl>
+<dt>Domain</dt>
+<dd><strong>jld:Option</strong></dd>
+<dt>Range</dt>
+<dd><strong>rdfs:Resource</strong></dd>
+</dl></dd>
+<dt><strong>compact arrays</strong>
+(<strong>jld:compactArrays</strong>)</dt>
 <dd><p>If set to <code>true</code>, the JSON-LD processor replaces arrays with just one element with that element during compaction. If set to false, all arrays will remain arrays even if they have just one element.</p>
-</dd>
-<dt><strong>compact to relative</strong></dt>
+
+<dl>
+<dt>Domain</dt>
+<dd><strong>jld:Option</strong></dd>
+<dt>Range</dt>
+<dd><strong>xsd:boolean</strong></dd>
+</dl></dd>
+<dt><strong>compact to relative</strong>
+(<strong>jld:compactToRelative</strong>)</dt>
 <dd><p>If set to <code>false</code>, the JSON-LD processor will not attempt to compact using document-relative IRIs.</p>
-</dd>
-<dt><strong>content type</strong></dt>
+
+<dl>
+<dt>Domain</dt>
+<dd><strong>jld:Option</strong></dd>
+<dt>Range</dt>
+<dd><strong>xsd:boolean</strong></dd>
+</dl></dd>
+<dt><strong>content type</strong>
+(<strong>jld:contentType</strong>)</dt>
 <dd><p>The HTTP Content-Type used for the input file, in case it is a non-registered type.</p>
-</dd>
-<dt><strong>context</strong></dt>
+
+<dl>
+<dt>Domain</dt>
+<dd><strong>jld:Option</strong></dd>
+<dt>Range</dt>
+<dd><strong>xsd:boolean</strong></dd>
+</dl></dd>
+<dt><strong>context</strong>
+(<strong>jld:context</strong>)</dt>
 <dd><p>A context that is used for transforming the input document.</p>
-</dd>
-<dt><strong>expand context</strong></dt>
+
+<dl>
+<dt>Domain</dt>
+<dd><strong>jld:Test</strong></dd>
+<dt>Range</dt>
+<dd><strong>rdfs:Resource</strong></dd>
+</dl></dd>
+<dt><strong>expand context</strong>
+(<strong>jld:expandContext</strong>)</dt>
 <dd><p>A context that is used to initialize the active context when expanding a document.</p>
-</dd>
-<dt><strong>input</strong></dt>
-<dd><p>Secondary input file</p>
-</dd>
-<dt><strong>input</strong></dt>
+
+<dl>
+<dt>Domain</dt>
+<dd><strong>jld:Option</strong></dd>
+<dt>Range</dt>
+<dd><strong>rdfs:Resource</strong></dd>
+</dl></dd>
+<dt><strong>input</strong>
+(<strong>jld:frame</strong>)</dt>
 <dd><p>A frame that is used for transforming the input document.</p>
-</dd>
-<dt><strong>option</strong></dt>
+
+<dl>
+<dt>Domain</dt>
+<dd><strong>jld:Test</strong></dd>
+<dt>Range</dt>
+<dd><strong>rdfs:Resource</strong></dd>
+</dl></dd>
+<dt><strong>input</strong>
+(<strong>jld:input</strong>)</dt>
+<dd><p>Secondary input file</p>
+
+<dl>
+<dt>Domain</dt>
+<dd><strong>jld:Test</strong></dd>
+<dt>Range</dt>
+<dd><strong>rdfs:Resource</strong></dd>
+</dl></dd>
+<dt><strong>option</strong>
+(<strong>jld:option</strong>)</dt>
 <dd><p>Options affecting processing</p>
-</dd>
-<dt><strong>processing mode</strong></dt>
+
+<dl>
+<dt>Domain</dt>
+<dd><strong>jld:Test</strong></dd>
+<dt>Range</dt>
+<dd><strong>jld:Option</strong></dd>
+</dl></dd>
+<dt><strong>processing mode</strong>
+(<strong>jld:processingMode</strong>)</dt>
 <dd><p>If set to &quot;json-ld-1.1&quot;, the JSON-LD processor must produce exactly the same results as the algorithms defined in this specification. If set to another value, the JSON-LD processor is allowed to extend or modify the algorithms defined in this specification to enable application-specific optimizations. The definition of such optimizations is beyond the scope of this specification and thus not defined. Consequently, different implementations may implement different optimizations. Developers must not define modes beginning with json-ld as they are reserved for future versions of this specification.</p>
-</dd>
-<dt><strong>produce generalized RDF</strong></dt>
+
+<dl>
+<dt>Domain</dt>
+<dd><strong>jld:Option</strong></dd>
+<dt>Range</dt>
+<dd><strong>xsd:string</strong></dd>
+</dl></dd>
+<dt><strong>produce generalized RDF</strong>
+(<strong>jld:produceGeneralizedRdf</strong>)</dt>
 <dd><p>Unless the produce generalized RDF flag is set to true, RDF triples containing a blank node predicate are excluded from output.</p>
-</dd>
-<dt><strong>redirect to</strong></dt>
+
+<dl>
+<dt>Domain</dt>
+<dd><strong>jld:Option</strong></dd>
+<dt>Range</dt>
+<dd><strong>xsd:boolean</strong></dd>
+</dl></dd>
+<dt><strong>redirect to</strong>
+(<strong>jld:redirectTo</strong>)</dt>
 <dd><p>The location of a URL for redirection. A request made of the input file must be redirected to the designated URL.</p>
-</dd>
-<dt><strong>spec version</strong></dt>
+
+<dl>
+<dt>Domain</dt>
+<dd><strong>jld:Option</strong></dd>
+<dt>Range</dt>
+<dd><strong>xsd:boolean</strong></dd>
+</dl></dd>
+<dt><strong>spec version</strong>
+(<strong>jld:specVersion</strong>)</dt>
 <dd><p>Indicates the JSON-LD version to which the test applies, rather than the specific processing mode. Values are &quot;json-ld-1.0&quot;, and &quot;json-ld-1.1&quot;. If not set, the test is presumed to be valid for all versions of JSON-LD. In cases where results differ between spec versions for the same test, the test will have both a &quot;1.0&quot; and &quot;1.1&quot; version, for example.</p>
-</dd>
-<dt><strong>use RDF types</strong></dt>
+
+<dl>
+<dt>Domain</dt>
+<dd><strong>jld:Option</strong></dd>
+<dt>Range</dt>
+<dd><strong>xsd:string</strong></dd>
+</dl></dd>
+<dt><strong>use RDF types</strong>
+(<strong>jld:useRdfType</strong>)</dt>
 <dd><p>If the <em>use rdf type</em> flag is set to <code>true</code>, statements with an <code>rdf:type</code> predicate will not use <code>@type</code>, but will be transformed as a normal property.</p>
-</dd>
-<dt><strong>use native types</strong></dt>
+
+<dl>
+<dt>Domain</dt>
+<dd><strong>jld:Option</strong></dd>
+<dt>Range</dt>
+<dd><strong>xsd:boolean</strong></dd>
+</dl></dd>
+<dt><strong>use native types</strong>
+(<strong>jld:useNativeTypes</strong>)</dt>
 <dd><p>If the <em>use native types</em> flag is set to <code>true</code>, RDF literals with a datatype IRI that equal <code>xsd:integer</code> or <code>xsd:double</code> are converted to a JSON numbers and RDF literals with a datatype IRI that equals <code>xsd:boolean</code> are converted to <code>true</code> or <code>false</code> based on their lexical form.</p>
-</dd>
+
+<dl>
+<dt>Domain</dt>
+<dd><strong>jld:Option</strong></dd>
+<dt>Range</dt>
+<dd><strong>xsd:boolean</strong></dd>
+</dl></dd>
 </dl>
 </section>
 <footer>

--- a/tests/vocab.jsonld
+++ b/tests/vocab.jsonld
@@ -24,253 +24,253 @@
   },
   "@graph": [
     {
-      "@id": "jld:compactArrays",
-      "rdfs:label": "compact arrays",
+      "@id": "jld:contentType",
+      "rdfs:comment": "The HTTP Content-Type used for the input file, in case it is a non-registered type.",
+      "rdfs:label": "content type",
       "rdfs:range": "xsd:boolean",
       "@type": "rdf:Property",
-      "rdfs:comment": "If set to `true`, the JSON-LD processor replaces arrays with just one element with that element during compaction. If set to false, all arrays will remain arrays even if they have just one element.",
       "rdfs:domain": "jld:Option"
     },
     {
       "@id": "jld:Option",
+      "rdfs:comment": "Options passed to the test runner to affect invocation of the appropriate API method.",
       "rdfs:label": "Processor Options",
-      "@type": "rdfs:Class",
-      "rdfs:comment": "Options passed to the test runner to affect invocation of the appropriate API method."
+      "@type": "rdfs:Class"
     },
     {
-      "@id": "jld:redirectTo",
-      "rdfs:label": "redirect to",
+      "@id": "jld:CompactTest",
+      "rdfs:comment": "A `CompactTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`.",
+      "rdfs:label": "Compact Evaluation Test",
+      "@type": "rdfs:Class",
+      "rdfs:subClassOf": "jld:Test"
+    },
+    {
+      "@id": "jld:Test",
+      "rdfs:comment": "All JSON-LD tests have an input file referenced using `mf:action` (aliased as \"input\" in test manifest). Positive and Negative Evaluation Tests also have a result file referenced using `mf:result` (aliased as \"expect\" and \"expectErrorCode\" for respectively Positive and Negative Evaluation Tests in test manifest). Other tests may take different inputs and options as defined for each test class. Tests should be run with the processingMode option set to \"json-ld-1.1\", unless specified explicitly as a test option.",
+      "rdfs:label": "Superclass of all JSON-LD tests",
+      "@type": "rdfs:Class"
+    },
+    {
+      "@id": "jld:httpAccept",
+      "rdfs:comment": "An HTTP Accept header.",
+      "rdfs:label": "HTTP Accept",
       "rdfs:range": "xsd:boolean",
       "@type": "rdf:Property",
-      "rdfs:comment": "The location of a URL for redirection. A request made of the input file must be redirected to the designated URL.",
+      "rdfs:domain": "jld:Option"
+    },
+    {
+      "@id": "jld:frame",
+      "rdfs:comment": "A frame that is used for transforming the input document.",
+      "rdfs:label": "input",
+      "rdfs:range": "rdfs:Resource",
+      "@type": "rdf:Property",
+      "rdfs:domain": "jld:Test"
+    },
+    {
+      "@id": "jld:FrameTest",
+      "rdfs:comment": "A `FrameTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`.",
+      "rdfs:label": "Frame Evaluation Test",
+      "@type": "rdfs:Class",
+      "rdfs:subClassOf": "jld:Test"
+    },
+    {
+      "@id": "jld:produceGeneralizedRdf",
+      "rdfs:comment": "Unless the produce generalized RDF flag is set to true, RDF triples containing a blank node predicate are excluded from output.",
+      "rdfs:label": "produce generalized RDF",
+      "rdfs:range": "xsd:boolean",
+      "@type": "rdf:Property",
+      "rdfs:domain": "jld:Option"
+    },
+    {
+      "@id": "jld:FromRDFTest",
+      "rdfs:comment": "A `FromRDFTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`.",
+      "rdfs:label": "From RDF Evaluation Test",
+      "@type": "rdfs:Class",
+      "rdfs:subClassOf": "jld:Test"
+    },
+    {
+      "@id": "jld:PositiveSyntaxTest",
+      "rdfs:comment": "A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action.",
+      "rdfs:label": "Positive Syntax Test",
+      "@type": "rdfs:Class",
+      "rdfs:subClassOf": "jld:Test"
+    },
+    {
+      "@id": "jld:ExpandTest",
+      "rdfs:comment": "A `ExpandTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`.",
+      "rdfs:label": "Expand Evaluation Test",
+      "@type": "rdfs:Class",
+      "rdfs:subClassOf": "jld:Test"
+    },
+    {
+      "@id": "jld:PositiveEvaluationTest",
+      "rdfs:comment": "A Positive Evaluation test is successful when the result of processing the input file specified as `mf:action` (aliased as \"input\" in test manifest) exactly matches the output file specified as `mf:result` (aliased as \"expect\" in test manifest) using the comparison defined in another class. The specifics of invoking test, including the interpretation of options (`:option`) and other input files are specified through another class.",
+      "rdfs:label": "Positive Evaluation Test",
+      "@type": "rdfs:Class",
+      "rdfs:subClassOf": "jld:Test"
+    },
+    {
+      "@id": "jld:option",
+      "rdfs:comment": "Options affecting processing",
+      "rdfs:label": "option",
+      "rdfs:range": "jld:Option",
+      "@type": "rdf:Property",
+      "rdfs:domain": "jld:Test"
+    },
+    {
+      "@id": "jld:NegativeEvaluationTest",
+      "rdfs:comment": "A Negative Evaluation test is successful when the result of processing the input file specified as `mf:action` (aliased as \"input\" in test manifest) results in the error identified by the literal value of `mf:result` (aliased as \"expectErrorCode\" in test manifest). The specifics of invoking test, including the interpretation of options (`:option`) and other input files are specified through another class. See the [README](https://w3c.github.io/json-ld-api/tests/) for more details on running tests.",
+      "rdfs:label": "Negative Evaluation Test",
+      "@type": "rdfs:Class",
+      "rdfs:subClassOf": "jld:Test"
+    },
+    {
+      "@id": "jld:base",
+      "rdfs:comment": "The base IRI to use when expanding or compacting the document. If set, this overrides the input document's IRI.",
+      "rdfs:label": "base",
+      "rdfs:range": "rdfs:Resource",
+      "@type": "rdf:Property",
       "rdfs:domain": "jld:Option"
     },
     {
       "@id": "jld:NegativeSyntaxTest",
+      "rdfs:comment": "A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action. Negative syntax tests are tests of which the result should be a parser error.",
       "rdfs:label": "Negative Syntax Test",
       "@type": "rdfs:Class",
-      "rdfs:subClassOf": "jld:Test",
-      "rdfs:comment": "A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action. Negative syntax tests are tests of which the result should be a parser error."
+      "rdfs:subClassOf": "jld:Test"
     },
     {
-      "@id": "jld:Test",
-      "rdfs:label": "Superclass of all JSON-LD tests",
-      "@type": "rdfs:Class",
-      "rdfs:comment": "All JSON-LD tests have an input file referenced using `mf:action` (aliased as \"input\" in test manifest). Positive and Negative Evaluation Tests also have a result file referenced using `mf:result` (aliased as \"expect\" and \"expectErrorCode\" for respectively Positive and Negative Evaluation Tests in test manifest). Other tests may take different inputs and options as defined for each test class. Tests should be run with the processingMode option set to \"json-ld-1.1\", unless specified explicitly as a test option."
-    },
-    {
-      "@id": "jld:useNativeTypes",
-      "rdfs:label": "use native types",
+      "@id": "jld:compactArrays",
+      "rdfs:comment": "If set to `true`, the JSON-LD processor replaces arrays with just one element with that element during compaction. If set to false, all arrays will remain arrays even if they have just one element.",
+      "rdfs:label": "compact arrays",
       "rdfs:range": "xsd:boolean",
       "@type": "rdf:Property",
-      "rdfs:comment": "If the _use native types_ flag is set to `true`, RDF literals with a datatype IRI that equal `xsd:integer` or `xsd:double` are converted to a JSON numbers and RDF literals with a datatype IRI that equals `xsd:boolean` are converted to `true` or `false` based on their lexical form.",
       "rdfs:domain": "jld:Option"
     },
     {
+      "@id": "https://w3c.github.io/json-ld-api/tests/vocab#",
+      "rdfs:comment": "Manifest vocabulary for JSON-LD test cases",
+      "dc11:publisher": "W3C Linked JSON Community Group",
+      "dc11:description": "Test case manifest vocabulary extensions",
+      "dc11:identifier": "https://w3c.github.io/json-ld-api/tests/vocab#",
+      "dc11:title": "Test case manifest vocabulary extensions",
+      "dc11:date": "2013-09-23",
+      "dc11:creator": "Gregg Kellogg"
+    },
+    {
       "@id": "jld:context",
+      "rdfs:comment": "A context that is used for transforming the input document.",
       "rdfs:label": "context",
       "rdfs:range": "rdfs:Resource",
       "@type": "rdf:Property",
-      "rdfs:comment": "A context that is used for transforming the input document.",
       "rdfs:domain": "jld:Test"
     },
     {
-      "@id": "jld:FromRDFTest",
-      "rdfs:label": "From RDF Evaluation Test",
-      "@type": "rdfs:Class",
-      "rdfs:subClassOf": "jld:Test",
-      "rdfs:comment": "A `FromRDFTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`."
-    },
-    {
       "@id": "jld:httpStatus",
+      "rdfs:comment": "The HTTP status code that must be returned when the input file is requested. This is typically used along with the `redirectTo` property.",
       "rdfs:label": "HTTP status",
       "rdfs:range": "xsd:boolean",
       "@type": "rdf:Property",
-      "rdfs:comment": "The HTTP status code that must be returned when the input file is requested. This is typically used along with the `redirectTo` property.",
+      "rdfs:domain": "jld:Option"
+    },
+    {
+      "@id": "jld:ToRDFTest",
+      "rdfs:comment": "A `ToRDFTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`.",
+      "rdfs:label": "To RDF Evaluation Test",
+      "@type": "rdfs:Class",
+      "rdfs:subClassOf": "jld:Test"
+    },
+    {
+      "@id": "jld:httpLink",
+      "rdfs:comment": "An HTTP Link header to be added to the result of requesting the input file.",
+      "rdfs:label": "HTTP link",
+      "rdfs:range": "xsd:boolean",
+      "@type": "rdf:Property",
+      "rdfs:domain": "jld:Option"
+    },
+    {
+      "@id": "jld:input",
+      "rdfs:comment": "Secondary input file",
+      "rdfs:label": "input",
+      "rdfs:range": "rdfs:Resource",
+      "@type": "rdf:Property",
+      "rdfs:domain": "jld:Test"
+    },
+    {
+      "@id": "jld:HtmlTest",
+      "rdfs:comment": "An `HtmlTest` modifies either a `PositiveEvaluationTest` or `NegativeEvaluationTest` indicating that the source is of type text/html, which requires optional _HTML script extraction_ support.",
+      "rdfs:label": "HTML Evaluation Test",
+      "@type": "rdfs:Class",
+      "rdfs:subClassOf": "jld:Test"
+    },
+    {
+      "@id": "jld:HttpTest",
+      "rdfs:comment": "An `HttpTest` modifies either a `PositiveEvaluationTest` or `NegativeEvaluationTest`.",
+      "rdfs:label": "HTTP Evaluation Test",
+      "@type": "rdfs:Class",
+      "rdfs:subClassOf": "jld:Test"
+    },
+    {
+      "@id": "jld:processingMode",
+      "rdfs:comment": "If set to \"json-ld-1.1\", the JSON-LD processor must produce exactly the same results as the algorithms defined in this specification. If set to another value, the JSON-LD processor is allowed to extend or modify the algorithms defined in this specification to enable application-specific optimizations. The definition of such optimizations is beyond the scope of this specification and thus not defined. Consequently, different implementations may implement different optimizations. Developers must not define modes beginning with json-ld as they are reserved for future versions of this specification.",
+      "rdfs:label": "processing mode",
+      "rdfs:range": "xsd:string",
+      "@type": "rdf:Property",
+      "rdfs:domain": "jld:Option"
+    },
+    {
+      "@id": "jld:useNativeTypes",
+      "rdfs:comment": "If the _use native types_ flag is set to `true`, RDF literals with a datatype IRI that equal `xsd:integer` or `xsd:double` are converted to a JSON numbers and RDF literals with a datatype IRI that equals `xsd:boolean` are converted to `true` or `false` based on their lexical form.",
+      "rdfs:label": "use native types",
+      "rdfs:range": "xsd:boolean",
+      "@type": "rdf:Property",
+      "rdfs:domain": "jld:Option"
+    },
+    {
+      "@id": "jld:expandContext",
+      "rdfs:comment": "A context that is used to initialize the active context when expanding a document.",
+      "rdfs:label": "expand context",
+      "rdfs:range": "rdfs:Resource",
+      "@type": "rdf:Property",
       "rdfs:domain": "jld:Option"
     },
     {
       "@id": "jld:useRdfType",
+      "rdfs:comment": "If the _use rdf type_ flag is set to `true`, statements with an `rdf:type` predicate will not use `@type`, but will be transformed as a normal property.",
       "rdfs:label": "use RDF types",
       "rdfs:range": "xsd:boolean",
       "@type": "rdf:Property",
-      "rdfs:comment": "If the _use rdf type_ flag is set to `true`, statements with an `rdf:type` predicate will not use `@type`, but will be transformed as a normal property.",
       "rdfs:domain": "jld:Option"
-    },
-    {
-      "@id": "jld:NegativeEvaluationTest",
-      "rdfs:label": "Negative Evaluation Test",
-      "@type": "rdfs:Class",
-      "rdfs:subClassOf": "jld:Test",
-      "rdfs:comment": "A Negative Evaluation test is successful when the result of processing the input file specified as `mf:action` (aliased as \"input\" in test manifest) results in the error identified by the literal value of `mf:result` (aliased as \"expectErrorCode\" in test manifest). The specifics of invoking test, including the interpretation of options (`:option`) and other input files are specified through another class. See the [README](https://w3c.github.io/json-ld-api/tests/) for more details on running tests."
-    },
-    {
-      "@id": "jld:HtmlTest",
-      "rdfs:label": "HTML Evaluation Test",
-      "@type": "rdfs:Class",
-      "rdfs:subClassOf": "jld:Test",
-      "rdfs:comment": "An `HtmlTest` modifies either a `PositiveEvaluationTest` or `NegativeEvaluationTest` indicating that the source is of type text/html, which requires optional _HTML script extraction_ support."
-    },
-    {
-      "@id": "jld:compactToRelative",
-      "rdfs:label": "compact to relative",
-      "rdfs:range": "xsd:boolean",
-      "@type": "rdf:Property",
-      "rdfs:comment": "If set to `false`, the JSON-LD processor will not attempt to compact using document-relative IRIs.",
-      "rdfs:domain": "jld:Option"
-    },
-    {
-      "@id": "jld:PositiveSyntaxTest",
-      "rdfs:label": "Positive Syntax Test",
-      "@type": "rdfs:Class",
-      "rdfs:subClassOf": "jld:Test",
-      "rdfs:comment": "A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action."
-    },
-    {
-      "@id": "jld:ToRDFTest",
-      "rdfs:label": "To RDF Evaluation Test",
-      "@type": "rdfs:Class",
-      "rdfs:subClassOf": "jld:Test",
-      "rdfs:comment": "A `ToRDFTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`."
-    },
-    {
-      "@id": "jld:ExpandTest",
-      "rdfs:label": "Expand Evaluation Test",
-      "@type": "rdfs:Class",
-      "rdfs:subClassOf": "jld:Test",
-      "rdfs:comment": "A `ExpandTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`."
-    },
-    {
-      "@id": "jld:HttpTest",
-      "rdfs:label": "HTTP Evaluation Test",
-      "@type": "rdfs:Class",
-      "rdfs:subClassOf": "jld:Test",
-      "rdfs:comment": "An `HttpTest` modifies either a `PositiveEvaluationTest` or `NegativeEvaluationTest`."
-    },
-    {
-      "@id": "jld:PositiveEvaluationTest",
-      "rdfs:label": "Positive Evaluation Test",
-      "@type": "rdfs:Class",
-      "rdfs:subClassOf": "jld:Test",
-      "rdfs:comment": "A Positive Evaluation test is successful when the result of processing the input file specified as `mf:action` (aliased as \"input\" in test manifest) exactly matches the output file specified as `mf:result` (aliased as \"expect\" in test manifest) using the comparison defined in another class. The specifics of invoking test, including the interpretation of options (`:option`) and other input files are specified through another class."
-    },
-    {
-      "@id": "jld:expandContext",
-      "rdfs:label": "expand context",
-      "rdfs:range": "rdfs:Resource",
-      "@type": "rdf:Property",
-      "rdfs:comment": "A context that is used to initialize the active context when expanding a document.",
-      "rdfs:domain": "jld:Option"
-    },
-    {
-      "@id": "jld:FrameTest",
-      "rdfs:label": "Frame Evaluation Test",
-      "@type": "rdfs:Class",
-      "rdfs:subClassOf": "jld:Test",
-      "rdfs:comment": "A `FrameTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`."
-    },
-    {
-      "@id": "jld:CompactTest",
-      "rdfs:label": "Compact Evaluation Test",
-      "@type": "rdfs:Class",
-      "rdfs:subClassOf": "jld:Test",
-      "rdfs:comment": "A `CompactTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`."
-    },
-    {
-      "@id": "https://w3c.github.io/json-ld-api/tests/vocab#",
-      "dc11:description": "Test case manifest vocabulary extensions",
-      "dc11:identifier": "https://w3c.github.io/json-ld-api/tests/vocab#",
-      "dc11:title": "Test case manifest vocabulary extensions",
-      "dc11:creator": "Gregg Kellogg",
-      "dc11:date": "2013-09-23",
-      "rdfs:comment": "Manifest vocabulary for JSON-LD test cases",
-      "dc11:publisher": "W3C Linked JSON Community Group"
-    },
-    {
-      "@id": "jld:input",
-      "rdfs:label": "input",
-      "rdfs:range": "rdfs:Resource",
-      "@type": "rdf:Property",
-      "rdfs:comment": "Secondary input file",
-      "rdfs:domain": "jld:Test"
-    },
-    {
-      "@id": "jld:frame",
-      "rdfs:label": "input",
-      "rdfs:range": "rdfs:Resource",
-      "@type": "rdf:Property",
-      "rdfs:comment": "A frame that is used for transforming the input document.",
-      "rdfs:domain": "jld:Test"
-    },
-    {
-      "@id": "jld:base",
-      "rdfs:label": "base",
-      "rdfs:range": "rdfs:Resource",
-      "@type": "rdf:Property",
-      "rdfs:comment": "The base IRI to use when expanding or compacting the document. If set, this overrides the input document's IRI.",
-      "rdfs:domain": "jld:Option"
-    },
-    {
-      "@id": "jld:option",
-      "rdfs:label": "option",
-      "rdfs:range": "jld:Option",
-      "@type": "rdf:Property",
-      "rdfs:comment": "Options affecting processing",
-      "rdfs:domain": "jld:Test"
     },
     {
       "@id": "jld:FlattenTest",
+      "rdfs:comment": "A `FlattenTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`.",
       "rdfs:label": "Flatten Evaluation Test",
       "@type": "rdfs:Class",
-      "rdfs:subClassOf": "jld:Test",
-      "rdfs:comment": "A `FlattenTest` modifies either a `PositiveEvaluationTest`, `NegativeEvaluationTest`, `PositiveSyntaxTest` or `NegativeSyntaxTest`."
+      "rdfs:subClassOf": "jld:Test"
+    },
+    {
+      "@id": "jld:redirectTo",
+      "rdfs:comment": "The location of a URL for redirection. A request made of the input file must be redirected to the designated URL.",
+      "rdfs:label": "redirect to",
+      "rdfs:range": "xsd:boolean",
+      "@type": "rdf:Property",
+      "rdfs:domain": "jld:Option"
+    },
+    {
+      "@id": "jld:compactToRelative",
+      "rdfs:comment": "If set to `false`, the JSON-LD processor will not attempt to compact using document-relative IRIs.",
+      "rdfs:label": "compact to relative",
+      "rdfs:range": "xsd:boolean",
+      "@type": "rdf:Property",
+      "rdfs:domain": "jld:Option"
     },
     {
       "@id": "jld:specVersion",
+      "rdfs:comment": "Indicates the JSON-LD version to which the test applies, rather than the specific processing mode. Values are \"json-ld-1.0\", and \"json-ld-1.1\". If not set, the test is presumed to be valid for all versions of JSON-LD. In cases where results differ between spec versions for the same test, the test will have both a \"1.0\" and \"1.1\" version, for example.",
       "rdfs:label": "spec version",
       "rdfs:range": "xsd:string",
       "@type": "rdf:Property",
-      "rdfs:comment": "Indicates the JSON-LD version to which the test applies, rather than the specific processing mode. Values are \"json-ld-1.0\", and \"json-ld-1.1\". If not set, the test is presumed to be valid for all versions of JSON-LD. In cases where results differ between spec versions for the same test, the test will have both a \"1.0\" and \"1.1\" version, for example.",
-      "rdfs:domain": "jld:Option"
-    },
-    {
-      "@id": "jld:produceGeneralizedRdf",
-      "rdfs:label": "produce generalized RDF",
-      "rdfs:range": "xsd:boolean",
-      "@type": "rdf:Property",
-      "rdfs:comment": "Unless the produce generalized RDF flag is set to true, RDF triples containing a blank node predicate are excluded from output.",
-      "rdfs:domain": "jld:Option"
-    },
-    {
-      "@id": "jld:processingMode",
-      "rdfs:label": "processing mode",
-      "rdfs:range": "xsd:string",
-      "@type": "rdf:Property",
-      "rdfs:comment": "If set to \"json-ld-1.1\", the JSON-LD processor must produce exactly the same results as the algorithms defined in this specification. If set to another value, the JSON-LD processor is allowed to extend or modify the algorithms defined in this specification to enable application-specific optimizations. The definition of such optimizations is beyond the scope of this specification and thus not defined. Consequently, different implementations may implement different optimizations. Developers must not define modes beginning with json-ld as they are reserved for future versions of this specification.",
-      "rdfs:domain": "jld:Option"
-    },
-    {
-      "@id": "jld:httpLink",
-      "rdfs:label": "HTTP link",
-      "rdfs:range": "xsd:boolean",
-      "@type": "rdf:Property",
-      "rdfs:comment": "An HTTP Link header to be added to the result of requesting the input file.",
-      "rdfs:domain": "jld:Option"
-    },
-    {
-      "@id": "jld:contentType",
-      "rdfs:label": "content type",
-      "rdfs:range": "xsd:boolean",
-      "@type": "rdf:Property",
-      "rdfs:comment": "The HTTP Content-Type used for the input file, in case it is a non-registered type.",
-      "rdfs:domain": "jld:Option"
-    },
-    {
-      "@id": "jld:httpAccept",
-      "rdfs:label": "HTTP Accept",
-      "rdfs:range": "xsd:boolean",
-      "@type": "rdf:Property",
-      "rdfs:comment": "An HTTP Accept header.",
       "rdfs:domain": "jld:Option"
     }
   ]

--- a/tests/vocab_template.haml
+++ b/tests/vocab_template.haml
@@ -23,6 +23,8 @@
         - classes.each do |cls|
           %dt<
             %strong<~cls["rdfs:label"]
+            = surround '(', ')' do
+              %strong<~cls['@id']
           %dd<
             :markdown
               #{cls["rdfs:comment"].to_s.gsub(/^\s+/, '')}
@@ -32,8 +34,19 @@
         - properties.each do |prop|
           %dt<
             %strong<~prop["rdfs:label"]
+            = surround '(', ')' do
+              %strong<~prop['@id']
           %dd<
             :markdown
               #{prop["rdfs:comment"].to_s.gsub(/^\s+/, '')}
+            %dl
+              - if prop['rdfs:domain']
+                %dt="Domain"
+                %dd<
+                  %strong=prop['rdfs:domain']
+              - if prop['rdfs:range']
+                %dt="Range"
+                %dd<
+                  %strong=prop['rdfs:range']
     %footer
       %span<= ontology["dc11:publisher"]


### PR DESCRIPTION
* It MAY be added on requests, and MUST be handled in responses.
* Add xhtml version of html/e001.
* Update test vocabulary, README, and manifest descriptions to describe default content types for test case properties identifying files, and how the _contentType_ option will override that for the _input_property.

For #244.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/250.html" title="Last updated on Dec 19, 2019, 9:18 PM UTC (b8df302)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/250/4b33c52...b8df302.html" title="Last updated on Dec 19, 2019, 9:18 PM UTC (b8df302)">Diff</a>