### PR TITLE
Change inline note to block note in Create Term Definition step 16.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1620,7 +1620,8 @@
           to <code>false</code>.</li>
         <li class="changed">If <var>value</var> contains the <a>entry</a> <code>@id</code> and its value
           neither equals <var>term</var> nor is <code>null</code>:
-          <div id="ctd-id-null" class="note">If `null`, the term is not used for IRI expansion, but is
+          <div id="ctd-id-null" class="note">If the `@id` entry is `null`,
+            the term is not used for IRI expansion, but is
             retained to be able to detect future redefinitions of this term.</div>
           <ol>
             <li>If the value associated with the <code>@id</code> <a>entry</a> is not a <a>string</a>, an

--- a/index.html
+++ b/index.html
@@ -1619,9 +1619,9 @@
         <li>Set the <a>reverse property</a> flag of <var>definition</var>
           to <code>false</code>.</li>
         <li class="changed">If <var>value</var> contains the <a>entry</a> <code>@id</code> and its value
-          neither equals <var>term</var> nor is <code>null</code>
-          <span id="ctd-id-null" class="note">If `null`, the term is not used for IRI expansion, but is
-            retained to be able to detect future redefinitions of this term.</span>:
+          neither equals <var>term</var> nor is <code>null</code>:
+          <div id="ctd-id-null" class="note">If `null`, the term is not used for IRI expansion, but is
+            retained to be able to detect future redefinitions of this term.</div>
           <ol>
             <li>If the value associated with the <code>@id</code> <a>entry</a> is not a <a>string</a>, an
               <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>


### PR DESCRIPTION
For #241.

@davidlehn and @kasei, I change the inline note to a block note, but I don't think it improves it. Please suggest any other changes you think would improve both formatting and clarity.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/273.html" title="Last updated on Dec 23, 2019, 8:09 PM UTC (12c9e21)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/273/3e9626a...12c9e21.html" title="Last updated on Dec 23, 2019, 8:09 PM UTC (12c9e21)">Diff</a>