### PR TITLE
To RDF improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -5054,6 +5054,9 @@
           and {{JsonLdOptions/rdfDirection}} is not `null`,
           <var>item</var> is a <a>value object</a> which is serialized using special rules.
           <ol>
+            <li id="alg-obj2rdf-direction-language">
+              Initialize <var>language</var> to the value of `@language` in <var>item</var>,
+              or the empty string (`""`) if there is no such entry.</li>
             <li>If {{JsonLdOptions/rdfDirection}} is `i18n-datatype`,
               set <var>datatype</var> to the result of appending <var>language</var>
               and the value of `@direction` in <var>item</var> separated by an underscore (`"_"`)
@@ -6979,6 +6982,12 @@
         <li>Changed step <a href="#alg-jld2rdf-add-list-triples">1.3.2.5.2</a>
           to use the {{RdfGraph/add}} method, rather than use "append".
           This is in response to <a href="https://github.com/w3c/json-ld-api/issues/279">Issue 279</a>.</li>
+      </ul>
+    </li>
+    <li>Misclaneous updates to <a href="#object-to-rdf-conversion" class="sectionRef"></a>:
+      <ul>
+        <li>Added a new step <a href="#alg-obj2rdf-direction-language">13.1</a> to create a variable for `@language`.
+          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/277">Issue 277</a>.</li>
       </ul>
     </li>
   </ul>

--- a/index.html
+++ b/index.html
@@ -4937,8 +4937,7 @@
                           <a href="#object-to-rdf-conversion">Object to RDF Conversion algorithm</a>
                           passing <var>item</var>
                           <span class="changed">and <var>list triples</var></span>
-                          to <var>triples</var> using
-                          its using its {{RdfGraph/add}} method,
+                          to <var>triples</var> using its {{RdfGraph/add}} method,
                           unless the result is <code>null</code>,
                           indicating a <span class="changed">non-<a>well-formed</a> <a>resource</a></span>
                           that has to be ignored.</li>

--- a/index.html
+++ b/index.html
@@ -4885,10 +4885,10 @@
             <li>If <var>graph name</var> is
               <span class="changed">not <a>well-formed</a></span>, continue
               with the next <var>graph name</var>-<var>graph</var> pair.</li>
-            <li class="changed">If <var>graph name</var> is <code>@default</code>,
+            <li id="alg-jld2rdf-init-triples" class="changed">If <var>graph name</var> is <code>@default</code>,
               initialize <var>triples</var> to the value of the <a data-link-for="RdfDataset">defaultGraph</a>
               attribute of <var>dataset</var>.
-              Otherwise, initialize <var>graph</var> as an empty <a>RdfGraph</a>
+              Otherwise, initialize <var>triples</var> as an empty <a>RdfGraph</a>
               and add to <var>dataset</var> using its
               {{RdfDataset/add}} method along with <var>graph name</var>
               for <a data-lt="RdfDataset-add-graphName">`graphName`</a>.</li>
@@ -6970,6 +6970,9 @@
       This is in response to <a href="https://github.com/w3c/json-ld-api/issues/269">Issue 269</a>.</li>
     <li>Misclaneous updates to <a href="#deserialize-json-ld-to-rdf-algorithm" class="sectionRef"></a>:
       <ul>
+        <li>Changed step <a href="#alg-jld2rdf-init-triples">1.2</a>
+          to initialize <var>triple</var>, not <var>graph</var>, which is an input.
+          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/281">Issue 281</a>.</li>
         <li>Changed step <a href="#alg-jld2rdf-init-list-triples">1.3.2.5.1</a>
           to be a note on the following step, as it was non-procedural.
           This is in response to <a href="https://github.com/w3c/json-ld-api/issues/278">Issue 278</a>.</li>

--- a/index.html
+++ b/index.html
@@ -4926,9 +4926,11 @@
                       <a>blank node identifier</a>. For each <var>item</var>
                       in <var>values</var>:
                       <ol>
