### PR TITLE
Move last 3 steps of the expansion algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -3085,14 +3085,7 @@
                 containing only the <code>@id</code> <a>entry</a> is retained.</span></li>
           </ol>
         </li>
-        <li>If <var>result</var> is a
-          <a class="changed">map</a> that contains only an <code>@graph</code> <a>entry</a>,
-          set <var>result</var> that value.</li>
-        <li>If <var>result</var> is <code>null</code>,
-          set <var>result</var> to an empty <a>array</a>.</li>
-        <li>If <var>result</var> is not an <a>array</a>,
-          set <var>result</var> to an <a>array</a> containing only <var>result</var>.</li>
-        <li>Return <var>result</var>.</li>
+        <li id="alg-expand-return">Return <var>result</var>.</li>
       </ol>
     </section>
   </section> <!-- end of Expansion Algorithm -->
@@ -5905,7 +5898,17 @@
             if there is no <var>remote document</var> as <var>element</var>,
             and if passed, the <span class="changed">{{JsonLdOptions/frameExpansion}}</span>
             <span class="changed">and {{JsonLdOptions/ordered}}</span>
-            flags in <a data-lt="jsonldprocessor-compact-options">options</a>.</li>
+            flags in <a data-lt="jsonldprocessor-compact-options">options</a>.
+            <ol id="api-expand-post-processing" class="changed">
+              <li>If <var>expanded output</var> is a
+                <a class="changed">map</a> that contains only an <code>@graph</code> <a>entry</a>,
+                set <var>expanded output</var> that value.</li>
+              <li>If <var>expanded output</var> is <code>null</code>,
+                set <var>expanded output</var> to an empty <a>array</a>.</li>
+              <li>If <var>expanded output</var> is not an <a>array</a>,
+                set <var>expanded output</var> to an <a>array</a> containing only <var>expanded output</var>.</li>
+            </ol>
+          </li>
           <li>Resolve the <var>promise</var> with <var>expanded output</var>
             <span class="changed">transforming <var>expanded output</var> from the
               <a>internal representation</a> to a JSON serialization</span>.</li>
@@ -7011,6 +7014,12 @@
         <li>Changed step <a href="#alg-expand-only-language">18</a>
           to return `null`, not set <var>result</var> to `null`.
           This is in response to <a href="https://github.com/w3c/json-ld-api/issues/284">Issue 284</a>.</li>
+        <li>Moved three steps prior to step <a href="#alg-expand-return">20</a> to
+          step <a href="#api-expand-post-processing">7.1</a> of
+          the <a data-link-for="JsonLdProcessor">expand()</a> method of the
+          <a>JsonLdProcessor</a> interface.
+          This corrects an issue introduced in <a href="https://github.com/w3c/json-ld-api/pull/184">PR 184</a> and is
+          in response to <a href="https://github.com/w3c/json-ld-api/issues/294">Issue 294</a>.</li>
       </ul>
     </li>
     <li>Misclaneous updates to <a href="#deserialize-json-ld-to-rdf-algorithm" class="sectionRef"></a>:

--- a/index.html
+++ b/index.html
@@ -2892,7 +2892,8 @@
                         and {{JsonLdOptions/ordered}} flags</span>.</li>
                     <li>For each <var>item</var> in <var>index value</var>:
                       <ol class="algorithm changed">
-                        <li>If <var>container mapping</var> includes <code>@graph</code>,
+                        <li id="alg-expand-container-index-graph">If <var>container mapping</var> includes <code>@graph</code>,
+                          <span class="changed">and <var>item</var> is not a <a>graph object</a>,</span>
                           set <var>item</var> to a new <a>map</a> containing the key-value pair
                           <code>@graph</code>-<var>item</var>,
                           ensuring that the value is represented using an <a>array</a>.</li>
@@ -7018,6 +7019,9 @@
           step <a href="#api-expand-post-processing">7.1</a> of
           the <a data-link-for="JsonLdProcessor">expand()</a> method of the
           <a>JsonLdProcessor</a> interface.
+          Additionally, in step <a href="#alg-expand-container-index-graph">13.8.3.7.1</a>,
+          when expanding properties where container includes both `@index` and `@graph`,
+          don't transform an item into a <a>graph object</a> repetitively.
           This corrects an issue introduced in <a href="https://github.com/w3c/json-ld-api/pull/184">PR 184</a> and is
           in response to <a href="https://github.com/w3c/json-ld-api/issues/294">Issue 294</a>.</li>
       </ul>


### PR DESCRIPTION
which were formally in a paragraph following the algorithm steps, into the `expand()` API method to be performed after the algorithm has completed.

This restores previous desired behavior that the expansion algorithm typically results in a map when starting with a map, and not an array containing that map.

For #294.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/299.html" title="Last updated on Jan 3, 2020, 7:51 PM UTC (41f4c8a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/299/3594011...41f4c8a.html" title="Last updated on Jan 3, 2020, 7:51 PM UTC (41f4c8a)">Diff</a>