### PR TITLE
Variable names

### DIFF
--- a/index.html
+++ b/index.html
@@ -3846,14 +3846,14 @@
                           href="#iri-compaction">IRI Compaction algorithm</a>
                           passing <var>active context</var>, <var>inverse context</var>, the value of <code>@id</code>
                           in <var>expanded item</var> as
-                          <var>var</var>.</li>
+                          <var>var</var> to <var>compacted item</var>.</li>
                         <li>If expanded item contains an <code>@index</code> <a>entry</a>,
                           add the key resulting from calling the <a
                           href="#iri-compaction">IRI Compaction algorithm</a>
                           passing <var>active context</var>, <var>inverse context</var>, <code>@index</code> as
                           <var>var</var>, and <code>true</code> for
                           <var>vocab</var> using the value of <code>@index</code>
-                          in <var>expanded item</var>.</li>
+                          in <var>expanded item</var> to <var>compacted item</var>.</li>
                         <li>If <var>as array</var> is <code>true</code>,
                           set <var>compacted item</var> to an <a>array</a>
                           containing that value.</li>

--- a/index.html
+++ b/index.html
@@ -4425,10 +4425,12 @@
               set <var>result</var> to the value associated with the `@value` <a>entry</a>.</li>
           </ol>
         </li>
-        <li>Otherwise, if the value of `@language` in <var>item</var> exactly matches <var>language</var>,
+        <li id="alg-valcompact-lang-dir">Otherwise, if <var>value</var> has an <code>@language</code> <a>entry</a>
+          whose value exactly matches <var>language</var>,
           <span class="changed">using a case-insensitive comparison</span>
           if it is not `null`, or is not present, if <var>language</var> is `null`,
-          <span class="changed">and the value of `@direction` in <var>item</var> exactly matches <var>direction</var>,
+          <span class="changed">and the <var>value</var> has an <code>@direction</code> <a>entry</a>
+            whose value exactly matches <var>direction</var>,
             if it is not `null`, or is not present, if <var>direction</var> is `null`</span>:
           <ol>
             <li>If <var>value</var> has an `@index` <a>entry</a>,
@@ -4437,7 +4439,7 @@
               or <var>value</var> has no `@index` <a>entry</a>,
               set <var>result</var> to the value associated with the `@value` <a>entry</a>.</li>
           </ol>
-          return <var>value</var>.</li>
+        </li>
         <li>If <var>result</var> is a <var>map</var>,
           replace each key in <var>result</var> with the result of using the
           <a href="#iri-compaction">IRI compaction algorithm</a>,
@@ -7085,6 +7087,9 @@
           <a href="#node-map-generation">Node Map Generation algorithm</a> to clarify
           that the steps iterates over any `@type` entries.
           This is in response to <a href="https://github.com/w3c/json-ld-api/issues/276">Issue 276</a>.</li>
+        <li>Updated the language in step <a href="alg-valcompact-lang-dir">8</a>
+          of <a href="#value-compaction" class="sectionRef"></a> to be consistent with other steps.
+          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/313">Issue 313</a>.</li>
       </ul>
     </li>
   </ul>

--- a/index.html
+++ b/index.html
@@ -3671,8 +3671,8 @@
                   in the <var>active context</var> has a <a>nest value</a>, that value (<var>nest term</var>) must be
                   <code>@nest</code>, or a <a>term</a> in the
                   <var>active context</var> that expands to <code>@nest</code>,
-                  otherwise an <a data-link-for="JsonLdErrorCode">invalid @nest
-                  value</a> error has been detected, and processing is aborted.
+                  otherwise an <a data-link-for="JsonLdErrorCode">invalid @nest value</a>
+                  error has been detected, and processing is aborted.
                   If <var>result</var> does not have a <var>nest term</var> <a>entry</a>,
                   initialize it to an empty <a>map</a> (<var>nest object</var>).
                   If <var>nest object</var> does not have an <var>item active property</var> <a>entry</a>,
@@ -3705,8 +3705,8 @@
                   <a>entry</a>, that value (<var>nest term</var>) must be
                   <code>@nest</code>, or a <a>term</a> in the
                   <var>active context</var> that expands to <code>@nest</code>,