-                        <li><var>item</var> is a <a>value object</a>, <a class="changed">list object</a>,
-                          or a <a>node object</a>.</li>
-                        <li class="changed">Initialize <var>list triples</var> as an empty <a>array</a>.</li>
+                        <li id="alg-jld2rdf-init-list-triples" class="changed">Initialize <var>list triples</var> as an empty <a>array</a>.
+                          <div class="note">
+                            <var>item</var> is a <a>value object</a>, <a class="changed">list object</a>,
+                            or a <a>node object</a>.</div>
+                        </li>
                         <li>Append a <a>triple</a>
                           composed of <var>subject</var>, <var>property</var>, and
                           the result of using the
@@ -6965,6 +6967,13 @@
       <a href="#expansion-algorithm">Expansion algorithm</a>
       <var>input type</var> to use the expanded value.
       This is in response to <a href="https://github.com/w3c/json-ld-api/issues/269">Issue 269</a>.</li>
+    <li>Misclaneous updates to <a href="#deserialize-json-ld-to-rdf-algorithm" class="sectionRef"></a>:
+      <ul>
+        <li>Changed step <a href="#alg-jld2rdf-init-list-triples">1.3.2.5.1</a>
+          to be a note on the following step, as it was non-procedural.
+          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/278">Issue 278</a>.</li>
+       </ul>
+    </li>
   </ul>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -1190,7 +1190,7 @@
         <li class="changed">If <var>local context</var> is an object containing the member <code>@propagate</code>,
           its value MUST be <a>boolean</a> <code>true</code> or <code>false</code>,
           set <var>propagate</var> to that value.
-          <span class="note">Error handling is performed in <a href="#step-propagate-entry">step 5.11</a>.</span></li>
+          <div class="note">Error handling is performed in <a href="#step-propagate-entry">step 5.11</a>.</div></li>
         <li class="changed">If <var>propagate</var> is <code>false</code>, and <var>result</var>
           does not have a <a>previous context</a>, set <a>previous context</a>
           in <var>result</var> to <var>active context</var>.</li>
@@ -1211,9 +1211,9 @@
                   <span class="changed">setting <a>previous context</a> in <var>result</var>
                     to the previous value of <var>result</var> if <var>propagate</var> is <code>false</code></span>.
                   Continue with the next <var>context</var>.
-                  <span class="note">In [[[JSON-LD10]]], the <a>base IRI</a> was given
+                  <div class="note">In [[[JSON-LD10]]], the <a>base IRI</a> was given
                     a default value here; this is now described conditionally
-                    in <a href="#the-application-programming-interface" class="sectionRef"></a>.</span></li>
+                    in <a href="#the-application-programming-interface" class="sectionRef"></a>.</div></li>
                   </ol>
             </li>
             <li>If <var>context</var> is a <a>string</a>,
@@ -1387,7 +1387,7 @@
                   <span class="changed">If <var>value</var> is not <a>well-formed</a> according to
                     <a data-cite="BCP47#section-2.2.9">section 2.2.9</a> of [[BCP47]],
                     processors SHOULD issue a warning.</span>
-                  <span class="changed note">Processors MAY normalize <a>language tags</a> to lower case.</span>
+                  <div class="changed note">Processors MAY normalize <a>language tags</a> to lower case.</div>
                 </li>
               </ol>
             </li>
@@ -1798,7 +1798,7 @@
               Otherwise, an <a data-link-for="JsonLdErrorCode">invalid language mapping</a>
               error has been detected and processing is aborted.</li>
             <li>Set the <a>language mapping</a> of <var>definition</var> to <var>language</var>.
-              <span class="changed note">Processors MAY normalize <a>language tags</a> to lower case.</span>
+              <div class="changed note">Processors MAY normalize <a>language tags</a> to lower case.</div>
             </li>
           </ol>
         </li>
@@ -2808,7 +2808,7 @@
                           <span class="changed">If <var>item</var> is neither `@none` nor <a>well-formed</a> according to
                             <a data-cite="BCP47#section-2.2.9">section 2.2.9</a> of [[BCP47]],
                             processors SHOULD issue a warning.</span>
