### PR TITLE
Add test for JSON literal with a context.

### DIFF
--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -6472,6 +6472,34 @@ Test tjs14 Expand JSON literal with aliased @value
 </dd>
 </dl>
 </dd>
+<dt id='tjs21'>
+Test tjs21 Expand JSON literal with @context
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tjs21</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>Tests expanding JSON literal with a @context.</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/js21-in.jsonld'>expand/js21-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='expand/js21-out.jsonld'>expand/js21-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
 <dt id='tl001'>
 Test tl001 Language map with null value
 </dt>

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -1928,6 +1928,14 @@
       "expect": "expand/js20-out.jsonld",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tjs21",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Expand JSON literal with @context",
+      "purpose": "Tests expanding JSON literal with a @context.",
+      "input": "expand/js21-in.jsonld",
+      "expect": "expand/js21-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tl001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "Language map with null value",

--- a/tests/expand/js21-in.jsonld
+++ b/tests/expand/js21-in.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "ex:foo": {
+      "@type": "@json"
+    }
+  },
+  "ex:foo": {
+    "@context": "ex:not:a:context",
+    "test": 1
+  }
+}

--- a/tests/expand/js21-out.jsonld
+++ b/tests/expand/js21-out.jsonld
@@ -1,0 +1,9 @@
+[{
+  "ex:foo": [{
+    "@type": "@json",
+    "@value": {
+      "@context": "ex:not:a:context",
+      "test": 1
+    }
+  }]
+}]

--- a/tests/toRdf-manifest.html
+++ b/tests/toRdf-manifest.html
@@ -6149,6 +6149,34 @@ Test tjs20 Transform JSON literal with aliased @value
 </dd>
 </dl>
 </dd>
+<dt id='tjs21'>
+Test tjs21 Transform JSON literal with @context
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tjs21</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Tests transforming JSON literal with a @context.</dd>
+<dt>input</dt>
+<dd>
+<a href='toRdf/js21-in.jsonld'>toRdf/js21-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='toRdf/js21-out.nq'>toRdf/js21-out.nq</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
 <dt id='tli01'>
 Test tli01 @list containing @list
 </dt>

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -1877,6 +1877,14 @@
       "expect": "toRdf/js20-out.nq",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tjs21",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Transform JSON literal with @context",
+      "purpose": "Tests transforming JSON literal with a @context.",
+      "input": "toRdf/js21-in.jsonld",
+      "expect": "toRdf/js21-out.nq",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tli01",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
       "name": "@list containing @list",

--- a/tests/toRdf/js21-in.jsonld
+++ b/tests/toRdf/js21-in.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "ex:foo": {
+      "@type": "@json"
+    }
+  },
+  "ex:foo": {
+    "@context": "ex:not:a:context",
+    "test": 1
+  }
+}

--- a/tests/toRdf/js21-out.nq
+++ b/tests/toRdf/js21-out.nq
@@ -1,0 +1,1 @@
+_:c14n0 <ex:foo> "{\"@context\":\"ex:not:a:context\",\"test\":1}"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON> .


### PR DESCRIPTION
Tests that no processing is done on a `@context`.

This is a test for https://github.com/w3c/json-ld-api/issues/237.
