### PR TITLE
Move parts of Compaction Algorithm that relate to the API call

### DIFF
--- a/index.html
+++ b/index.html
@@ -4444,22 +4444,18 @@
         which collects all <a>properties</a> of a <a>node</a> in a single
         <a class="changed">map</a>. In the next step, the <var>node map</var> is
         converted to a JSON-LD document in
-        <a data-cite="JSON-LD11#flattened-document-form">flattened document form</a>.
-        Finally, if a <a>context</a> has been passed, the flattened document
-        is compacted using the <a href="#compaction-algorithm">Compaction algorithm</a>
-        before being returned.</p>
+        <a data-cite="JSON-LD11#flattened-document-form">flattened document form</a>.</p>
     </section>
 
     <section class="algorithm">
       <h3>Algorithm</h3>
 
-      <p>The algorithm takes <span class="changed">one required and two optional</span> input variables.
+      <p>The algorithm takes <span class="changed">one required and one optional</span> input variables.
         The required input is an <var>element</var> to flatten.
-        The optional inputs are the <var>context</var> used to compact the flattened document
-        <span class="changed">and the {{JsonLdOptions/ordered}} flag, used to order
+        <span class="changed">The optional input is
+          the {{JsonLdOptions/ordered}} flag, used to order
           <a>map entry</a> keys lexicographically, where noted</span>.
-        If not passed, <var>context</var> is set to <code>null</code>
-        <span class="changed">and, the {{JsonLdOptions/ordered}} flag is set to <code>false</code></span>.</p>
+        If not passed, the {{JsonLdOptions/ordered}} flag is set to <code>false</code></span>.</p>
 
       <p>This algorithm uses the
         <a href="#generate-blank-node-identifier">Generate Blank Node Identifier algorithm</a>
@@ -4505,14 +4501,7 @@
           <span class="changed">if {{JsonLdOptions/ordered}} is <code>true</code></span>,
           add <var>node</var> to <var>flattened</var>,
           unless the only <a>entry</a> of <var>node</var> is <code>@id</code>.</li>
-        <li>If <var>context</var> is <code>null</code>, return <var>flattened</var>.</li>
-        <li>Otherwise, return the result of <a>compacting</a> <var>flattened</var> according the
-          <a href="#compaction-algorithm">Compaction algorithm</a> passing <var>context</var>
-          <span class="changed">and the {{JsonLdOptions/ordered}} flag</span>
-          ensuring that the compaction result has only the <code>@graph</code> keyword (or its alias)
-          at the top-level other than <code>@context</code>, even if the context is empty or if there is only one element to
-          put in the <code>@graph</code> <a>array</a>. This ensures that the returned
-          document has a deterministic structure.</li>
+        <li>Return <var>flattened</var>.</li>
       </ol>
     </section>
   </section> <!-- end of Flattening Algorithm -->
@@ -5939,7 +5928,7 @@
       <dt><dfn data-dfn-for="JsonLdProcessor">flatten()</dfn></dt>
       <dd class="algorithm">
         <p><a href="#flattening">Flattens</a> the given <a data-lt="jsonldprocessor-flatten-input">input</a>
-          and <a>compacts</a> it using the passed <a data-lt="jsonldprocessor-flatten-context">context</a>
+          and optionally <a>compacts</a> it using the passed <a data-lt="jsonldprocessor-flatten-context">context</a>
           according to the steps in the <a href="#flattening-algorithm">Flattening algorithm</a>:</p>
 
         <ol>
@@ -5950,11 +5939,7 @@
             and <a data-lt="jsonldprocessor-flatten-options">options</a>
             <span class="changed">with {{JsonLdOptions/ordered}} set to <code>false</code></span>,
             <span class="changed">and {{JsonLdOptions/extractAllScripts}} defaulting to <code>true</code></span>.</li>