-                          <span class="changed note">Processors MAY normalize <a>language tags</a> to lower case.</span>
+                          <div class="changed note">Processors MAY normalize <a>language tags</a> to lower case.</div>
                         </li>
                         <li class="changed">If <var>language</var> is <code>@none</code>,
                           or expands to <code>@none</code>, remove <code>@language</code> from <var>v</var>.</li>
@@ -4828,10 +4828,10 @@
       <li>A <a>blank node identifier</a> is <a>well-formed</a> if it matches the
         <a data-cite="Turtle#sec-grammar-grammar">EBNF for
         <strong>BLANK_NODE_LABEL</strong></a> as described in [[Turtle]].
-        <span class="note">When following the algorithm described here,
+        <div class="note">When following the algorithm described here,
           all blank node identifiers will be normalized using the <a
           href="#generate-blank-node-identifier">Generate Blank Node Identifier
-          algorithm</a> and automatically adhere to this form.</span>
+          algorithm</a> and automatically adhere to this form.</div>
       </li>
       <li>A <a>literal</a> is <a>well-formed</a> if it has the
         <a>lexical form</a> of a <a>string</a>, any <a>datatype IRI</a> is
@@ -5062,9 +5062,9 @@
               set <var>datatype</var> to the result of appending <var>language</var>
               and the value of `@direction` in <var>item</var> separated by an underscore (`"_"`)
               to `https://www.w3.org/ns/i18n#`.
-              <span class="changed note">Processors MAY normalize <a>language tags</a> to lower case.</span>
               Initialize <var>literal</var> as an <a>RDF literal</a> using
               <var>value</var> and <var>datatype</var>.
+              <div class="changed note">Processors MAY normalize <a>language tags</a> to lower case.</div>
               <div class="note">As `@direction` may be used without `@language`,
                 it is possible, and legitimate, to create a datatype IRI
                 such as `http://w3.org/ns/i18n#_ltr`, which does not encode a language tag.</div></li>
@@ -5078,7 +5078,7 @@
                   create a new triple using <var>literal</var> as the subject,
                   `rdf:language` as the predicate, and the value of `@language` in <var>item</var>
                   as the object, and add it to <var>list triples</var>.
-                  <span class="changed note">Processors MAY normalize <a>language tags</a> to lower case.</span></li>
+                  <div class="changed note">Processors MAY normalize <a>language tags</a> to lower case.</div></li>
                 <li>Create a new triple using <var>literal</var> as the subject,
                   `rdf:direction` as the predicate, and the value of `@direction` in <var>item</var>
                   as the object, and add it to <var>list triples</var>.</li>

--- a/index.html
+++ b/index.html
@@ -4890,7 +4890,7 @@
               attribute of <var>dataset</var>.
               Otherwise, initialize <var>graph</var> as an empty <a>RdfGraph</a>
               and add to <var>dataset</var> using its
-              <a data-link-for="RdfDataset">add</a> method along with <var>graph name</var>
+              {{RdfDataset/add}} method along with <var>graph name</var>
               for <a data-lt="RdfDataset-add-graphName">`graphName`</a>.</li>
             <li>For each <var>subject</var> and <var>node</var> in <var>graph</var> ordered
               by <var>subject</var>:
@@ -4907,7 +4907,7 @@
                       composed of <var>subject</var>, <code>rdf:type</code> for <a data-link-for="rdftriple">predicate</a>,
                       and <var>type</var> for <a data-link-for="rdftriple">object</a>
                       <span class="changed">and add to <var>triples</var>
-                      using its <a data-link-for="RdfGraph">add</a> method,
+                      using its {{RdfGraph/add}} method,
                       unless <var>type</var> is not <a>well-formed</a></span>.</li>
                     <li>Otherwise, if <var>property</var> is a <a>keyword</a>
                       continue with the next <var>property</var>-<var>values</var> pair.</li>
@@ -4931,19 +4931,20 @@
                             <var>item</var> is a <a>value object</a>, <a class="changed">list object</a>,
                             or a <a>node object</a>.</div>
                         </li>
