### PR TITLE
Rework Create Term Definition step 16 (again)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1621,7 +1621,7 @@
         <li>If <var>value</var> contains the <a>entry</a> <code>@id</code> and its value
           does not equal <var>term</var>:
           <ol>
-            <li id="ctd-id-null">If <var>value</var> contains the <code>@id</code> <a>entry</a>
+            <li id="ctd-id-null">If the <code>@id</code> <a>entry</a> of <var>value</var>
               is <code>null</code>, the term is not used for IRI expansion, but is
               retained to be able to detect future redefinitions of this term.</li>
             <li id="ctd-id-not-null">Otherwise:

--- a/index.html
+++ b/index.html
@@ -6931,8 +6931,9 @@
       <ul>
         <li>Added missing `@none` in <a href="#ctd-invalid-type">13.4</a>.
           This is in response to <a href="https://github.com/w3c/json-ld-api/issues/259">Issue 259</a>.</li>
-        <li>Merged <a href="#ctd-id-null">the former substep 16.1</a> into step 16
-          to make the control flow clearer and homogeneous with the rest of the specification.
+        <li>Moved step <a href="#ctd-id-not-null">16.2</a>,
+          and subsequent substeps of step 16 into a new grouping, to separate the logic
+          from step <a href="#ctd-id-not-null">16.1</a>.
           This is in response to <a href="https://github.com/w3c/json-ld-api/issues/241">Issue 241</a>.</li>
         <li>Updated step <a href="#ctd-contains-colon">16.4</a>
           to prevent an issue where <var>term</var> might not be defined at the time it is expanded.

--- a/index.html
+++ b/index.html
@@ -1618,55 +1618,59 @@
         </li>
         <li>Set the <a>reverse property</a> flag of <var>definition</var>
           to <code>false</code>.</li>
-        <li class="changed">If <var>value</var> contains the <a>entry</a> <code>@id</code> and its value
-          neither equals <var>term</var> nor is <code>null</code>:
-          <div id="ctd-id-null" class="note">If the `@id` entry is `null`,
-            the term is not used for IRI expansion, but is
-            retained to be able to detect future redefinitions of this term.</div>
+        <li>If <var>value</var> contains the <a>entry</a> <code>@id</code> and its value
+          does not equal <var>term</var>:
           <ol>
-            <li>If the value associated with the <code>@id</code> <a>entry</a> is not a <a>string</a>, an
-              <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
-              error has been detected and processing is aborted.</li>
-            <li>If the value associated with the `@id` <a>entry</a>
-              is not a <a>keyword</a>, but
-              has the form of a <a>keyword</a>
-              (i.e., it matches the ABNF rule `"@"1*ALPHA` from [[RFC5234]]),
-              return; processors SHOULD generate a warning.</li>
-            <li>Otherwise, set the <a>IRI mapping</a> of <var>definition</var> to the
-              result of using the <a href="#iri-expansion">IRI Expansion algorithm</a>, passing
-              <var>active context</var>, the value associated with the <code>@id</code> <a>entry</a> for
-              <var>value</var>, <code>true</code> for <var>vocab</var>,
-              <var>local context</var>, and <var>defined</var>. If the resulting
-              <a>IRI mapping</a> is neither a <a>keyword</a>, nor an
-              <a>IRI</a>, nor a <a>blank node identifier</a>, an
-              <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
-              error has been detected and processing is aborted; if it equals <code>@context</code>, an
-              <a data-link-for="JsonLdErrorCode">invalid keyword alias</a>
-              error has been detected and processing is aborted.</li>
-            <li id="ctd-contains-colon" class="changed">If the <var>term</var> contains a colon (`:`)
-              anywhere but as the first or last character of <var>term</var>,
-              or if it contains a slash (`/`) anywhere:
+            <li id="ctd-id-null">If <var>value</var> contains the <code>@id</code> <a>entry</a>
+              is <code>null</code>, the term is not used for IRI expansion, but is
+              retained to be able to detect future redefinitions of this term.</li>
+            <li id="ctd-id-not-null">Otherwise:
               <ol>
