### PR TITLE
Adds tests for null json literals, and fixes one expected result

### DIFF
--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -6445,7 +6445,7 @@ Test tjs21 Expand JSON literal with @context
 </dl>
 </dd>
 <dt id='tjs22'>
-Test tjs22 Expand JSON literal (null).
+Test tjs22 Expand JSON literal (null) aleady in expanded form.
 </dt>
 <dd>
 <dl class='entry'>
@@ -6462,34 +6462,6 @@ Test tjs22 Expand JSON literal (null).
 <dt>expect</dt>
 <dd>
 <a href='expand/js22-out.jsonld'>expand/js22-out.jsonld</a>
-</dd>
-<dt>Options</dt>
-<dd>
-<dl class='options'>
-<dt>specVersion</dt>
-<dd>json-ld-1.1</dd>
-</dl>
-</dd>
-</dl>
-</dd>
-<dt id='tjs23'>
-Test tjs23 Expand JSON literal (null) aleady in expanded form.
-</dt>
-<dd>
-<dl class='entry'>
-<dt>id</dt>
-<dd>#tjs23</dd>
-<dt>Type</dt>
-<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
-<dt>Purpose</dt>
-<dd>Tests expanding property with @type @json to a JSON literal (null).</dd>
-<dt>input</dt>
-<dd>
-<a href='expand/js23-in.jsonld'>expand/js23-in.jsonld</a>
-</dd>
-<dt>expect</dt>
-<dd>
-<a href='expand/js23-out.jsonld'>expand/js23-out.jsonld</a>
 </dd>
 <dt>Options</dt>
 <dd>

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -5614,7 +5614,7 @@ Test tin01 Basic Included array
 <dt>Type</dt>
 <dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
 <dt>Purpose</dt>
-<dd>Tests included maps.</dd>
+<dd>Tests included blocks.</dd>
 <dt>input</dt>
 <dd>
 <a href='expand/in01-in.jsonld'>expand/in01-in.jsonld</a>
@@ -5642,7 +5642,7 @@ Test tin02 Basic Included object
 <dt>Type</dt>
 <dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
 <dt>Purpose</dt>
-<dd>Tests included maps.</dd>
+<dd>Tests included blocks.</dd>
 <dt>input</dt>
 <dd>
 <a href='expand/in02-in.jsonld'>expand/in02-in.jsonld</a>
@@ -5670,7 +5670,7 @@ Test tin03 Multiple properties mapping to @included are folded together
 <dt>Type</dt>
 <dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
 <dt>Purpose</dt>
-<dd>Tests included maps.</dd>
+<dd>Tests included blocks.</dd>
 <dt>input</dt>
 <dd>
 <a href='expand/in03-in.jsonld'>expand/in03-in.jsonld</a>
@@ -5698,7 +5698,7 @@ Test tin04 Included containing @included
 <dt>Type</dt>
 <dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
 <dt>Purpose</dt>
-<dd>Tests included maps.</dd>
+<dd>Tests included blocks.</dd>
 <dt>input</dt>
 <dd>
 <a href='expand/in04-in.jsonld'>expand/in04-in.jsonld</a>
@@ -5726,7 +5726,7 @@ Test tin05 Property value with @included
 <dt>Type</dt>
 <dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
 <dt>Purpose</dt>
-<dd>Tests included maps.</dd>
+<dd>Tests included blocks.</dd>
 <dt>input</dt>
 <dd>
 <a href='expand/in05-in.jsonld'>expand/in05-in.jsonld</a>
@@ -5754,7 +5754,7 @@ Test tin06 json.api example
 <dt>Type</dt>
 <dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
 <dt>Purpose</dt>
-<dd>Tests included maps.</dd>
+<dd>Tests included blocks.</dd>
 <dt>input</dt>
 <dd>
 <a href='expand/in06-in.jsonld'>expand/in06-in.jsonld</a>
@@ -5782,7 +5782,7 @@ Test tin07 Error if @included value is a string
 <dt>Type</dt>
 <dd>jld:NegativeEvaluationTest, jld:ExpandTest</dd>
 <dt>Purpose</dt>
-<dd>Tests included maps.</dd>
+<dd>Tests included blocks.</dd>
 <dt>input</dt>
 <dd>
 <a href='expand/in07-in.jsonld'>expand/in07-in.jsonld</a>
@@ -5810,7 +5810,7 @@ Test tin08 Error if @included value is a value object
 <dt>Type</dt>
 <dd>jld:NegativeEvaluationTest, jld:ExpandTest</dd>
 <dt>Purpose</dt>