-          <li>If <a data-lt="jsonldprocessor-flatten-context">context</a> is a <a class="changed">map</a> having an <code>@context</code> <a>entry</a>,
-            set <var>context</var> to that <a data-lt="entry">entry's</a> value,
-            otherwise to <a data-lt="jsonldprocessor-flatten-context">context</a>.</li>
-          <li class="changed">Initialize an <var>active context</var> using <var>context</var>;
-            the <a>base IRI</a> is set to the {{JsonLdOptions/base}} option
+          <li class="changed">Initialize the <a>base IRI</a> to the {{JsonLdOptions/base}} option
             from <a data-lt="jsonldprocessor-flatten-options">options</a>, if set;
             otherwise, if the <a data-link-for="JsonLdOptions">compactToRelative</a> option is <strong>true</strong>,
             to the IRI of the currently being processed document, if available;
@@ -5962,10 +5947,17 @@
           <li>Initialize an empty <var>identifier map</var>.</li>
           <li>Set <var>flattened output</var> to the result of using the <a href="#flattening-algorithm">Flattening algorithm</a>,
             passing <var>expanded input</var> as <var>element</var>,
-            <var>active context</var>,
-            and if passed, the {{JsonLdOptions/compactArrays}}
-            <span class="changed">and {{JsonLdOptions/ordered}}</span>
-            flags in <a data-lt="jsonldprocessor-compact-options">options</a>.</li>
+            <span class="changed">and if passed, the {{JsonLdOptions/ordered}} flag
+              in <a data-lt="jsonldprocessor-flatten-options">options</a></span>.
+            <ol id="api-flatten-post-processing" class="changed">
+              <li>If a non-empty <a data-lt="jsonldprocessor-flatten-context">context</a> has been passed,
+                set <var>flattened output</var> to the result of
+                using the <a data-link-for="JsonLdProcessor">compact()</a> method
+                using <var>flattened output</var> for <a data-lt="jsonldprocessor-compact-input">input</a>,
+                <a data-lt="jsonldprocessor-flatten-context">context</a>,
+                and <a data-lt="jsonldprocessor-flatten-options">options</a>.</li>
+            </ol>
+          </li>
           <li>Resolve the <var>promise</var> with <var>flattened output</var>
             <span class="changed">transforming <var>flattened output</var> from the
               <a>internal representation</a> to a JSON serialization</span>.</li>

--- a/index.html
+++ b/index.html
@@ -3391,17 +3391,8 @@
         <span class="changed">The optional inputs are the
           {{JsonLdOptions/compactArrays}} flag
           and the {{JsonLdOptions/ordered}} flag, used to order
-          <a>map entry</a> keys lexicographically, where noted</span>.
-        To begin, the <var>active context</var> is set to the result of
-        performing <a href="#context-processing-algorithm">Context Processing</a>
-        on the passed <a>context</a>, the <var>inverse context</var> is
-        set to the result of performing the
-        <a href="#inverse-context-creation">Inverse Context Creation algorithm</a>
-        on <var>active context</var>, the <var>active property</var> is
-        set to <code>null</code>, <var>element</var> is set to the result of
-        performing the <a href="#expansion-algorithm">Expansion algorithm</a>
-        on the <a>JSON-LD input</a>.
-        <span class="changed">If not passed, the both flags are set to <code>false</code></span>.</p>
+          <a>map entry</a> keys lexicographically, where noted.
+          If not passed, the both flags are set to <code>false</code></span>.</p>
 
       <ol>
         <li class="changed">Initialize <var>type-scoped context</var> to <var>active context</var>.
@@ -5824,20 +5815,25 @@
           <li>If <a data-lt="jsonldprocessor-compact-context">context</a> is a <a class="changed">map</a> having an <code>@context</code> <a>entry</a>,
             set <var>context</var> to that <a data-lt="entry">entry's</a> value,
             otherwise to <a data-lt="jsonldprocessor-compact-context">context</a>.</li>