-                  otherwise an <a data-link-for="JsonLdErrorCode">invalid @nest
-                  value</a> error has been detected, and processing is aborted.
+                  otherwise an <a data-link-for="JsonLdErrorCode">invalid @nest value</a>
+                  error has been detected, and processing is aborted.
                   Set <var>nest result</var> to the value of <var>nest term</var> in <var>result</var>,
                   initializing it to a new <a class="changed">map</a>, if necessary; otherwise
                   set <var>nest result</var> to <var>result</var>.</li>
@@ -6883,8 +6883,8 @@
       used to create a <a>named graph</a> from either a <a>node object</a>, or
       objects which are values of <a>entries</a> in an <a>id map</a> or <a>index map</a>.
       The <a href="#compaction-algorithm">Compaction Algorithm</a> allows
-      specific forms of graph objects to be compacted back to a set of <a>node
-      objects</a>, or maps of <a>node objects</a>.</li>
+      specific forms of graph objects to be compacted back to a set of <a>node objects</a>,
+      or maps of <a>node objects</a>.</li>
     <li><a href="#value-expansion">Value Expansion</a> will not turn native values
       into <a>node objects</a>.</li>
     <li>The <a href="#term-selection">Term Selection algorithm</a> has been

--- a/index.html
+++ b/index.html
@@ -3824,7 +3824,7 @@
                           set it to a new <a>array</a> containing only the value.</li>
                         <li>Then append <var>compacted item</var> to the value if
                           <var>compacted item</var> is not an <a>array</a>,
-                          otherwise, concatenate it.</li>
+                          otherwise, concatenate <var>compacted item</var> to the value.</li>
                       </ol>                      
                     </li>
                     <li>Otherwise, <var>container</var> does not include <code>@graph</code>
@@ -3859,7 +3859,7 @@
                           containing that value.</li>
                         <li>Then append <var>compacted item</var> to the value if
                           <var>compacted item</var> is not an <a>array</a>,
-                          otherwise, concatenate it.</li>
+                          otherwise, concatenate <var>compacted item</var> to the value.</li>
                       </ol>
                     </li>
                   </ol>
@@ -3959,7 +3959,7 @@
                       <a>array</a> containing only the value. Then
                       append <var>compacted item</var> to the value if
                       <var>compacted item</var> is not an <a>array</a>,
-                      otherwise, concatenate it.</li>
+                      otherwise, concatenate <var>compacted item</var> to the value.</li>
                   </ol>
                 </li>
               </ol>

--- a/index.html
+++ b/index.html
@@ -3666,7 +3666,7 @@
                   <var>expanded property</var> for <var>var</var>,
                   <var>expanded value</var> for <var>value</var>,
                   <code>true</code> for <var>vocab</var>, and
-                  <var>inside reverse</var>.</li>
+                  <var>inside reverse</var> for the <var>reverse</var> flag.</li>
                 <li class="changed">If the <a>term definition</a> for <var>item active property</var>
                   in the <var>active context</var> has a <a>nest value</a>, that value (<var>nest term</var>) must be
                   <code>@nest</code>, or a <a>term</a> in the
@@ -3699,7 +3699,7 @@
                   <var>expanded property</var> for <var>var</var>,
                   <var>expanded item</var> for <var>value</var>,
                   <code>true</code> for <var>vocab</var>, and
-                  <var>inside reverse</var>.</li>
+                  <var>inside reverse</var> for the <var>reverse</var> flag.</li>
                 <li class="changed">If the <a>term definition</a> for <var>item active property</var>
                   in the <var>active context</var> has a <a>nest value</a>
                   <a>entry</a>, that value (<var>nest term</var>) must be


### PR DESCRIPTION
* Updated the language in step 8 of the Value Compaction Algorithm to be consistent with other steps. For #313.
* Fix some references that had a line-wrap affecting the text styling. Fixes #315.
* Update language from Compaction to use _inside reverse_ **for the _reverse_ flag**. Fixes #316.
* Add clarity when adding an array to an array using concatenate. For #323.
* Clarify where compacted key/value is added in steps 12.8.7.4.2 and 12.8.7.4.3. For #324.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/325.html" title="Last updated on Jan 15, 2020, 11:33 PM UTC (67cb0e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/325/fc9e30f...67cb0e2.html" title="Last updated on Jan 15, 2020, 11:33 PM UTC (67cb0e2)">Diff</a>