-<dd>Tests included maps.</dd>
+<dd>Tests included blocks.</dd>
 <dt>input</dt>
 <dd>
 <a href='expand/in08-in.jsonld'>expand/in08-in.jsonld</a>
@@ -5838,7 +5838,7 @@ Test tin09 Error if @included value is a list object
 <dt>Type</dt>
 <dd>jld:NegativeEvaluationTest, jld:ExpandTest</dd>
 <dt>Purpose</dt>
-<dd>Tests included maps.</dd>
+<dd>Tests included blocks.</dd>
 <dt>input</dt>
 <dd>
 <a href='expand/in09-in.jsonld'>expand/in09-in.jsonld</a>
@@ -6416,62 +6416,6 @@ Test tjs20 Expand JSON literal with aliased @value
 </dd>
 </dl>
 </dd>
-<dt id='tjs13'>
-Test tjs13 Expand JSON literal with aliased @type
-</dt>
-<dd>
-<dl class='entry'>
-<dt>id</dt>
-<dd>#tjs13</dd>
-<dt>Type</dt>
-<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
-<dt>Purpose</dt>
-<dd>Tests expanding JSON literal with aliased @type.</dd>
-<dt>input</dt>
-<dd>
-<a href='expand/js13-in.jsonld'>expand/js13-in.jsonld</a>
-</dd>
-<dt>expect</dt>
-<dd>
-<a href='expand/js13-out.jsonld'>expand/js13-out.jsonld</a>
-</dd>
-<dt>Options</dt>
-<dd>
-<dl class='options'>
-<dt>specVersion</dt>
-<dd>json-ld-1.1</dd>
-</dl>
-</dd>
-</dl>
-</dd>
-<dt id='tjs14'>
-Test tjs14 Expand JSON literal with aliased @value
-</dt>
-<dd>
-<dl class='entry'>
-<dt>id</dt>
-<dd>#tjs14</dd>
-<dt>Type</dt>
-<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
-<dt>Purpose</dt>
-<dd>Tests expanding JSON literal with aliased @value.</dd>
-<dt>input</dt>
-<dd>
-<a href='expand/js14-in.jsonld'>expand/js14-in.jsonld</a>
-</dd>
-<dt>expect</dt>
-<dd>
-<a href='expand/js14-out.jsonld'>expand/js14-out.jsonld</a>
-</dd>
-<dt>Options</dt>
-<dd>
-<dl class='options'>
-<dt>specVersion</dt>
-<dd>json-ld-1.1</dd>
-</dl>
-</dd>
-</dl>
-</dd>
 <dt id='tjs21'>
 Test tjs21 Expand JSON literal with @context
 </dt>
@@ -6490,6 +6434,62 @@ Test tjs21 Expand JSON literal with @context
 <dt>expect</dt>
 <dd>
 <a href='expand/js21-out.jsonld'>expand/js21-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='tjs22'>
+Test tjs22 Expand JSON literal (null).
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tjs22</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>Tests expanding property with @type @json to a JSON literal (null).</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/js22-in.jsonld'>expand/js22-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='expand/js22-out.jsonld'>expand/js22-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='tjs23'>
+Test tjs23 Expand JSON literal (null) aleady in expanded form.
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tjs23</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>Tests expanding property with @type @json to a JSON literal (null).</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/js23-in.jsonld'>expand/js23-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='expand/js23-out.jsonld'>expand/js23-out.jsonld</a>
 </dd>
 <dt>Options</dt>
 <dd>
@@ -7147,7 +7147,7 @@ Test tm012 type map with alias of @none
 </dl>
 </dd>
 <dt id='tm013'>
-Test tm013 index map with @none
+Test tm013 graph index map with @none
 </dt>
 <dd>
 <dl class='entry'>
@@ -7175,7 +7175,7 @@ Test tm013 index map with @none
 </dl>
 </dd>
 <dt id='tm014'>
-Test tm014 index map with alias @none
+Test tm014 graph index map with alias @none
 </dt>
 <dd>
 <dl class='entry'>
@@ -7203,7 +7203,7 @@ Test tm014 index map with alias @none
 </dl>
 </dd>
 <dt id='tm015'>
-Test tm015 index map with alias @none
+Test tm015 graph id index map with aliased @none
 </dt>
 <dd>
 <dl class='entry'>
@@ -7212,7 +7212,7 @@ Test tm015 index map with alias @none
 <dt>Type</dt>
 <dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
 <dt>Purpose</dt>