-          <li class="changed">Initialize an <var>active context</var> using <var>context</var>;
-            the <a>base IRI</a> is set to the {{JsonLdOptions/base}} option from <a data-lt="jsonldprocessor-compact-options">options</a>, if set;
+          <li class="changed">Initialize <var>active context</var>
+            to the result of the <a href="#context-processing-algorithm">Context Processing algorithm</a>
+            passing a new empty <a>context</a> as <var>active context</var>
+            and <var>context</var> as <var>local context</var>.</li>
+          <li>Initialize <var>inverse context</var> to the result of performing the
+            <a href="#inverse-context-creation">Inverse Context Creation algorithm</a>.</li>
+          <li>Initialize <a>base IRI</a> to the {{JsonLdOptions/base}} option from <a data-lt="jsonldprocessor-compact-options">options</a>, if set;
             otherwise, if the <a data-link-for="JsonLdOptions">compactToRelative</a> option is <strong>true</strong>,
             to the IRI of the currently being processed document, if available;
             otherwise to <code>null</code>.</li>
           <li>Set <var>compacted output</var> to the result of using the <a href="#compaction-algorithm">Compaction algorithm</a>,
             using <a>active context</a>,
-            an empty <a>map</a> as <var>inverse context</var>,
-            <code>null</code> as <var>property</var>,
+            <var>inverse context</var>,
+            <code>null</code> for <var>active property</var>,
             <var>expanded input</var> as <var>element</var>,
             and if passed, the {{JsonLdOptions/compactArrays}}
             <span class="changed">and {{JsonLdOptions/ordered}}</span>
             flags in <a data-lt="jsonldprocessor-compact-options">options</a>.
-            <ol id = "api-compact-post-processing" class="changed">
+            <ol id="api-compact-post-processing" class="changed">
               <li>If <var>compacted output</var> is an empty <a>array</a>,
                 replace it with a new <a>map</a>.</li>
               <li>Otherwise, if <var>compacted output</var> is an <a>array</a>,
@@ -7095,7 +7091,7 @@
           of <a href="#value-compaction" class="sectionRef"></a> to be consistent with other steps.
           This is in response to <a href="https://github.com/w3c/json-ld-api/issues/313">Issue 313</a>.</li>
         <li>Moved the last part of the compaction algorithm to
-          step <a href="#api-compact-post-processing">5</a> of
+          step <a href="#api-compact-post-processing">7</a> of
           the <a data-link-for="JsonLdProcessor">compact()</a> method of the
           <a>JsonLdProcessor</a> interface.</li>
       </ul>

--- a/index.html
+++ b/index.html
@@ -2394,10 +2394,8 @@
           the {{JsonLdOptions/ordered}} flag, used to order
           <a>map entry</a> keys lexicographically, where noted,
           and the <var>from map</var> flag, used to control reverting
-          previous <a>term definitions</a> in the <a>active context</a> associated with non-propagated <a>contexts</a>.</span>
-        To begin, the <var>active property</var> is set to <code>null</code>,
-        and <var>element</var> is set to the <a>JSON-LD input</a>.
-        <span class="changed">If not passed, the both flags are set to <code>false</code></span>.</p>
+          previous <a>term definitions</a> in the <a>active context</a> associated with non-propagated <a>contexts</a>.
+          If not passed, the both flags are set to <code>false</code></span>.</p>
 
       <p class="changed">The algorithm also performs processing steps specific to expanding
         a <a>JSON-LD Frame</a>. For a <a>frame</a>, the <code>@id</code> and
@@ -5900,7 +5898,9 @@
             update the <var>active context</var> using the <a href="#context-processing-algorithm">Context Processing algorithm</a>,
             passing the <a data-link-for="RemoteDocument">contextUrl</a> as <var>local context</var>.</li>
           <li>Set <var>expanded output</var> to the result of using the <a href="#expansion-algorithm">Expansion algorithm</a>,
