### PR TITLE
Update 13.21.1 to _always_ make _ev_ a graph object

### DIFF
--- a/index.html
+++ b/index.html
@@ -2970,10 +2970,12 @@
               then convert each value <var>ev</var> in <var>expanded value</var> into a
               <a>graph object</a>:
               <ol>
-                <li>If <var>ev</var> is not a <a>graph object</a>, convert it into
-                  one by creating a <a>map</a> containing the key-value
+                <li>Convert var>ev</var> into
+                  a <a>graph object</a> by creating a <a>map</a> containing the key-value
                   pair <code>@graph</code>-<var>ev</var>
-                  where <var>ev</var> is represented as an <a>array</a>.</li>
+                  where <var>ev</var> is represented as an <a>array</a>.
+                  <div class="note">This may lead to a <a>graph object</a> including another <a>graph object</a>,
+                    if <var>ev</var> was already in the form of a <a>graph object</a>.</div></li>
               </ol>
             </li>
             <li>If the <a>term definition</a> associated to

--- a/index.html
+++ b/index.html
@@ -2966,11 +2966,13 @@
               and then by setting it to a <a class="changed">map</a> containing
               the key-value pair <code>@list</code>-<var>expanded value</var>.</li>
             <li class="changed">If <var>container mapping</var> <span>includes</span>
-              <code>@graph</code>, convert <var>expanded value</var> into an <a>array</a>, if necessary,
+              <code>@graph</code>,
+              and includes neither <code>@id</code> nor <code>@index</code>,
+              convert <var>expanded value</var> into an <a>array</a>, if necessary,
               then convert each value <var>ev</var> in <var>expanded value</var> into a
               <a>graph object</a>:
               <ol>
-                <li>Convert var>ev</var> into
+                <li>Convert <var>ev</var> into
                   a <a>graph object</a> by creating a <a>map</a> containing the key-value
                   pair <code>@graph</code>-<var>ev</var>
                   where <var>ev</var> is represented as an <a>array</a>.


### PR DESCRIPTION
even if it is already a _graph object_.

Fixes #311.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/335.html" title="Last updated on Jan 17, 2020, 11:01 PM UTC (aaa7c88)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/335/4a41d9c...aaa7c88.html" title="Last updated on Jan 17, 2020, 11:01 PM UTC (aaa7c88)">Diff</a>