-<dd>index on @graph and @index</dd>
+<dd>index on @graph and @id with @none</dd>
 <dt>input</dt>
 <dd>
 <a href='expand/m015-in.jsonld'>expand/m015-in.jsonld</a>
@@ -7231,7 +7231,7 @@ Test tm015 index map with alias @none
 </dl>
 </dd>
 <dt id='tm016'>
-Test tm016 index map with alias @none
+Test tm016 graph id index map with aliased @none
 </dt>
 <dd>
 <dl class='entry'>
@@ -7240,7 +7240,7 @@ Test tm016 index map with alias @none
 <dt>Type</dt>
 <dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
 <dt>Purpose</dt>
-<dd>index on @graph and @index</dd>
+<dd>index on @graph and @id with @none</dd>
 <dt>input</dt>
 <dd>
 <a href='expand/m016-in.jsonld'>expand/m016-in.jsonld</a>

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -6472,6 +6472,34 @@ Test tjs22 Expand JSON literal (null) aleady in expanded form.
 </dd>
 </dl>
 </dd>
+<dt id='tjs23'>
+Test tjs23 Expand JSON literal (empty array).
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tjs23</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>Tests expanding property with @type @json to a JSON literal (empty array).</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/js23-in.jsonld'>expand/js23-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='expand/js23-out.jsonld'>expand/js23-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
 <dt id='tl001'>
 Test tl001 Language map with null value
 </dt>

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -1938,18 +1938,10 @@
     }, {
       "@id": "#tjs22",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "Expand JSON literal (null).",
+      "name": "Expand JSON literal (null) aleady in expanded form.",
       "purpose": "Tests expanding property with @type @json to a JSON literal (null).",
       "input": "expand/js22-in.jsonld",
       "expect": "expand/js22-out.jsonld",
-      "option": {"specVersion": "json-ld-1.1"}
-    }, {
-      "@id": "#tjs23",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "Expand JSON literal (null) aleady in expanded form.",
-      "purpose": "Tests expanding property with @type @json to a JSON literal (null).",
-      "input": "expand/js23-in.jsonld",
-      "expect": "expand/js23-out.jsonld",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tl001",

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -1936,6 +1936,22 @@
       "expect": "expand/js21-out.jsonld",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tjs22",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Expand JSON literal (null).",
+      "purpose": "Tests expanding property with @type @json to a JSON literal (null).",
+      "input": "expand/js22-in.jsonld",
+      "expect": "expand/js22-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tjs23",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Expand JSON literal (null) aleady in expanded form.",
+      "purpose": "Tests expanding property with @type @json to a JSON literal (null).",
+      "input": "expand/js23-in.jsonld",
+      "expect": "expand/js23-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tl001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "Language map with null value",

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -1944,6 +1944,14 @@
       "expect": "expand/js22-out.jsonld",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tjs23",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Expand JSON literal (empty array).",
+      "purpose": "Tests expanding property with @type @json to a JSON literal (empty array).",
+      "input": "expand/js23-in.jsonld",
+      "expect": "expand/js23-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tl001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "Language map with null value",

--- a/tests/expand/0122-out.jsonld
+++ b/tests/expand/0122-out.jsonld
@@ -1,5 +1,5 @@
 [{
   "http://example.org/vocab/at": [{"@id": "http://example.org/@"}],
   "http://example.org/vocab/foo.bar": [{"@id": "http://example.org/@foo.bar"}],
-  "http://example.org/vocab/ignoreme": [{"@id": ""}]
+  "http://example.org/vocab/ignoreme": [{"@id": null}]
 }]

--- a/tests/expand/js22-in.jsonld
+++ b/tests/expand/js22-in.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "e": {"@id": "http://example.org/vocab#null", "@type": "@json"}
+  },
+  "e": null
+}

--- a/tests/expand/js22-in.jsonld
+++ b/tests/expand/js22-in.jsonld
@@ -1,7 +1,3 @@
 {
-  "@context": {
-    "@version": 1.1,
-    "e": {"@id": "http://example.org/vocab#null", "@type": "@json"}
-  },
-  "e": null
+  "http://example.org/vocab#null": {"@value": null, "@type": "@json"}
 }

--- a/tests/expand/js22-out.jsonld
+++ b/tests/expand/js22-out.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example.org/vocab#null": [{
+    "@value": null,
+    "@type": "@json"
+  }]
+}]

--- a/tests/expand/js23-in.jsonld
+++ b/tests/expand/js23-in.jsonld
@@ -1,0 +1,3 @@
+{
+  "http://example.org/vocab#null": {"@value": [], "@type": "@json"}
+}