-            passing the <var>active context</var> and <a data-link-for="RemoteDocument">document</a>
+            passing the <var>active context</var>,
+            <code>null</code> for <var>active property</var>,
+            and <a data-link-for="RemoteDocument">document</a>
             from <var>remote document</var>, or <a data-lt="jsonldprocessor-expand-input">input</a>
             if there is no <var>remote document</var> as <var>element</var>,
             and if passed, the <span class="changed">{{JsonLdOptions/frameExpansion}}</span>

--- a/index.html
+++ b/index.html
@@ -4454,7 +4454,7 @@
         The required input is an <var>element</var> to flatten.
         <span class="changed">The optional input is
           the {{JsonLdOptions/ordered}} flag, used to order
-          <a>map entry</a> keys lexicographically, where noted</span>.
+          <a>map entry</a> keys lexicographically, where noted.
         If not passed, the {{JsonLdOptions/ordered}} flag is set to <code>false</code></span>.</p>
 
       <p>This algorithm uses the

--- a/index.html
+++ b/index.html
@@ -3379,12 +3379,6 @@
           specified in the context such as <code>@index</code> or <code>@language</code>
           maps.</li>
       </ol>
-
-      <p>The final output is a <a class="changed">map</a> with an <code>@context</code>
-        <a>entry</a>, if a non-empty <a>context</a> was given, where the <a class="changed">map</a>
-        is either <var>result</var> or a wrapper for it where <var>result</var> appears
-        as the value of an (aliased) <code>@graph</code> <a>entry</a> because <var>result</var>
-        contained two or more items in an <a>array</a>.</p>
     </section>
 
     <section class="algorithm">
@@ -3968,18 +3962,6 @@
         </li>
         <li>Return <var>result</var>.</li>
       </ol>
-
-      <p>If, after the algorithm outlined above is run, <var>result</var>
-        <span class="changed">is an empty <a>array</a>, replace it with a new <a>map</a></span>.
-        Otherwise, if <var>result</var> is an <a>array</a>, replace it with a new
-        <a class="changed">map</a> with a single <a>entry</a> whose key is the result
-        of using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
-        passing <var>active context</var>, <var>inverse context</var>, and
-        <code>@graph</code> as <var>var</var> and whose value is the <a>array</a>
-        <var>result</var>.</p>
-      <p>Finally, if a non-empty <var>context</var> has been passed,
-        add an <code>@context</code> <a>entry</a> to <var>result</var> and set its value
-        to the passed <var>context</var>.</p>
     </section>
   </section> <!-- end of Compaction -->
 
@@ -5824,6 +5806,12 @@
         <p><a>Compacts</a> the given <a data-lt="jsonldprocessor-compact-input">input</a> using the
           <var>context</var> according to the steps in the <a href="#compaction-algorithm">Compaction algorithm</a>:</p>
 
+        <p class="changed">The final output is an <a>map</a> with an <code>@context</code>
+          <a>entry</a>, if a non-empty <a>context</a> was given, where the <a>map</a>
+          is either <var>compacted output</var> or a wrapper for it where <var>compacted output</var> appears
+          as the value of an (aliased) <code>@graph</code> <a>entry</a> because <var>compacted output</var>
+          contained two or more items in an <a>array</a>.</p>
+
         <ol>
           <li>Create a new {{Promise}} <var>promise</var> and return it.
             The following steps are then deferred.</li>
@@ -5848,7 +5836,21 @@
             <var>expanded input</var> as <var>element</var>,
             and if passed, the {{JsonLdOptions/compactArrays}}
             <span class="changed">and {{JsonLdOptions/ordered}}</span>