-                <li>Set the value associated with <var>defined</var>'s <var>term</var> <a>entry</a> to
-                  <code>true</code>.</li>
-                <li>If the result of expanding <var>term</var>
-                  using the <a href="#iri-expansion">IRI Expansion algorithm</a>,
-                  passing <var>active context</var>,
-                  <var>term</var> for <var>value</var>,
-                  <code>true</code> for <var>vocab</var>,
-                  <var>local context</var>,
-                  and <var>defined</var>,
-                  is not the same as the <a>IRI mapping</a> of <var>definition</var>,
-                  an <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
+                <li>If the value associated with the <code>@id</code> <a>entry</a> is not a <a>string</a>, an
+                  <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
                   error has been detected and processing is aborted.</li>
+                <li>If the value associated with the `@id` <a>entry</a>
+                  is not a <a>keyword</a>, but
+                  has the form of a <a>keyword</a>
+                  (i.e., it matches the ABNF rule `"@"1*ALPHA` from [[RFC5234]]),
+                  return; processors SHOULD generate a warning.</li>
+                <li>Otherwise, set the <a>IRI mapping</a> of <var>definition</var> to the
+                  result of using the <a href="#iri-expansion">IRI Expansion algorithm</a>, passing
+                  <var>active context</var>, the value associated with the <code>@id</code> <a>entry</a> for
+                  <var>value</var>, <code>true</code> for <var>vocab</var>,
+                  <var>local context</var>, and <var>defined</var>. If the resulting
+                  <a>IRI mapping</a> is neither a <a>keyword</a>, nor an
+                  <a>IRI</a>, nor a <a>blank node identifier</a>, an
+                  <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
+                  error has been detected and processing is aborted; if it equals <code>@context</code>, an
+                  <a data-link-for="JsonLdErrorCode">invalid keyword alias</a>
+                  error has been detected and processing is aborted.</li>
+                <li id="ctd-contains-colon" class="changed">If the <var>term</var> contains a colon (`:`)
+                  anywhere but as the first or last character of <var>term</var>,
+                  or if it contains a slash (`/`) anywhere:
+                  <ol>
+                    <li>Set the value associated with <var>defined</var>'s <var>term</var> <a>entry</a> to
+                      <code>true</code>.</li>
+                    <li>If the result of expanding <var>term</var>
+                      using the <a href="#iri-expansion">IRI Expansion algorithm</a>,
+                      passing <var>active context</var>,
+                      <var>term</var> for <var>value</var>,
+                      <code>true</code> for <var>vocab</var>,
+                      <var>local context</var>,
+                      and <var>defined</var>,
+                      is not the same as the <a>IRI mapping</a> of <var>definition</var>,
+                      an <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
+                      error has been detected and processing is aborted.</li>
+                  </ol>
+                </li>
+                <li class="changed">If <var>term</var> contains neither a colon (`:`) nor a slash (`/`),
+                  <span class="changed"><var>simple term</var> is <code>true</code></span>,
+                  and if the <a>IRI mapping</a> of <var>definition</var>
+                  is either an <a>IRI</a> ending with a <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
+                  or a <a>blank node identifier</a>,
+                  set the <a>prefix flag</a> in <var>definition</var> to <code>true</code>.</li>
               </ol>
             </li>
-            <li class="changed">If <var>term</var> contains neither a colon (`:`) nor a slash (`/`),
-              <span class="changed"><var>simple term</var> is <code>true</code></span>,
-              and if the <a>IRI mapping</a> of <var>definition</var>
-              is either an <a>IRI</a> ending with a <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
-              or a <a>blank node identifier</a>,
-              set the <a>prefix flag</a> in <var>definition</var> to <code>true</code>.</li>
           </ol>
         </li>
         <li>


### PR DESCRIPTION
to restore step 16.1, and move 16.2-16.n to a new 16.2 "Otherwise" substep.

For #241.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/288.html" title="Last updated on Dec 31, 2019, 6:38 PM UTC (0f3bd0b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/288/2d6fe87...0f3bd0b.html" title="Last updated on Dec 31, 2019, 6:38 PM UTC (0f3bd0b)">Diff</a>