-                        <li>Append a <a>triple</a>
+                        <li id="alg-jld2rdf-add-list-triples">Add a <a>triple</a>
                           composed of <var>subject</var>, <var>property</var>, and
                           the result of using the
                           <a href="#object-to-rdf-conversion">Object to RDF Conversion algorithm</a>
                           passing <var>item</var>
                           <span class="changed">and <var>list triples</var></span>
-                          to <var>triples</var>, unless the result is
-                          <code>null</code>, indicating a
-                          <span class="changed">non-<a>well-formed</a> <a>resource</a></span>
+                          to <var>triples</var> using
+                          its using its {{RdfGraph/add}} method,
+                          unless the result is <code>null</code>,
+                          indicating a <span class="changed">non-<a>well-formed</a> <a>resource</a></span>
                           that has to be ignored.</li>
                         <li class="changed">Add all <a>RdfTriple</a> instances from
                           <var>list triples</var> to <var>triples</var> using
-                          its using its <a data-link-for="RdfGraph">add</a> method.</li>
+                          its using its {{RdfGraph/add}} method.</li>
                       </ol>
                     </li>
                   </ol>
@@ -6972,7 +6973,10 @@
         <li>Changed step <a href="#alg-jld2rdf-init-list-triples">1.3.2.5.1</a>
           to be a note on the following step, as it was non-procedural.
           This is in response to <a href="https://github.com/w3c/json-ld-api/issues/278">Issue 278</a>.</li>
-       </ul>
+        <li>Changed step <a href="#alg-jld2rdf-add-list-triples">1.3.2.5.2</a>
+          to use the {{RdfGraph/add}} method, rather than use "append".
+          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/279">Issue 279</a>.</li>
+      </ul>
     </li>
   </ul>
 </section>

--- a/index.html
+++ b/index.html
@@ -5006,7 +5006,8 @@
         <li>Initialize <var>datatype</var> to the value associated with the
           <code>@type</code> <a>entry</a> of <var>item</var> or <code>null</code> if
           <var>item</var> does not have such an <a>entry</a>.</li>
-        <li class="changed">If <var>datatype</var> is not <a>well-formed</a>, return <code>null</code>.</li>
+        <li id="alg-obj2rdf-datatype" class="changed">If <var>datatype</var> is not `null` and not a <a>well-formed</a> <a>IRI</a>,
+          return <code>null</code>.</li>
         <li class="changed">If <var>item</var> has an <code>@language</code>
           <a>entry</a> which is not <a>well-formed</a>, return <code>null</code>.</li>
         <li class="changed">If <var>datatype</var> is <code>@json</code>,
@@ -6986,6 +6987,10 @@
     </li>
     <li>Misclaneous updates to <a href="#object-to-rdf-conversion" class="sectionRef"></a>:
       <ul>
+        <li>Updated step <a href="#alg-obj2rdf-datatype">6</a>
+          to only check that a datatype is well-formed if it is not null,
+          and to specify that the check is for a well-formed IRI.
+          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/282">Issue 282</a>.</li>
         <li>Added a new step <a href="#alg-obj2rdf-direction-language">13.1</a> to create a variable for `@language`.
           This is in response to <a href="https://github.com/w3c/json-ld-api/issues/277">Issue 277</a>.</li>
       </ul>


### PR DESCRIPTION
* Changed step 1.3.2.5.1 to be a note on the following step, as it was non-procedural. For #278.
* Changed step 1.3.2.5.2 to use the add method, rather than use "append". For #279.
* Changed step 1.2 to initialize <var>triple</var>, not <var>graph</var>, which is an input. For #281.
* Added a new step 13.1 to Object to RDF conversion to create a variable for `@language`. For #277.
* Updated step 6 of Object to RDF to only check that a datatype is well-formed if it is not null, and to specify that the check is for a well-formed IRI. For #282.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/286.html" title="Last updated on Dec 26, 2019, 9:23 PM UTC (a4254e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/286/188dea7...a4254e2.html" title="Last updated on Dec 26, 2019, 9:23 PM UTC (a4254e2)">Diff</a>