-            flags in <a data-lt="jsonldprocessor-compact-options">options</a>.</li>
+            flags in <a data-lt="jsonldprocessor-compact-options">options</a>.
+            <ol id = "api-compact-post-processing" class="changed">
+              <li>If <var>compacted output</var> is an empty <a>array</a>,
+                replace it with a new <a>map</a>.</li>
+              <li>Otherwise, if <var>compacted output</var> is an <a>array</a>,
+                replace it with a new <a>map</a> with a single <a>entry</a>
+                whose key is the result of using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
+                passing <var>active context</var>, <var>inverse context</var>, and
+                <code>@graph</code> as <var>var</var> and whose value is the <a>array</a>
+                <var>compacted output</var>.</li>
+              <li>If a non-empty <var>context</var> has been passed,
+                add an <code>@context</code> <a>entry</a> to <var>compacted output</var> and set its value
+                to the passed <var>context</var>.</li>
+            </ol>
+          </li>
           <li>Resolve the <var>promise</var> with <var>compacted output</var>
             <span class="changed">transforming <var>compacted output</var> from the
               <a>internal representation</a> to a JSON serialization</span>.</li>
@@ -7092,6 +7094,10 @@
         <li>Updated the language in step <a href="alg-valcompact-lang-dir">8</a>
           of <a href="#value-compaction" class="sectionRef"></a> to be consistent with other steps.
           This is in response to <a href="https://github.com/w3c/json-ld-api/issues/313">Issue 313</a>.</li>
+        <li>Moved the last part of the compaction algorithm to
+          step <a href="#api-compact-post-processing">5</a> of
+          the <a data-link-for="JsonLdProcessor">compact()</a> method of the
+          <a>JsonLdProcessor</a> interface.</li>
       </ul>
     </li>
   </ul>

