### PR TITLE
Optionally order when iterating on _nesting-key_

### DIFF
--- a/index.html
+++ b/index.html
@@ -3003,7 +3003,8 @@
             </li>
           </ol>
         </li>
-        <li id="alg-expand-resolve-nest" class="changed">For each key <var>nesting-key</var> in <var>nests</var>
+        <li id="alg-expand-resolve-nest" class="changed">For each key <var>nesting-key</var> in <var>nests</var>,
+          ordered lexicographically if {{JsonLdOptions/ordered}} is <code>true</code>:
           <ol>
             <li>Initialize <var>nested values</var> to the value of <var>nesting-key</var>
               in <var>element</var>, ensuring that it is an <a>array</a>.</li>
@@ -7002,6 +7003,9 @@
         <li>Improved text in step <a href="#alg-expand-container-mapping-type">13.8.3.7.5</a>
           to exclude the <var>expanded index</var> being `@none`.
           This is in response to <a href="https://github.com/w3c/json-ld-api/issues/264">Issue 264</a>.</li>
+        <li>Update step <a href="#alg-expand-resolve-nest">14</a>
+          to order by <var>nesting-key</var>, if `ordered` is `true`.
+          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/295">Issue 295</a>.</li>
         <li>Move step 13.15 of the expansion algorithm up one level to step <a href="#alg-expand-resolve-nest">14</a>,
           as it had accidentally been set to run for every entry in the object, rather than
           after all entries had been expanded.

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -7455,7 +7455,7 @@ Test tn003 Appends nested values when property at base and nested
 </dl>
 </dd>
 <dt id='tn004'>
-Test tn004 Appends nested values from all @nest aliases in term order
+Test tn004 Appends nested values from all @nest aliases
 </dt>
 <dd>
 <dl class='entry'>

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -2226,7 +2226,7 @@
     }, {
       "@id": "#tn004",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "Appends nested values from all @nest aliases in term order",
+      "name": "Appends nested values from all @nest aliases",
       "purpose": "Expansion using @nest",
       "input": "expand/n004-in.jsonld",
       "expect": "expand/n004-out.jsonld",


### PR DESCRIPTION
in Expansion Algorithm step 14.

For #295.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/297.html" title="Last updated on Jan 3, 2020, 12:19 AM UTC (6ba6d40)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/297/3594011...6ba6d40.html" title="Last updated on Jan 3, 2020, 12:19 AM UTC (6ba6d40)">Diff</a>