--- a/tests/expand/js23-in.jsonld
+++ b/tests/expand/js23-in.jsonld
@@ -1,0 +1,3 @@
+{
+  "http://example.org/vocab#null": {"@value": null, "@type": "@json"}
+}

--- a/tests/expand/js23-in.jsonld
+++ b/tests/expand/js23-in.jsonld
@@ -1,3 +1,0 @@
-{
-  "http://example.org/vocab#null": {"@value": null, "@type": "@json"}
-}

--- a/tests/expand/js23-out.jsonld
+++ b/tests/expand/js23-out.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example.org/vocab#null": [{
+    "@value": [],
+    "@type": "@json"
+  }]
+}]

--- a/tests/expand/js23-out.jsonld
+++ b/tests/expand/js23-out.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example.org/vocab#null": [{
+    "@value": null,
+    "@type": "@json"
+  }]
+}]

--- a/tests/expand/js23-out.jsonld
+++ b/tests/expand/js23-out.jsonld
@@ -1,6 +1,0 @@
-[{
-  "http://example.org/vocab#null": [{
-    "@value": null,
-    "@type": "@json"
-  }]
-}]

--- a/tests/toRdf-manifest.html
+++ b/tests/toRdf-manifest.html
@@ -6177,6 +6177,34 @@ Test tjs21 Transform JSON literal with @context
 </dd>
 </dl>
 </dd>
+<dt id='tjs22'>
+Test tjs22 Transform JSON literal (null) aleady in expanded form.
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tjs22</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Tests transforming property with @type @json to a JSON literal (null).</dd>
+<dt>input</dt>
+<dd>
+<a href='toRdf/js22-in.jsonld'>toRdf/js22-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='toRdf/js22-out.nq'>toRdf/js22-out.nq</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
 <dt id='tli01'>
 Test tli01 @list containing @list
 </dt>

--- a/tests/toRdf-manifest.html
+++ b/tests/toRdf-manifest.html
@@ -6205,6 +6205,34 @@ Test tjs22 Transform JSON literal (null) aleady in expanded form.
 </dd>
 </dl>
 </dd>
+<dt id='tjs23'>
+Test tjs23 Transform JSON literal (empty array).
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tjs23</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Tests transforming property with @type @json to a JSON literal (empty array).</dd>
+<dt>input</dt>
+<dd>
+<a href='toRdf/js23-in.jsonld'>toRdf/js23-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='toRdf/js23-out.nq'>toRdf/js23-out.nq</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
 <dt id='tli01'>
 Test tli01 @list containing @list
 </dt>

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -1893,6 +1893,14 @@
       "expect": "toRdf/js22-out.nq",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tjs23",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Transform JSON literal (empty array).",
+      "purpose": "Tests transforming property with @type @json to a JSON literal (empty array).",
+      "input": "toRdf/js23-in.jsonld",
+      "expect": "toRdf/js23-out.nq",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tli01",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
       "name": "@list containing @list",

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -1885,6 +1885,14 @@
       "expect": "toRdf/js21-out.nq",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tjs22",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Transform JSON literal (null) aleady in expanded form.",
+      "purpose": "Tests transforming property with @type @json to a JSON literal (null).",
+      "input": "toRdf/js22-in.jsonld",
+      "expect": "toRdf/js22-out.nq",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tli01",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
       "name": "@list containing @list",

--- a/tests/toRdf/js22-in.jsonld
+++ b/tests/toRdf/js22-in.jsonld
@@ -1,0 +1,3 @@
+{
+  "http://example.org/vocab#null": {"@value": null, "@type": "@json"}
+}

--- a/tests/toRdf/js22-out.nq
+++ b/tests/toRdf/js22-out.nq
@@ -1,0 +1,1 @@
+_:b0 <http://example.org/vocab#null> "null"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON> .

--- a/tests/toRdf/js23-in.jsonld
+++ b/tests/toRdf/js23-in.jsonld
@@ -1,0 +1,3 @@
+{
+  "http://example.org/vocab#null": {"@value": [], "@type": "@json"}
+}

--- a/tests/toRdf/js23-out.nq
+++ b/tests/toRdf/js23-out.nq
@@ -1,0 +1,1 @@
+_:b0 <http://example.org/vocab#null> "[]"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON> .


### PR DESCRIPTION
Note that this identifies an issue with the expected result for expand/0122, which was inconsistent with the spec.

For #270.