--- a/index.html
+++ b/index.html
@@ -5760,14 +5760,14 @@
         constructor();
         static Promise&lt;JsonLdDictionary> compact(
           JsonLdInput input,
-          optional JsonLdContext context = {},
+          optional JsonLdContext context = null,
           optional JsonLdOptions options = {});
         static Promise&lt;sequence&lt;JsonLdDictionary>> expand(
           JsonLdInput input,
           optional JsonLdOptions options = {});
         static Promise&lt;JsonLdDictionary> flatten(
           JsonLdInput input,
-          optional JsonLdContext context = {},
+          optional JsonLdContext context = null,
           optional JsonLdOptions options = {});
         static Promise&lt;sequence&lt;JsonLdDictionary>> fromRdf(
           RdfDataset input,
@@ -5790,8 +5790,8 @@
           included with an entry of (a possibly aliased) <code>@graph</code>
           with the value of <var>compacted output</var>,
           otherwise <var>compacted output</var> is used as the <a>map</a> result.
-          If a non-empty <var>context</var> was given,
-          it an <code>@context</code> entry is added to the <a>map</a> result.</p>
+          If <a data-lt="jsonldprocessor-compact-context">context</a> not <code>null</code>,
+          an <code>@context</code> entry is added to the <a>map</a> result.</p>
 
         <ol>
           <li>Create a new {{Promise}} <var>promise</var> and return it.
@@ -5833,7 +5833,7 @@
                 passing <var>active context</var>, <var>inverse context</var>, and
                 <code>@graph</code> as <var>var</var> and whose value is the <a>array</a>
                 <var>compacted output</var>.</li>
-              <li>If a non-empty <var>context</var> has been passed,
+              <li>If <a data-lt="jsonldprocessor-compact-context">context</a> was not <code>null</code>,
                 add an <code>@context</code> <a>entry</a> to <var>compacted output</var> and set its value
                 to the passed <var>context</var>.</li>
             </ol>
@@ -5892,7 +5892,6 @@
             passing the <a data-link-for="RemoteDocument">contextUrl</a> as <var>local context</var>.</li>
           <li>Set <var>expanded output</var> to the result of using the <a href="#expansion-algorithm">Expansion algorithm</a>,
             passing the <var>active context</var>,
-            <code>null</code> for <var>active property</var>,
             and <a data-link-for="RemoteDocument">document</a>
             from <var>remote document</var>, or <a data-lt="jsonldprocessor-expand-input">input</a>
             if there is no <var>remote document</var> as <var>element</var>,
@@ -5950,7 +5949,7 @@
             <span class="changed">and if passed, the {{JsonLdOptions/ordered}} flag
               in <a data-lt="jsonldprocessor-flatten-options">options</a></span>.
             <ol id="api-flatten-post-processing" class="changed">
-              <li>If a non-empty <a data-lt="jsonldprocessor-flatten-context">context</a> has been passed,
+              <li>If <a data-lt="jsonldprocessor-flatten-context">context</a> is not <code>null</code>,
                 set <var>flattened output</var> to the result of
                 using the <a data-link-for="JsonLdProcessor">compact()</a> method
                 using <var>flattened output</var> for <a data-lt="jsonldprocessor-compact-input">input</a>,
@@ -5960,7 +5959,8 @@
           </li>
           <li>Resolve the <var>promise</var> with <var>flattened output</var>
             <span class="changed">transforming <var>flattened output</var> from the
-              <a>internal representation</a> to a JSON serialization</span>.</li>
+              <a>internal representation</a> to a JSON serialization</span>,
+              if necessary.</li>
         </ol>
 
         <dl class="parameters">

--- a/index.html
+++ b/index.html
@@ -5795,11 +5795,14 @@
         <p><a>Compacts</a> the given <a data-lt="jsonldprocessor-compact-input">input</a> using the
           <var>context</var> according to the steps in the <a href="#compaction-algorithm">Compaction algorithm</a>:</p>
 
-        <p class="changed">The final output is an <a>map</a> with an <code>@context</code>
-          <a>entry</a>, if a non-empty <a>context</a> was given, where the <a>map</a>
-          is either <var>compacted output</var> or a wrapper for it where <var>compacted output</var> appears
-          as the value of an (aliased) <code>@graph</code> <a>entry</a> because <var>compacted output</var>
-          contained two or more items in an <a>array</a>.</p>
+        <p class="changed">The final output is a <a>map</a>
+          derived from <var>compacted output</var>.
+          If <var>compacted output</var> is an <a>array</a>, it is
+          included with an entry of (a possibly aliased) <code>@graph</code>
+          with the value of <var>compacted output</var>,
+          otherwise <var>compacted output</var> is used as the <a>map</a> result.
+          If a non-empty <var>context</var> was given,
+          it an <code>@context</code> entry is added to the <a>map</a> result.</p>
 
         <ol>
           <li>Create a new {{Promise}} <var>promise</var> and return it.
@@ -5809,8 +5812,9 @@
             using <a data-lt="jsonldprocessor-compact-input">input</a>
             and <a data-lt="jsonldprocessor-compact-options">options</a>,
             <span class="changed">with {{JsonLdOptions/ordered}} set to <code>false</code></span>,
-            <span class="changed">and {{JsonLdOptions/extractAllScripts}} defaulting to <code>false</code></span>.
-          <li>If <a data-lt="jsonldprocessor-compact-context">context</a> is a <a class="changed">map</a> having an <code>@context</code> <a>entry</a>,
+            <span class="changed">and {{JsonLdOptions/extractAllScripts}} defaulting to <code>false</code></span>.</li>
+          <li>If <a data-lt="jsonldprocessor-compact-context">context</a> is a <a class="changed">map</a>
+            having an <code>@context</code> <a>entry</a>,
             set <var>context</var> to that <a data-lt="entry">entry's</a> value,
             otherwise to <a data-lt="jsonldprocessor-compact-context">context</a>.</li>
           <li class="changed">Initialize <var>active context</var>


### PR DESCRIPTION
rather than the algorithm, into the description of `compact()` in the API.

For #318.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/336.html" title="Last updated on Jan 18, 2020, 7:57 PM UTC (218b9cf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/336/95f5d46...218b9cf.html" title="Last updated on Jan 18, 2020, 7:57 PM UTC (218b9cf)">Diff</a>