### PR TITLE
Reduce boilerplate language by introducing macros.

### DIFF
--- a/common/algorithm-terms.html
+++ b/common/algorithm-terms.html
@@ -43,12 +43,13 @@
   <dt><dfn data-cite="JSON-LD11-API#dfn-iri-compacting">iri compacting</dfn></dt><dd class="algorithm">
     Used as a macro within various algorithms as to reduce the language used to describe
     the process of compacting a <a>string</a> <var>var</var> representing an <a>IRI</a> or <a>keyword</a>
-    relative to an <var>active context</var> either specified directly, or coming from the scope of
+    using an <var>active context</var> either specified directly, or coming from the scope of
     the algorithm step using this term and <var>inverse context</var> also taken
     from the scope of the algorithm step using this term.
     An optional <var>value</var> is used, if explicitly provided.
-    Unless specified, the <var>vocab</var>
-    flag defaults to `true`, and the <var>reverse</var> flag defaults to `false`.
+    Unless specified,
+    the <var>vocab</var> flag defaults to `true`,
+    and the <var>reverse</var> flag defaults to `false`.
     <ol>
       <li>Return the result of using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
         passing <var>active context</var>, <var>inverse context</var>,
@@ -56,6 +57,25 @@
         <var>value</var> (if supplied),
         <var>vocab</var>,
         and <var>result</var>.</li>
+    </ol>
+  </dd>
+  <dt><dfn data-cite="JSON-LD11-API#dfn-iri-expanding">iri expanding</dfn></dt><dd class="algorithm">
+    Used as a macro within various algorithms as to reduce the language used to describe
+    the process of expanding a <a>string</a> <var>value</var> representing an <a>IRI</a> or <a>keyword</a>
+    using an <var>active context</var> either specified directly, or coming from the scope of
+    the algorithm step using this term.
+    Optional <var>defined</var> and <var>local context</var> arguments are used, if explicitly provided.
+    Unless specified,
+    the <var>document relative</var> flag defaults to `false`,
+    and the <var>vocab</var> flag defaults to `true`.
+    <ol>
+      <li>Return the result of using the <a href="#iri-expansion">IRI Expansion algorithm</a>,
+        passing <var>active context</var>,
+        <var>value</var>,
+        <var>local context</var> (if supplied),
+        <var>defined</var> (if supplied),
+        <var>document relative</var>,
+        and <var>vocab</var>.</li>
     </ol>
   </dd>
   <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-input-frame">input frame</dfn></dt><dd>

--- a/common/algorithm-terms.html
+++ b/common/algorithm-terms.html
@@ -9,6 +9,27 @@
     which is used for finding coercion mappings in the <a>active context</a>.</dd>
   <dt><dfn data-cite="JSON-LD11-API#dfn-active-subject">active subject</dfn></dt><dd>
     The currently active subject that the processor should use when processing.</dd>
+  <dt><dfn data-cite="JSON-LD11-API#add-value">add value</dfn></dt><dd class="algorithm">
+    Used as a macro within various algorithms as a way to add a <var>value</var>
+    to an <a>entry</a> in a <a>map</a> (<var>object</var>) using a specified <var>key</var>.
+    The invocation may include an <var>as array</var> flag, either taken from the scope of the
+    algorithm step, or provided explicity, it otherwise defaults to <code>false</code>.
+    <ol>
+      <li>If <var>as array</var> is <code>true</code>,
+        and <var>value</var> is not an <a>array</a>,
+        set it to an <a>array</a> containing <var>value</var>.</li>
+      <li>If <var>key</var> is not an entry in <var>object</var>,
+        add <var>value</var> as the value of <var>key</var> in <var>object</var>.</li>
+      <li>Otherwise
+        <ol>
+          <li>If the value of <var>key</var> <a>entry</a> in <var>object</var> is not an <a>array</a>,
+            set it to a new <a>array</a> containing the original value.</li>
+          <li>If <var>value</var> is an <a>array</a>, concatenate <var>value</var>
+            to that <a>entry</a>.</li>
+          <li>Otherwise, append <var>value</var> to that <a>entry</a>.</li>
+        </ol>
+    </ol>
+  </dd>
   <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-expicit-inclusion-flag">explicit inclusion flag</dfn></dt><dd>
     A flag specifying that for <a>properties</a> to be included in the output,
     they must be explicitly declared in the matching <a>frame</a>.</dd>

--- a/common/algorithm-terms.html
+++ b/common/algorithm-terms.html
@@ -40,6 +40,24 @@
     used internally to help determine if object embedding is appropriate,</span>
     the <a>explicit inclusion flag</a>,
     and the <a>omit default flag</a>.</dd>
+  <dt><dfn data-cite="JSON-LD11-API#dfn-iri-compacting">iri compacting</dfn></dt><dd class="algorithm">
+    Used as a macro within various algorithms as to reduce the language used to describe
+    the process of compacting a <a>string</a> <var>var</var> representing an <a>IRI</a> or <a>keyword</a>
+    relative to an <var>active context</var> either specified directly, or coming from the scope of
+    the algorithm step using this term and <var>inverse context</var> also taken
+    from the scope of the algorithm step using this term.
+    An optional <var>value</var> is used, if explicitly provided.
+    Unless specified, the <var>vocab</var>
+    flag defaults to `true`, and the <var>reverse</var> flag defaults to `false`.
+    <ol>
+      <li>Return the result of using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
+        passing <var>active context</var>, <var>inverse context</var>,
+        <var>var</var>,
+        <var>value</var> (if supplied),
+        <var>vocab</var>,
+        and <var>result</var>.</li>
+    </ol>
+  </dd>
   <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-input-frame">input frame</dfn></dt><dd>
     The initial <a>Frame</a> provided to the framing algorithm.</dd>
   <dt><dfn data-cite="JSON-LD11-API#dfn-json-ld-input">JSON-LD input</dfn></dt><dd>

--- a/common/algorithm-terms.html
+++ b/common/algorithm-terms.html
@@ -9,7 +9,8 @@
     which is used for finding coercion mappings in the <a>active context</a>.</dd>
   <dt><dfn data-cite="JSON-LD11-API#dfn-active-subject">active subject</dfn></dt><dd>
     The currently active subject that the processor should use when processing.</dd>
-  <dt><dfn data-cite="JSON-LD11-API#add-value">add value</dfn></dt><dd class="algorithm">
+  <dt class="changed"><dfn data-cite="JSON-LD11-API#add-value">add value</dfn></dt>
+  <dd class="algorithm changed">
     Used as a macro within various algorithms as a way to add a <var>value</var>
     to an <a>entry</a> in a <a>map</a> (<var>object</var>) using a specified <var>key</var>.
     The invocation may include an <var>as array</var> flag defaulting to <code>false</code>.
@@ -40,7 +41,8 @@
     used internally to help determine if object embedding is appropriate,</span>
     the <a>explicit inclusion flag</a>,
     and the <a>omit default flag</a>.</dd>
-  <dt><dfn data-cite="JSON-LD11-API#dfn-iri-compacting">iri compacting</dfn></dt><dd class="algorithm">
+  <dt class="changed"><dfn data-cite="JSON-LD11-API#dfn-iri-compacting">IRI compacting</dfn></dt>
+  <dd class="algorithm changed">
     Used as a macro within various algorithms as to reduce the language used to describe
     the process of compacting a <a>string</a> <var>var</var> representing an <a>IRI</a> or <a>keyword</a>
     using an <var>active context</var> either specified directly, or coming from the scope of
@@ -59,7 +61,8 @@
         and <var>result</var>.</li>
     </ol>
   </dd>
-  <dt><dfn data-cite="JSON-LD11-API#dfn-iri-expanding">iri expanding</dfn></dt><dd class="algorithm">
+  <dt class="changed"><dfn data-cite="JSON-LD11-API#dfn-iri-expanding">IRI expanding</dfn></dt>
+  <dd class="algorithm changed">
     Used as a macro within various algorithms as to reduce the language used to describe
     the process of expanding a <a>string</a> <var>value</var> representing an <a>IRI</a> or <a>keyword</a>
     using an <var>active context</var> either specified directly, or coming from the scope of

--- a/common/algorithm-terms.html
+++ b/common/algorithm-terms.html
@@ -12,8 +12,7 @@
   <dt><dfn data-cite="JSON-LD11-API#add-value">add value</dfn></dt><dd class="algorithm">
     Used as a macro within various algorithms as a way to add a <var>value</var>
     to an <a>entry</a> in a <a>map</a> (<var>object</var>) using a specified <var>key</var>.
-    The invocation may include an <var>as array</var> flag, either taken from the scope of the
-    algorithm step, or provided explicity, it otherwise defaults to <code>false</code>.
+    The invocation may include an <var>as array</var> flag defaulting to <code>false</code>.
     <ol>
       <li>If <var>as array</var> is <code>true</code>,
         and <var>value</var> is not an <a>array</a>,

--- a/index.html
+++ b/index.html
@@ -2744,18 +2744,16 @@
                       i.e., <a>properties</a> that are reversed twice, execute for each of its
                       <var>property</var> and <var>item</var> the following steps:
                       <ol>
-                        <li>If <var>result</var> does not have a <var>property</var> <a>entry</a>, create
-                          one and set its value to an empty <a>array</a>.</li>
-                        <li>Append <var>item</var> to the value of the <var>property</var> <a>entry</a>
-                          of <var>result</var>.</li>
+                        <li class="changed">Use <a>add value</a> to add <var>item</var>
+                          to the <var>property</var> <a>entry</a> in <var>result</var>
+                          using `true` for <var>as array</var>.</li>
                       </ol>
                     </li>
                     <li>If <var>expanded value</var> contains an <a>entry</a> other than <code>@reverse</code>:
                       <ol>
-                        <li>If <var>result</var> does not have an <code>@reverse</code> <a>entry</a>, create
-                          one and set its value to an empty <a class="changed">map</a>.</li>
-                        <li>Reference the value of the <code>@reverse</code> <a>entry</a> in <var>result</var>
-                          using the variable <var>reverse map</var>.</li>
+                        <li class="changed">Set <var>reverse map</var> to the value
+                          of the `@reverse` entry in <var>result</var>,
+                          initializing it to an empty <a>map</a>, if necessary.</li>
                         <li>For each <var>property</var> and <var>items</var> in <var>expanded value</var>
                           other than <code>@reverse</code>:
                           <ol>
@@ -2764,10 +2762,9 @@
                                 <li>If <var>item</var> is a <a>value object</a> or <a>list object</a>, an
                                   <a data-link-for="JsonLdErrorCode">invalid reverse property value</a>
                                   has been detected and processing is aborted.</li>
-                                <li>If <var>reverse map</var> has no <var>property</var> <a>entry</a>, create one
-                                  and initialize its value to an empty <a>array</a>.</li>
-                                <li>Append <var>item</var> to the value of the <var>property</var>
-                                  <a>entry</a> in <var>reverse map</var>.</li>
+                                <li class="changed">Use <a>add value</a> to add <var>item</var>
+                                  to the <var>property</var> <a>entry</a> in <var>reverse map</var>
+                                  using `true` for <var>as array</var>.</li>
                               </ol>
                             </li>
                           </ol>
@@ -2994,20 +2991,17 @@
                       has been detected and processing is aborted.</li>
                     <li>If <var>reverse map</var> has no <var>expanded property</var> <a>entry</a>,
                       create one and initialize its value to an empty <a>array</a>.</li>
-                    <li>Append <var>item</var> to the value of the <var>expanded property</var>
-                      <a>entry</a> of <var>reverse map</var>.</li>
+                    <li class="changed">Use <a>add value</a> to add <var>item</var>
+                      to the <var>expanded property</var> <a>entry</a> in <var>reverse map</var>
+                      using `true` for <var>as array</var>.</li>
                   </ol>
                 </li>
               </ol>
             </li>
-            <li>Otherwise, <var>key</var> is not a <a>reverse property</a>:
-              <ol>
-                <li>If <var>result</var> does not have an <var>expanded property</var>
-                  <a>entry</a>, create one and initialize its value to an empty
-                  <a>array</a>.</li>
-                <li>Append <var>expanded value</var> to value of the <var>expanded property</var>
-                  <a>entry</a> of <var>result</var>.</li>
-              </ol>
+            <li>Otherwise, <var>key</var> is not a <a>reverse property</a>
+              <span class="changed">use <a>add value</a> to add <var>expanded value</var>
+                to the <var>expanded property</var> <a>entry</a> in <var>result</var>
+                using `true` for <var>as array</var>.</span>
             </li>
           </ol>
         </li>
@@ -3537,9 +3531,6 @@
                         <li>Append <var>term</var>, to <var>compacted value</var>.</li>
                       </ol>
                     </li>
-                    <li>If <var>compacted value</var> contains only one
-                      item (it has a length of <code>1</code>), then
-                      set <var>compacted value</var> to its only item.</li>
                   </ol>
                 </li>
                 <li>Initialize <var>alias</var> to the result of using the
@@ -3547,12 +3538,14 @@
                   passing <var>active context</var>, <var>inverse context</var>,
                   <var>expanded property</var> for <var>var</var>,
                   and <code>true</code> for <var>vocab</var>.</li>
-                <li class="changed">If the <a>term definition</a> for <var>alias</var> in the
-                  <var>active context</var> has a <a>container mapping</a> including <code>@set</code>,
-                  ensure that <var>compacted value</var> is an <a>array</a>.</li>
-                <li>Add an <a>entry</a> <var>alias</var> to <var>result</var> whose value is
-                  set to <var>compacted value</var> and continue to the next
-                  <var>expanded property</var>.</li>
+                <li class="changed">Initialize <var>as array</var>
+                  to <code>true</code> if the <a>container mapping</a> for <var>alias</var> in the
+                  <var>active context</var> includes <code>@set</code>,
+                  otherwise to the negation of {{JsonLdOptions/compactArrays}}.</li>
+                <li class="changed">Use <a>add value</a> to add <var>compacted value</var>
+                  to the <var>alias</var> <a>entry</a> in <var>result</var>
+                  using <var>as array</var>.</li>
+                <li>Continue to the next <var>expanded property</var>.</li>
               </ol>
             </li>
             <li>If <var>expanded property</var> is <code>@reverse</code>:
@@ -3569,22 +3562,14 @@
                     <li>If the <a>term definition</a> for <var>property</var> in the
                       <var>active context</var> indicates that <var>property</var> is
                       a <a>reverse property</a>
-                            <ol>
-                        <li>If the <a>term definition</a> for <var>property</var> in
-                          the <var>active context</var> has a
-                          <a>container mapping</a> <span class="changed">including</span> <code>@set</code> or
-                          {{JsonLdOptions/compactArrays}}
-                          is <code>false</code>, and <var>value</var> is not an
-                          <a>array</a>, set <var>value</var> to a new
-                          <a>array</a> containing only <var>value</var>.</li>
-                        <li>If <var>property</var> is not an <a>entry</a> of
-                          <var>result</var>, add one and set its value to <var>value</var>.</li>
-                        <li>Otherwise, if the value of the <var>property</var> <a>entry</a> of
-                          <var>result</var> is not an <a>array</a>, set it to a new
-                          <a>array</a> containing only the value. Then
-                          append <var>value</var> to its value if <var>value</var>
-                          is not an <a>array</a>, otherwise append each
-                          of its items.</li>
+                      <ol>
+                        <li class="changed">Initialize <var>as array</var>
+                          to <code>true</code> if the <a>container mapping</a> for <var>property</var> in the
+                          <var>active context</var> includes <code>@set</code>,
+                          otherwise the negation of {{JsonLdOptions/compactArrays}}.</li>
+                        <li class="changed">Use <a>add value</a> to add <var>value</var>
+                          to the <var>property</var> <a>entry</a> in <var>result</var>
+                          using <var>as array</var>.</li>
                         <li>Remove the <var>property</var> <a>entry</a> from
                           <var>compacted value</var>.</li>
                       </ol>
@@ -3652,23 +3637,22 @@
                   <code>true</code> for <var>vocab</var>, and
                   <var>inside reverse</var> for the <var>reverse</var> flag.</li>
                 <li class="changed">If the <a>term definition</a> for <var>item active property</var>
-                  in the <var>active context</var> has a <a>nest value</a>, that value (<var>nest term</var>) must be
-                  <code>@nest</code>, or a <a>term</a> in the
-                  <var>active context</var> that expands to <code>@nest</code>,
-                  otherwise an <a data-link-for="JsonLdErrorCode">invalid @nest value</a>
-                  error has been detected, and processing is aborted.
-                  If <var>result</var> does not have a <var>nest term</var> <a>entry</a>,
-                  initialize it to an empty <a>map</a> (<var>nest object</var>).
-                  If <var>nest object</var> does not have an <var>item active property</var> <a>entry</a>,
-                  set this <a data-lt="entry">entry's</a>
-                  value in <var>nest object</var> to an empty
-                  <a>array</a>.Otherwise, if the <a data-lt="entry">entry's</a> value is not an
-                  <a>array</a>, then set it to one containing only the value.</li>
-                <li>Otherwise, if <var>result</var> does not have an
-                  <var>item active property</var> <a>entry</a>, set this <a data-lt="entry">entry's</a> value in
-                  <var>result</var> to an empty <a>array</a>. Otherwise, if
-                  the <a data-lt="entry">entry's</a> value is not an <a>array</a>, then set it
-                  to one containing only the value.</li>
+                  in the <var>active context</var> has a <a>nest value</a>
+                  <a>entry</a> (<var>nest term</var>).
+                  <ol>
+                    <li>If <var>nest term</var> is not <code>@nest</code>,
+                      or a <a>term</a> in the <var>active context</var> that expands to <code>@nest</code>,
+                      an <a data-link-for="JsonLdErrorCode">invalid @nest value</a>
+                      error has been detected, and processing is aborted.</li>
+                    <li>If <var>result</var> does not have a <var>nest term</var> <a>entry</a>,
+                      initialize it to an empty <a>map</a>.</li>
+                    <li>Initialize <var>nest result</var> to the value of <var>nest term</var> in <var>result</var>.</li>
+                  </ol>
+                </li>
+                <li class="changed">Otherwise, initialize <var>nest result</var> to <var>result</var>.</li>
+                <li class="changed">Use <a>add value</a> to add an empty <a>array</a>
+                  to the <var>item active property</var> <a>entry</a> in <var>nest result</var>
+                  using <code>true</code> for <var>as array</var>.</li>
               </ol>
             </li>
             <li>
@@ -3686,22 +3670,25 @@
                   <var>inside reverse</var> for the <var>reverse</var> flag.</li>
                 <li class="changed">If the <a>term definition</a> for <var>item active property</var>
                   in the <var>active context</var> has a <a>nest value</a>
-                  <a>entry</a>, that value (<var>nest term</var>) must be
-                  <code>@nest</code>, or a <a>term</a> in the
-                  <var>active context</var> that expands to <code>@nest</code>,
-                  otherwise an <a data-link-for="JsonLdErrorCode">invalid @nest value</a>
-                  error has been detected, and processing is aborted.
-                  Set <var>nest result</var> to the value of <var>nest term</var> in <var>result</var>,
-                  initializing it to a new <a class="changed">map</a>, if necessary; otherwise
-                  set <var>nest result</var> to <var>result</var>.</li>
+                  <a>entry</a> (<var>nest term</var>).
+                  <ol>
+                    <li>If <var>nest term</var> is not <code>@nest</code>,
+                      or a <a>term</a> in the <var>active context</var> that expands to <code>@nest</code>,
+                      an <a data-link-for="JsonLdErrorCode">invalid @nest value</a>
+                      error has been detected, and processing is aborted.</li>
+                    <li>If <var>result</var> does not have a <var>nest term</var> <a>entry</a>,
+                      initialize it to an empty <a>map</a>.</li>
+                    <li>Initialize <var>nest result</var> to the value of <var>nest term</var> in <var>result</var>.</li>
+                  </ol>
+                </li>
+                <li>Otherwise, initialize <var>nest result</var> to <var>result</var>.</li>
                 <li>Initialize <var>container</var> to <a>container mapping</a> for
                   <var>item active property</var> in <var>active context</var>,
                   or to a new empty <a>array</a>, if there is no such <a>container mapping</a>.</li>
-                <li class="changed">Initialize <var>as array</var> to
-                  <code>true</code> or <code>false</code> depending on if the <a>container mapping</a> for
-                  <var>item active property</var> in <var>active context</var>
-                  includes <code>@set</code> or if <var>item active property</var>
-                  is <code>@graph</code> or <code>@list</code>.</li>
+                <li class="changed">Initialize <var>as array</var>
+                  to <code>true</code> if <var>container</var> includes <code>@set</code>,
+                  or if <var>item active property</var> is <code>@graph</code> or <code>@list</code>,
+                  otherwise the negation of {{JsonLdOptions/compactArrays}}.</li>
                 <li>Initialize <var>compacted item</var> to the result of using
                   this algorithm recursively, passing
                   <var>active context</var>, <var>inverse context</var>,
@@ -3712,11 +3699,10 @@
                   otherwise pass the value of the <a>entry</a> for <var>element</var>.
                   <span class="changed">Along with the {{JsonLdOptions/compactArrays}}
                     and {{JsonLdOptions/ordered}} flags</span></li>
-                <li>
-                  If <var>expanded item</var> is a <a>list object</a>:
+                <li>If <var>expanded item</var> is a <a>list object</a>:
                   <ol>
                     <li>If <var>compacted item</var> is not an <a>array</a>,
-                      then set it to an <a>array</a> containing only
+                      then set <var>compacted item</var> to an <a>array</a> containing only
                       <var>compacted item</var>.</li>
                     <li>If <var>container</var> does not include <code>@list</code>:
                       <ol>
@@ -3735,64 +3721,51 @@
                           passing <var>active context</var>, <var>inverse context</var>,
                           <code>@index</code> as <var>var</var>, and the value associated with the
                           <code>@index</code> <a>entry</a> in <var>expanded item</var> as <var>value</var>.</li>
+                        <li>Use <a>add value</a> to add <var>compacted item</var>
+                          to the <var>item active property</var> <a>entry</a> in
+                          <var>nest result</var>
+                          using <var>as array</var>.</li>
                       </ol>
                     </li>
-                    <li class="changed">Otherwise, append <var>compacted item</var>
-                      to the value associated with the
-                      <var>item active property</var> <a>entry</a> in
-                      <var>nest result</var>, initializing it to a new empty <a>array</a>, if
-                      necessary.</li>
+                    <li class="changed">Otherwise, set the value of the <var>item active property</var> entry
+                      in <var>nest result</var> to <var>compacted item</var>.</li>
                   </ol>
                 </li>
-                <li class="changed">
-                  If <var>expanded item</var> is a <a>graph object</a>:
+                <li class="changed">If <var>expanded item</var> is a <a>graph object</a>:
                   <ol>
                     <li>If <var>container</var> includes <code>@graph</code> and <code>@id</code>:
                       <ol>
                         <li>Initialize <var>map object</var> to the value of <var>item active property</var>
-                          in <var>nest result</var>.</li>
+                          in <var>nest result</var>,
+                          initializing it to a new empty <a>map</a>, if necessary.</li>
                         <li>Initialize <var>map key</var> to the result of calling the
                           <a href="#iri-compaction">IRI Compaction algorithm</a>
                           passing <var>active context</var>, <var>inverse context</var>, and the value of <code>@id</code> in <var>expanded item</var>
                           or <code>@none</code> if no such value exists as <var>var</var>, with <var>vocab</var> set to <code>true</code>
                           if there is no <code>@id</code> <a>entry</a> in <var>expanded item</var>.</li>
-                        <li>If <var>compacted item</var> is not an
-                          <a>array</a> and <var>as array</var> is <code>true</code>,
-                          set <var>compacted item</var> to an <a>array</a> containing that value.</li>
-                        <li>If <var>map key</var> is not an <a>entry</a> in <var>map object</var>,
-                          then set this <a data-lt="entry">entry's</a> value in <var>map object</var>
-                          to <var>compacted item</var>. Otherwise, if the value
-                          is not an <a>array</a>, then set it to one
-                          containing only the value and then append
-                          <var>compacted item</var> to it.</li>
+                        <li class="changed">Use <a>add value</a> to add <var>compacted item</var>
+                          to the <var>map key</var> entry in <var>map object</var>
+                          using <var>as array</var>.</li>
                       </ol>
                     </li>
                     <li>Otherwise, if <var>container</var> includes <code>@graph</code> and <code>@index</code>
                       and <var>expanded item</var> is a <a>simple graph object</a>:
                       <ol>
                         <li>Initialize <var>map object</var> to the value of <var>item active property</var>
-                          in <var>nest result</var>.</li>
+                          in <var>nest result</var>,
+                          initializing it to a new empty <a>map</a>, if necessary.</li>
                         <li>Initialize <var>map key</var> the value of <code>@index</code> in
                           <var>expanded item</var> or <code>@none</code>, if no such
                           value exists.</li>
-                        <li>If <var>compacted item</var> is not an
-                          <a>array</a> and <var>as array</var> is <code>true</code>,
-                          set <var>compacted item</var> to an <a>array</a> containing that value.</li>
-                        <li>If <var>map key</var> is not an <a>entry</a> in <var>map object</var>,
-                          then set this <a data-lt="entry">entry's</a> value in <var>map object</var>
-                          to <var>compacted item</var>. Otherwise, if the value
-                          is not an <a>array</a>, then set it to one
-                          containing only the value and then append
-                          <var>compacted item</var> to it.</li>
+                        <li class="changed">Use <a>add value</a> to add <var>compacted item</var>
+                          to the <var>map key</var> entry in <var>map object</var>
+                          using <var>as array</var>.</li>
                       </ol>
                     </li>
                     <li>Otherwise, if <var>container</var> includes <code>@graph</code>
                       and <var>expanded item</var> is a <a>simple graph object</a>
                       the value cannot be represented as a map object.
                       <ol>
-                        <li>If <var>compacted item</var> is not an <a>array</a>
-                          and <var>as array</var> is <code>true</code>,
-                          set <var>compacted item</var> to an <a>array</a> containing that value.</li>
                         <li>If <var>compacted item</var> is an <a>array</a>
                           with more than one value, it cannot be directly represented,
                           as multiple objects would be interpreted as different named graphs.
@@ -3801,16 +3774,13 @@
                           passing <var>active context</var>, <var>inverse context</var>, `@included` as
                           <var>var</var>, and `true` for
                           <var>vocab</var> and the original <var>compacted item</var> as the value. </li>
-                        <li>If the value of an <var>item active property</var> <a>entry</a> in <var>nest result</var>
-                          is not an <a>array</a>,
-                          set it to a new <a>array</a> containing only the value.</li>
-                        <li>Then append <var>compacted item</var> to the value if
-                          <var>compacted item</var> is not an <a>array</a>,
-                          otherwise, concatenate <var>compacted item</var> to the value.</li>
+                        <li class="changed">Use <a>add value</a> to add <var>compacted item</var>
+                          to the <var>item active property</var> entry in <var>nest result</var>
+                          using <var>as array</var>.</li>
                       </ol>                      
                     </li>
                     <li>Otherwise, <var>container</var> does not include <code>@graph</code>
-                      or otherwise does not match one of the previous cases, redo <var>compacted item</var>.
+                      or otherwise does not match one of the previous cases.
                       <ol>
                         <li>Set <var>compacted item</var> to a new map containing
                           the key resulting from calling the <a
@@ -3836,12 +3806,9 @@
                           <var>var</var>, and <code>true</code> for
                           <var>vocab</var> using the value of <code>@index</code>
                           in <var>expanded item</var> to <var>compacted item</var>.</li>
-                        <li>If <var>as array</var> is <code>true</code>,
-                          set <var>compacted item</var> to an <a>array</a>
-                          containing that value.</li>
-                        <li>Then append <var>compacted item</var> to the value if
-                          <var>compacted item</var> is not an <a>array</a>,
-                          otherwise, concatenate <var>compacted item</var> to the value.</li>
+                        <li class="changed">Use <a>add value</a> to add <var>compacted item</var>
+                          to the <var>item active property</var> entry in <var>nest result</var>
+                          using <var>as array</var>.</li>
                       </ol>
                     </li>
                   </ol>
@@ -3852,10 +3819,9 @@
                     or <code>@type</code></span>
                     <span class="changed">and <var>container</var> does not include <code>@graph</code></span>:
                   <ol>
-                    <li>If <var>item active property</var> is not an <a>entry</a> in
-                      <var class="changed">nest result</var>, initialize it to an empty <a class="changed">map</a>.
-                      Initialize <var>map object</var> to the value of <var>item active property</var>
-                      in <var class="changed">nest result</var>.</li>
+                    <li class="changed">Initialize <var>map object</var> to the value of <var>item active property</var>
+                      in <var>nest result</var>,
+                      initializing it to a new empty <a>map</a>, if necessary.</li>
                     <li>Initialize <var>container key</var> to the result of calling the
                       <a href="#iri-compaction">IRI Compaction algorithm</a>
                       passing <var>active context</var>, <var>inverse context</var>,
@@ -3906,44 +3872,19 @@
                         </li>
                       </ol>
                     </li>
-                    <li class="changed">If <var>compacted item</var> is not an
-                      <a>array</a> and <var>as array</var> is <code>true</code>,
-                      set <var>compacted item</var> to an <a>array</a> containing that value.</li>
                     <li>If <var>map key</var> is <code>null</code>, set it to the result of calling the
                       <a href="#iri-compaction">IRI Compaction algorithm</a>
                       passing <var>active context</var>, <var>inverse context</var>, <code>@none</code> as
                       <var>var</var>, and <code>true</code> for
                       <var>vocab</var>.</li>
-                    <li>If <var>map key</var> is not an <a>entry</a> of <var>map object</var>,
-                      then set this <a data-lt="entry">entry's</a> value in <var>map object</var>
-                      to <var>compacted item</var>. Otherwise, if the value
-                      is not an <a>array</a>, then set it to one
-                      containing only the value and then append
-                      <var>compacted item</var> to it.</li>
+                    <li class="changed">Use <a>add value</a> to add <var>compacted item</var>
+                      to the <var>map key</var> entry in <var>map object</var>
+                      using <var>as array</var>.</li>
                   </ol>
                 </li>
-                <li>
-                  Otherwise,
-                  <ol>
-                    <li>If
-                      {{JsonLdOptions/compactArrays}}
-                      is <code>false</code>, <var>as array</var> is <code>true</code> and
-                      <var>compacted item</var> is not an <a>array</a>,
-                      set it to a new <a>array</a>
-                      containing only <var>compacted item</var>.</li>
-                    <li>If <var>item active property</var> is not an <a>entry</a> in
-                      <var>result</var> then add the <a>entry</a>,
-                      (<var>item active property</var>-<var>compacted item</var>),
-                      to <var class="changed">nest result</var>.</li>
-                    <li>Otherwise, if the value associated with the 
-                      <var>item active property</var> <a>entry</a> in <var class="changed">nest result</var>
-                      is not an <a>array</a>, set it to a new
-                      <a>array</a> containing only the value. Then
-                      append <var>compacted item</var> to the value if
-                      <var>compacted item</var> is not an <a>array</a>,
-                      otherwise, concatenate <var>compacted item</var> to the value.</li>
-                  </ol>
-                </li>
+                <li class="changed">Otherwise, use <a>add value</a> to add <var>compacted item</var>
+                  to the <var>item active property</var> entry in <var>result</var>
+                  using <var>as array</var>.</li>
               </ol>
             </li>
           </ol>

--- a/index.html
+++ b/index.html
@@ -3638,7 +3638,7 @@
                   <var>inside reverse</var> for the <var>reverse</var> flag.</li>
                 <li class="changed">If the <a>term definition</a> for <var>item active property</var>
                   in the <var>active context</var> has a <a>nest value</a>
-                  <a>entry</a> (<var>nest term</var>).
+                  <a>entry</a> (<var>nest term</var>):
                   <ol>
                     <li>If <var>nest term</var> is not <code>@nest</code>,
                       or a <a>term</a> in the <var>active context</var> that expands to <code>@nest</code>,
@@ -3670,7 +3670,7 @@
                   <var>inside reverse</var> for the <var>reverse</var> flag.</li>
                 <li class="changed">If the <a>term definition</a> for <var>item active property</var>
                   in the <var>active context</var> has a <a>nest value</a>
-                  <a>entry</a> (<var>nest term</var>).
+                  <a>entry</a> (<var>nest term</var>):
                   <ol>
                     <li>If <var>nest term</var> is not <code>@nest</code>,
                       or a <a>term</a> in the <var>active context</var> that expands to <code>@nest</code>,

--- a/index.html
+++ b/index.html
@@ -3465,10 +3465,8 @@
         <li class="changed">If <var>element</var> has an <code>@type</code> <a>entry</a>,
           create a new array <var>compacted types</var> initialized
           by transforming each <var>expanded type</var> of that <a>entry</a>
-          into its compacted form using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
-          passing <var>active context</var>, <var>inverse context</var>,
-          <var>expanded type</var> for <var>var</var>,
-          and <code>true</code> for <var>vocab</var>.
+          into its compacted form
+          <span class="changed">by <a>iri compacting</a> <var>expanded context</var></span>.
           Then, for each <var>term</var>
           in <var>compacted types</var> ordered lexicographically:
           <ol>
@@ -3493,15 +3491,11 @@
             <li>If <var>expanded property</var> is <code>@id</code>:
               <ol>
                 <li>If <var>expanded value</var> is a <a>string</a>,
-                  then initialize <var>compacted value</var> to the result
-                  of using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
-                  passing <var>active context</var>, <var>inverse context</var>,
-                  and <var>expanded value</var> for <var>var</var>.</li>
-                <li>Initialize <var>alias</var> to the result of using the
-                  <a href="#iri-compaction">IRI Compaction algorithm</a>,
-                  passing <var>active context</var>, <var>inverse context</var>,
-                  <var>expanded property</var> for <var>var</var>,
-                  and <code>true</code> for <var>vocab</var>.</li>
+                  then initialize <var>compacted value</var>
+                  <span class="changed">by <a>iri compacting</a> <var>expanded value</var>
+                    with <var>vocab</var> set to `false`</span>.</li>
+                <li>Initialize <var>alias</var>
+                  <span class="changed">by <a>iri compacting</a> <var>expanded property</var></span>.</li>
                 <li>Add an <a>entry</a> <var>alias</var> to <var>result</var> whose value is
                   set to <var>compacted value</var> and continue to the next
                   <var>expanded property</var>.</li>
@@ -3510,11 +3504,9 @@
             <li>If <var>expanded property</var> is <code>@type</code>:
               <ol>
                 <li>If <var>expanded value</var> is a <a>string</a>,
-                  then initialize <var>compacted value</var> to the result
-                  of using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
-                  passing <var>type-scoped context</var> for <var>active context</var>, <var>inverse context</var>,
-                  <var>expanded value</var> for <var>var</var>,
-                  and <code>true</code> for <var>vocab</var>.</li>
+                  then initialize <var>compacted value</var>
+                  <span class="changed">by <a>iri compacting</a> <var>expanded value</var>
+                    using <var>type-scoped context</var> for <var>active context</var></span>.</li>
                 <li>Otherwise, <var>expanded value</var> must be a
                   <code>@type</code> <a>array</a>:
                   <ol>
@@ -3523,21 +3515,16 @@
                     <li>For each item <var>expanded type</var> in
                       <var>expanded value</var>:
                       <ol>
-                        <li>Set <var>term</var> to the result of
-                          of using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
-                          passing <var>type-scoped context</var> for <var>active context</var>, <var>inverse context</var>,
-                          <var>expanded type</var> for <var>var</var>, and
-                          <code>true</code> for <var>vocab</var>.</li>
+                        <li>Set <var>term</var>
+                          <span class="changed">by <a>iri compacting</a> <var>expanded type</var>
+                            using <var>type-scoped context</var> for <var>active context</var></span>.</li>
                         <li>Append <var>term</var>, to <var>compacted value</var>.</li>
                       </ol>
                     </li>
                   </ol>
                 </li>
-                <li>Initialize <var>alias</var> to the result of using the
-                  <a href="#iri-compaction">IRI Compaction algorithm</a>,
-                  passing <var>active context</var>, <var>inverse context</var>,
-                  <var>expanded property</var> for <var>var</var>,
-                  and <code>true</code> for <var>vocab</var>.</li>
+                <li>Initialize <var>alias</var>
+                  <span class="changed">by <a>iri compacting</a> <var>expanded property</var></span>.</li>
                 <li class="changed">Initialize <var>as array</var>
                   to <code>true</code> if the <a>container mapping</a> for <var>alias</var> in the
                   <var>active context</var> includes <code>@set</code>,
@@ -3579,11 +3566,8 @@
                 <li>If <var>compacted value</var> has some remaining <a>map entries</a>, i.e.,
                   it is not an empty <a class="changed">map</a>:
                   <ol>
-                    <li>Initialize <var>alias</var> to the result of using the
-                      <a href="#iri-compaction">IRI Compaction algorithm</a>,
-                      passing <var>active context</var>, <var>inverse context</var>,
-                      <code>@reverse</code> for <var>var</var>,
-                      and <code>true</code> for <var>vocab</var>.</li>
+                    <li>Initialize <var>alias</var>
+                      <span class="changed">by <a>iri compacting</a> `@reverse`</span>.</li>
                     <li>Set the value of the <var>alias</var> <a>entry</a> of <var>result</var> to
                       <var>compacted value</var>.</li>
                   </ol>
@@ -3617,11 +3601,8 @@
               <code>@language</code>,
               or <code>@value</code>:
               <ol>
-                <li>Initialize <var>alias</var> to the result of using
-                  the <a href="#iri-compaction">IRI Compaction algorithm</a>,
-                  passing <var>active context</var>, <var>inverse context</var>,
-                  <var>expanded property</var> for <var>var</var>,
-                  and <code>true</code> for <var>vocab</var>.</li>
+                <li>Initialize <var>alias</var>
+                  <span class="changed">by <a>iri compacting</a> <var>expanded property</var></span>.</li>
                 <li>Add an <a>entry</a> <var>alias</var> to <var>result</var> whose value is
                   set to <var>expanded value</var> and continue with the next
                   <var>expanded property</var>.</li>
@@ -3629,13 +3610,10 @@
             </li>
             <li>If <var>expanded value</var> is an empty <a>array</a>:
               <ol>
-                <li>Initialize <var>item active property</var> to the result of
-                  using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
-                  passing <var>active context</var>, <var>inverse context</var>,
-                  <var>expanded property</var> for <var>var</var>,
-                  <var>expanded value</var> for <var>value</var>,
-                  <code>true</code> for <var>vocab</var>, and
-                  <var>inside reverse</var> for the <var>reverse</var> flag.</li>
+                <li>Initialize <var>item active property</var>
+                  <span class="changed">by <a>iri compacting</a> <var>expanded property</var>
+                    using <var>expanded value</var> for <var>value</var>
+                    and <var>inside reverse</var> for <var>reverse</var></span>.</li>
                 <li class="changed">If the <a>term definition</a> for <var>item active property</var>
                   in the <var>active context</var> has a <a>nest value</a>
                   <a>entry</a> (<var>nest term</var>):
@@ -3661,13 +3639,10 @@
               <a href="#expansion-algorithm">Expansion algorithm</a>.
               For each item <var>expanded item</var> in <var>expanded value</var>:
               <ol>
-                <li>Initialize <var>item active property</var> to the result of using
-                  the <a href="#iri-compaction">IRI Compaction algorithm</a>,
-                  passing <var>active context</var>, <var>inverse context</var>,
-                  <var>expanded property</var> for <var>var</var>,
-                  <var>expanded item</var> for <var>value</var>,
-                  <code>true</code> for <var>vocab</var>, and
-                  <var>inside reverse</var> for the <var>reverse</var> flag.</li>
+                <li>Initialize <var>item active property</var>
+                  <span class="changed">by <a>iri compacting</a> <var>expanded property</var>
+                    using <var>expanded item</var> for <var>value</var>
+                    and <var>inside reverse</var> for <var>reverse</var></span>.</li>
                 <li class="changed">If the <a>term definition</a> for <var>item active property</var>
                   in the <var>active context</var> has a <a>nest value</a>
                   <a>entry</a> (<var>nest term</var>):
@@ -3709,18 +3684,15 @@
                         <li>Convert <var>compacted item</var> to a
                           <a>list object</a> by setting it to a
                           <a class="changed">map</a> containing an <a>entry</a>
-                          where the key is the result of the
-                          <a href="#iri-compaction">IRI Compaction algorithm</a>,
-                          passing <var>active context</var>, <var>inverse context</var>,
-                          <code>@list</code> for <var>var</var>, and <var>compacted item</var>
-                          for <var>value</var> and the value is the original <var>compacted item</var>.</li>
+                          where the key is the result of
+                          <span class="changed"><a>iri compacting</a> `@list`</span>
+                          and the value is the original <var>compacted item</var>.</li>
                         <li>If <var>expanded item</var> contains the <a>entry</a>
-                          <code>@index</code>, then add an <a>entry</a>
+                          <code>@index</code>-<var>value</var>, then add an <a>entry</a>
                           to <var>compacted item</var> where the key is the
-                          result of the <a href="#iri-compaction">IRI Compaction algorithm</a>,
-                          passing <var>active context</var>, <var>inverse context</var>,
-                          <code>@index</code> as <var>var</var>, and the value associated with the
-                          <code>@index</code> <a>entry</a> in <var>expanded item</var> as <var>value</var>.</li>
+                          result of
+                          <span class="changed"><a>iri compacting</a> `@index`</span>
+                          and value is <var>value</var>.</li>
                         <li>Use <a>add value</a> to add <var>compacted item</var>
                           to the <var>item active property</var> <a>entry</a> in
                           <var>nest result</var>
@@ -3738,11 +3710,12 @@
                         <li>Initialize <var>map object</var> to the value of <var>item active property</var>
                           in <var>nest result</var>,
                           initializing it to a new empty <a>map</a>, if necessary.</li>
-                        <li>Initialize <var>map key</var> to the result of calling the
-                          <a href="#iri-compaction">IRI Compaction algorithm</a>
-                          passing <var>active context</var>, <var>inverse context</var>, and the value of <code>@id</code> in <var>expanded item</var>
-                          or <code>@none</code> if no such value exists as <var>var</var>, with <var>vocab</var> set to <code>true</code>
-                          if there is no <code>@id</code> <a>entry</a> in <var>expanded item</var>.</li>
+                        <li>Initialize <var>map key</var>
+                          <span class="changed">by <a>iri compacting</a>
+                            the value of `@id` in <var>expanded item</var>
+                            or <code>@none</code> if no such value exists
+                            with <var>vocab</var> set to <code>false</code>
+                            if there is an <code>@id</code> <a>entry</a> in <var>expanded item</var></span>.</li>
                         <li class="changed">Use <a>add value</a> to add <var>compacted item</var>
                           to the <var>map key</var> entry in <var>map object</var>
                           using <var>as array</var>.</li>
@@ -3770,10 +3743,9 @@
                           with more than one value, it cannot be directly represented,
                           as multiple objects would be interpreted as different named graphs.
                           Set <var>compacted item</var> to a new <a>map</a>,
-                          containing the key created by calling the <a href="#iri-compaction">IRI Compaction algorithm</a>
-                          passing <var>active context</var>, <var>inverse context</var>, `@included` as
-                          <var>var</var>, and `true` for
-                          <var>vocab</var> and the original <var>compacted item</var> as the value. </li>
+                          containing the key
+                          from <span class="changed"><a>iri compacting</a> `@included`</span>
+                          and the original <var>compacted item</var> as the value. </li>
                         <li class="changed">Use <a>add value</a> to add <var>compacted item</var>
                           to the <var>item active property</var> entry in <var>nest result</var>
                           using <var>as array</var>.</li>
@@ -3783,29 +3755,19 @@
                       or otherwise does not match one of the previous cases.
                       <ol>
                         <li>Set <var>compacted item</var> to a new map containing
-                          the key resulting from calling the <a
-                          href="#iri-compaction">IRI Compaction algorithm</a>
-                          passing <var>active context</var>, <var>inverse context</var>, <code>@graph</code> as
-                          <var>var</var>, and <code>true</code> for
-                          <var>vocab</var> using the original
-                          <var>compacted item</var> as a value.</li>
+                          the key
+                          from <span class="changed"><a>iri compacting</a> `@graph`</span>
+                          using the original <var>compacted item</var> as a value.</li>
                         <li>If expanded item contains an <code>@id</code> <a>entry</a>,
-                          add the key resulting from calling the <a
-                          href="#iri-compaction">IRI Compaction algorithm</a>
-                          passing <var>active context</var>, <var>inverse context</var>, <code>@id</code> as
-                          <var>var</var>, and <code>true</code> for
-                          <var>vocab</var> using the value resulting from calling the <a
-                          href="#iri-compaction">IRI Compaction algorithm</a>
-                          passing <var>active context</var>, <var>inverse context</var>, the value of <code>@id</code>
-                          in <var>expanded item</var> as
-                          <var>var</var> to <var>compacted item</var>.</li>
+                          add an entry in <var>compacted item</var> using the key
+                          from <span class="changed"><a>iri compacting</a> `@id`</span>
+                          using the value
+                          of <span class="changed"><a>iri compacting</a> the value of `@id` in <var>expanded item</var>
+                            using `false` for <var>vocab</var></span>.</li>
                         <li>If expanded item contains an <code>@index</code> <a>entry</a>,
-                          add the key resulting from calling the <a
-                          href="#iri-compaction">IRI Compaction algorithm</a>
-                          passing <var>active context</var>, <var>inverse context</var>, <code>@index</code> as
-                          <var>var</var>, and <code>true</code> for
-                          <var>vocab</var> using the value of <code>@index</code>
-                          in <var>expanded item</var> to <var>compacted item</var>.</li>
+                          add an entry in <var>compacted item</var> using the key
+                          from <span class="changed"><a>iri compacting</a> `@index`</span>
+                          and the value of <code>@index</code> in <var>expanded item</var>.</li>
                         <li class="changed">Use <a>add value</a> to add <var>compacted item</var>
                           to the <var>item active property</var> entry in <var>nest result</var>
                           using <var>as array</var>.</li>
@@ -3822,12 +3784,10 @@
                     <li class="changed">Initialize <var>map object</var> to the value of <var>item active property</var>
                       in <var>nest result</var>,
                       initializing it to a new empty <a>map</a>, if necessary.</li>
-                    <li>Initialize <var>container key</var> to the result of calling the
-                      <a href="#iri-compaction">IRI Compaction algorithm</a>
-                      passing <var>active context</var>, <var>inverse context</var>,
+                    <li>Initialize <var>container key</var>
+                      by <span class="changed"><a>iri compacting</a></span>
                       either <code>@language</code>, <code>@index</code>, <code>@id</code>, or <code>@type</code>
-                      based on the contents of <var>container</var>, as <var>var</var>, and <code>true</code>
-                      for <var>vocab</var>.</li>
+                      based on the contents of <var>container</var>.</li>
                     <li class="changed">Initialize <var>index key</var> to the value of <a>index mapping</a> in
                       the <a>term definition</a> associated with <var>item active property</var> in <var>active context</var>,
                       or <code>@index</code>, if no such value exists.</li>
@@ -3872,11 +3832,9 @@
                         </li>
                       </ol>
                     </li>
-                    <li>If <var>map key</var> is <code>null</code>, set it to the result of calling the
-                      <a href="#iri-compaction">IRI Compaction algorithm</a>
-                      passing <var>active context</var>, <var>inverse context</var>, <code>@none</code> as
-                      <var>var</var>, and <code>true</code> for
-                      <var>vocab</var>.</li>
+                    <li>If <var>map key</var> is <code>null</code>,
+                      set it to the result of
+                      <span class="changed"><a>iri compacting</a> `@none`</span>.</li>
                     <li class="changed">Use <a>add value</a> to add <var>compacted item</var>
                       to the <var>map key</var> entry in <var>map object</var>
                       using <var>as array</var>.</li>
@@ -4153,12 +4111,10 @@
             <li>If <var>type/language value</var> is <code>@id</code> or <code>@reverse</code>
               and <var>value</var> has an <code>@id</code> <a>entry</a>:
               <ol>
-                <li>If the result of using the
-                  <a href="#iri-compaction">IRI compaction algorithm</a>,
-                  passing <var>active context</var>, <var>inverse context</var>,
-                  the value associated with the <code>@id</code> <a>entry</a> in <var>value</var> for
-                  <var>var</var>, and <code>true</code> for <var>vocab</var> has a
-                  <a>term definition</a> in the <var>active context</var>
+                <li>If the result of
+                  <span class="changed"><a>iri compacting</a>
+                    the value associated with the <code>@id</code> <a>entry</a> in <var>value</var></span>
+                  has a <a>term definition</a> in the <var>active context</var>
                   with an <a>IRI mapping</a> that equals the value associated
                   with the <code>@id</code> <a>entry</a> in <var>value</var>,
                   then append <code>@vocab</code>, <code>@id</code>, and
@@ -4300,16 +4256,14 @@
           and has no other <a>entries</a> other than `@index`:
           <ol>
             <li>If the <a>type mapping</a> of <var>active property</var>
-              is set to <code>@id</code>, set <var>result</var> to the result of using the
-              <a href="#iri-compaction">IRI compaction algorithm</a>,
-              passing <var>active context</var>, <var>inverse context</var>,
-              and the value of the <code>@id</code> <a>entry</a> for <var>var</var>.</li>
+              is set to <code>@id</code>, set <var>result</var> to the result of
+              <span class="changed"><a>iri compacting</a>
+                the value associated with the <code>@id</code> <a>entry</a>
+                using `false` for <var>vocab</var></span>.</li>
             <li>Otherwise, if the <a>type mapping</a> of <var>active property</var>
-              is set to <code>@vocab</code>, set <var>result</var> to the result of using the
-              <a href="#iri-compaction">IRI compaction algorithm</a>,
-              passing <var>active context</var>, <var>inverse context</var>,
-              the value of the <code>@id</code> <a>entry</a> for <var>var</var>, and
-              <code>true</code> for <var>vocab</var>.</li>
+              is set to <code>@vocab</code>, set <var>result</var> to the result of
+              <span class="changed"><a>iri compacting</a>
+                the value associated with the <code>@id</code> <a>entry</a></span>.</li>
           </ol>
         </li>
         <li>Otherwise, if <var>value</var> has an <code>@type</code> <a>entry</a> whose
@@ -4321,11 +4275,9 @@
           and the value of `@type` in <var>value</var> does not match the <a>type mapping</a> of <var>active property</var>,
           leave <var>value</var> as is, as value compaction is disabled.
           <ol>
-            <li>Replace any value of <code>@type</code> in <var>result</var> with the result of using the
-              <a href="#iri-compaction">IRI compaction algorithm</a>,
-              passing <var>active context</var>, <var>inverse context</var>,
-              the value of the <code>@type</code> <a>entry</a> for <var>var</var>, and
-              <code>true</code> for <var>vocab</var>.</li>
+            <li>Replace any value of <code>@type</code> in <var>result</var> with the result of
+              <span class="changed"><a>iri compacting</a></span>
+              the value of the <code>@type</code> <a>entry</a>.</li>
           </ol>
         </li>
         <li>Otherwise, if the value of the <code>@value</code> <a>entry</a> is not a <a>string</a>:
@@ -4352,11 +4304,8 @@
           </ol>
         </li>
         <li>If <var>result</var> is a <var>map</var>,
-          replace each key in <var>result</var> with the result of using the
-          <a href="#iri-compaction">IRI compaction algorithm</a>,
-          passing <var>active context</var>, <var>inverse context</var>,
-          the that key for <var>var</var>, and
-          <code>true</code> for <var>vocab</var>.</li>
+          replace each key in <var>result</var> with the result of
+          <span class="changed"><a>iri compacting</a> that key</span>.</li>
         <li>Return <var>result</var>.</li>
       </ol>
     </section>
@@ -5770,10 +5719,9 @@
                 replace it with a new <a>map</a>.</li>
               <li>Otherwise, if <var>compacted output</var> is an <a>array</a>,
                 replace it with a new <a>map</a> with a single <a>entry</a>
-                whose key is the result of using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
-                passing <var>active context</var>, <var>inverse context</var>, and
-                <code>@graph</code> as <var>var</var> and whose value is the <a>array</a>
-                <var>compacted output</var>.</li>
+                whose key is the result of
+                <span class="changed"><a>iri compacting</a> `@graph`</span>
+                and value is <var>compacted output</var>.</li>
               <li>If <a data-lt="jsonldprocessor-compact-context">context</a> was not <code>null</code>,
                 add an <code>@context</code> <a>entry</a> to <var>compacted output</var> and set its value
                 to the passed <var>context</var>.</li>

--- a/index.html
+++ b/index.html
@@ -1195,7 +1195,7 @@
           does not have a <a>previous context</a>, set <a>previous context</a>
           in <var>result</var> to <var>active context</var>.</li>
         <li>If <var>local context</var> is not an <a>array</a>,
-          set it to an <a>array</a> containing only
+          set <var>local context</var> to an <a>array</a> containing only
           <var>local context</var>.</li>
         <li>
           For each item <var>context</var> in <var>local context</var>:
@@ -2059,7 +2059,7 @@
               <a>language mapping</a> (might be <code>null</code>):
               <ol>
                 <li>If the <a>language mapping</a> equals <code>null</code>,
-                  set <var>language</var> to <code>@null</code>; otherwise set it
+                  set <var>language</var> to <code>@null</code>; otherwise
                   to the <a>language mapping</a>,
                   <span class="changed">normalized to lower case</span>.</li>
                 <li>If <var>language map</var> does not have a <var>language</var> <a>entry</a>,
@@ -2071,7 +2071,7 @@
               <a>direction mapping</a> (might be <code>null</code>):
               <ol>
                 <li>If the <a>direction mapping</a> equals <code>null</code>,
-                  set <var>direction</var> to <code>@none</code>; otherwise set it
+                  set <var>direction</var> to <code>@none</code>; otherwise
                   to <a>direction mapping</a> preceded by an underscore (`"_"`).</li>
                 <li>If <var>language map</var> does not have a <var>direction</var> <a>entry</a>,
                   create one and set its value to the <a>term</a>
@@ -2821,7 +2821,7 @@
                   in <var>value</var>, ordered lexicographically by <var>language</var> <span class="changed">if {{JsonLdOptions/ordered}} is <code>true</code></span>:
                   <ol>
                     <li>If <var>language value</var> is not an <a>array</a>
-                      set it to an <a>array</a> containing only
+                      set <var>language value</var> to an <a>array</a> containing only
                       <var>language value</var>.</li>
                     <li>For each <var>item</var> in <var>language value</var>:
                       <ol>
@@ -2884,7 +2884,7 @@
                       passing <var>active context</var>, <var>index</var>, and <code>true</code>
                       for <var>vocab</var>.</li>
                     <li>If <var>index value</var> is not an <a>array</a>
-                      set it to an <a>array</a> containing only
+                      set <var>index value</var> to an <a>array</a> containing only
                       <var>index value</var>.</li>
                     <li>Initialize <var>index value</var> to the result of
                       using this algorithm recursively, passing
@@ -3450,7 +3450,7 @@
           <a>entry</a> and the result of using the
           <a href="#value-compaction">Value Compaction algorithm</a>,
           passing <var>active context</var>, <var>inverse context</var>,
-          <var>active property</var>,and <var>element</var> as <var>value</var> is
+          <var>active property</var>, and <var>element</var> as <var>value</var> is
           a <a>scalar</a>,
           <span class="changed">or the <a>term definition</a> for <var>active property</var>
             has a <a>type mapping</a> of <code>@json</code>,</span>
@@ -4099,15 +4099,15 @@
                       </ol>
                     </li>
                     <li>Otherwise, set <var>item type</var> to <code>@id</code>.</li>
-                    <li>If <var>common language</var> is <code>null</code>, set it
-                      to <var>item language</var>.</li>
+                    <li>If <var>common language</var> is <code>null</code>,
+                      set <var>common language</var> to <var>item language</var>.</li>
                     <li>Otherwise, if <var>item language</var> does not equal
                       <var>common language</var> and <var>item</var> contains a
                       <code>@value</code> <a>entry</a>, then set <var>common language</var>
                       to <code>@none</code> because list items have conflicting
                       languages.</li>
-                    <li>If <var>common type</var> is <code>null</code>, set it
-                      to <var>item type</var>.</li>
+                    <li>If <var>common type</var> is <code>null</code>,
+                      set <var>common type</var> to <var>item type</var>.</li>
                     <li>Otherwise, if <var>item type</var> does not equal
                       <var>common type</var>, then set <var>common type</var>
                       to <code>@none</code> because list items have conflicting
@@ -4119,10 +4119,10 @@
                       the items.</li>
                   </ol>
                 </li>
-                <li>If <var>common language</var> is <code>null</code>, set it to
-                  <code>@none</code>.</li>
-                <li>If <var>common type</var> is <code>null</code>, set it to
-                  <code>@none</code>.</li>
+                <li>If <var>common language</var> is <code>null</code>,
+                  set <var>common language</var> to <code>@none</code>.</li>
+                <li>If <var>common type</var> is <code>null</code>,
+                  set <var>common type</var> to <code>@none</code>.</li>
                 <li>If <var>common type</var> is not <code>@none</code> then set
                   <var>type/language</var> to <code>@type</code> and
                   <var>type/language value</var> to <var>common type</var>.</li>
@@ -4199,8 +4199,9 @@
               If <a>processing mode</a> is not `json-ld-1.0` and value contains only an <code>@value</code> <a>entry</a>,
               append <code>@language</code> and <code>@language@set</code> to <var>containers</var>.
             </li>
-            <li>If <var>type/language value</var> is <code>null</code>, set it to
-              <code>@null</code>. This is the key under which <code>null</code> values
+            <li>If <var>type/language value</var> is <code>null</code>,
+              set <var>type/language value</var> to <code>@null</code>.
+              This is the key under which <code>null</code> values
               are stored in the <var>inverse context</var> <var>entry</var>.</li>
             <li>Initialize <var>preferred values</var> to an empty <a>array</a>.
               This <a>array</a> will indicate, in order, the preferred values for
@@ -5026,8 +5027,8 @@
           <code>true</code> or <code>false</code> which is the
           <a>canonical lexical form</a> as described in
           <a class="sectionRef" href="#data-round-tripping"></a>
-          If <var>datatype</var> is <code>null</code>, set it to
-          <code>xsd:boolean</code>.</li>
+          If <var>datatype</var> is <code>null</code>,
+          set <var>datatype</var> to <code>xsd:boolean</code>.</li>
         <li>Otherwise, if <var>value</var> is a <a>number</a> with a non-zero fractional
           part (the result of a modulo&#8209;1 operation) or <var>value</var> is a <a>number</a>
           and <var>datatype</var> equals <code>xsd:double</code>, convert <var>value</var> to a
@@ -5035,8 +5036,8 @@
           an <a data-cite="XMLSCHEMA11-2#double"><code>xsd:double</code></a> as defined in [[XMLSCHEMA11-2]]
           and described in
           <a class="sectionRef" href="#data-round-tripping"></a>.
-          If <var>datatype</var> is <code>null</code>, set it to
-          <code>xsd:double</code>.</li>
+          If <var>datatype</var> is <code>null</code>,
+          set <var>datatype</var> to <code>xsd:double</code>.</li>
         <li>Otherwise, if <var>value</var> is a <a>number</a> with no non-zero
           fractional part (the result of a modulo&#8209;1 operation) or <var>value</var>
           is a <a>number</a> and <var>datatype</var>
@@ -5045,11 +5046,11 @@
           an <a data-cite="XMLSCHEMA11-2#integer"><code>xsd:integer</code></a> as defined in [[XMLSCHEMA11-2]]
           and described in
           <a class="sectionRef" href="#data-round-tripping"></a>.
-          If <var>datatype</var> is <code>null</code>, set it to
-          <code>xsd:integer</code>.</li>
-        <li>Otherwise, if <var>datatype</var> is <code>null</code>, set it to
-          <code>xsd:string</code> or <code>rdf:langString</code>, depending on if
-          item has an <code>@language</code> <a>entry</a>.</li>
+          If <var>datatype</var> is <code>null</code>,
+          set <var>datatype</var> to <code>xsd:integer</code>.</li>
+        <li>Otherwise, if <var>datatype</var> is <code>null</code>,
+          set <var>datatype</var> to <code>xsd:string</code> or <code>rdf:langString</code>,
+          depending on if item has an <code>@language</code> <a>entry</a>.</li>
         <li class="changed">If <var>item</var> contains an `@direction` <a>entry</a>
           and {{JsonLdOptions/rdfDirection}} is not `null`,
           <var>item</var> is a <a>value object</a> which is serialized using special rules.

--- a/index.html
+++ b/index.html
@@ -3466,7 +3466,7 @@
           create a new array <var>compacted types</var> initialized
           by transforming each <var>expanded type</var> of that <a>entry</a>
           into its compacted form
-          <span class="changed">by <a>iri compacting</a> <var>expanded context</var></span>.
+          <span class="changed">by <a>iri compacting</a> <var>expanded type</var></span>.
           Then, for each <var>term</var>
           in <var>compacted types</var> ordered lexicographically:
           <ol>

--- a/index.html
+++ b/index.html
@@ -1383,7 +1383,7 @@
                   of <var>result</var> is set to
                   <span class="changed">the result of
                     <a>iri expanding</a> <var>value</var>
-                    using <code>true</code> for <var>document relative</var>.
+                    using <code>true</code> for <var>document relative</var>
                   </span>.
                   If it is not an <a>IRI</a>, or a <a>blank node identifier</a>, an
                   <a data-link-for="JsonLdErrorCode">invalid vocab mapping</a>

--- a/index.html
+++ b/index.html
@@ -1382,7 +1382,7 @@
                   or <a>blank node identifier</a>, the <a>vocabulary mapping</a>
                   of <var>result</var> is set to
                   <span class="changed">the result of
-                    <a>iri expanding</a> <var>value</var>
+                    <a>IRI expanding</a> <var>value</var>
                     using <code>true</code> for <var>document relative</var>
                   </span>.
                   If it is not an <a>IRI</a>, or a <a>blank node identifier</a>, an
@@ -1579,7 +1579,7 @@
               <a data-link-for="JsonLdErrorCode">invalid type mapping</a>
               error has been detected and processing is aborted.</li>
             <li>Set <var>type</var> to the result of
-              <span class="changed"><a>iri expanding</a> <var>type</var></span>,
+              <span class="changed"><a>IRI expanding</a> <var>type</var></span>,
               using <var>local context</var>, and <var>defined</var>.</li>
             <li class="changed">If the expanded <var>type</var> is
               `@json` or `@none`, and <a>processing mode</a> is `json-ld-1.0`,
@@ -1610,7 +1610,7 @@
               return; processors SHOULD generate a warning.</li>
             <li>Otherwise, set the <a>IRI mapping</a> of <var>definition</var> to the
               result of
-              <span class="changed"><a>iri expanding</a></span>
+              <span class="changed"><a>IRI expanding</a></span>
               the value associated with the <code>@reverse</code> <a>entry</a>,
               using <var>local context</var>, and <var>defined</var>.
               If the result does not have the <a href="https://tools.ietf.org/html/rfc3987#section-2.2">form</a> of an <a>IRI</a> or a <a>blank node identifier</a>,
@@ -1652,7 +1652,7 @@
                   return; processors SHOULD generate a warning.</li>
                 <li>Otherwise, set the <a>IRI mapping</a> of <var>definition</var> to the
                   result of
-                  <span class="changed"><a>iri expanding</a></span>
+                  <span class="changed"><a>IRI expanding</a></span>
                   the value associated with the <code>@id</code> <a>entry</a>,
                   using <var>local context</var>, and <var>defined</var>.
                   If the resulting <a>IRI mapping</a> is neither a <a>keyword</a>, nor an
@@ -1667,7 +1667,7 @@
                   <ol>
                     <li>Set the value associated with <var>defined</var>'s <var>term</var> <a>entry</a> to
                       <code>true</code>.</li>
-                    <li>If the result of <span class="changed"><a>iri expanding</a></span> <var>term</var>
+                    <li>If the result of <span class="changed"><a>IRI expanding</a></span> <var>term</var>
                       using <var>local context</var>, and <var>defined</var>,
                       is not the same as the <a>IRI mapping</a> of <var>definition</var>,
                       an <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
@@ -1708,7 +1708,7 @@
           <ol>
             <li><var>Term</var> is a <a>relative IRI reference</a>.</li>
             <li>Set the <a>IRI mapping</a> of <var>definition</var> to the
-              result of <span class="changed"><a>iri expanding</a></span> <var>term</var>.
+              result of <span class="changed"><a>IRI expanding</a></span> <var>term</var>.
               If the resulting <a>IRI mapping</a> is not an <a>IRI</a>, an
               <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
               error has been detected and processing is aborted.</li>
@@ -2464,7 +2464,7 @@
           If <var>from map</var> is undefined or <code>false</code>,
           and <var>element</var> does not contain an <a>entry</a> expanding to <code>@value</code>,
           and <var>element</var> does not consist of a single <a>entry</a> expanding to <code>@id</code>
-          (where <a>entries</a> are <span class="changed"><a data-lt="iri expanding">iri expanded</a></span>,
+          (where <a>entries</a> are <span class="changed"><a data-lt="IRI expanding">IRI expanded</a></span>,
           set <var>active context</var> to <a>previous context</a> from <var>active context</var>,
           as the scope of a term-scoped <a>context</a> does not apply when processing new <a>node objects</a>.</li>
         <li id="alg-expand-property-scoped-context" class="changed">If <var>property-scoped context</var> is defined,
@@ -2482,7 +2482,7 @@
           <a>type-scoped context</a>.</li>
         <li class="changed">For each <var>key</var> and <var>value</var> in <var>element</var>
           ordered lexicographically by <var>key</var>
-          where <var>key</var> <span class="changed"><a data-lt="iri expanding">iri expands</a></span> to <code>@type</code>:
+          where <var>key</var> <span class="changed"><a data-lt="IRI expanding">IRI expands</a></span> to <code>@type</code>:
           <ol>
             <li>Convert <var>value</var> into an <a>array</a>, if necessary.</li>
             <li id="expand-type-scoped-context">For each <var>term</var> which is a value of <var>value</var> ordered lexicographically,
@@ -2501,7 +2501,7 @@
             Initialize <var>input type</var> to expansion of the last value of the first <a>entry</a> in <var>element</var>
             expanding to <code>@type</code> (if any), ordering <a>entries</a> lexicographically by key</span>.
             Both the key and value of the matched entry are
-            <span class="changed"><a data-lt="iri expanding">iri expanded</a></span>.
+            <span class="changed"><a data-lt="IRI expanding">IRI expanded</a></span>.
         </li>
         <li id="alg-expand-each-key-value">
           For each <var>key</var> and <var>value</var> in <var>element</var>,
@@ -2510,7 +2510,7 @@
             <li>If <var>key</var> is <code>@context</code>, continue to
               the next <var>key</var>.</li>
             <li>Initialize <var>expanded property</var> to the result of
-              <span class="changed"><a>iri expanding</a></span> <var>key</var>.</li>
+              <span class="changed"><a>IRI expanding</a></span> <var>key</var>.</li>
             <li>If <var>expanded property</var> is <code>null</code> or it neither
               contains a colon (<code>:</code>) nor it is a <a>keyword</a>,
               drop <var>key</var> by continuing to the next <var>key</var>.</li>
@@ -2535,7 +2535,7 @@
                         or more <a>strings</a>.</span></li>
                     <li>Otherwise,
                       set <var>expanded value</var> to the result of
-                      <span class="changed"><a>iri expanding</a></span> <var>value</var>
+                      <span class="changed"><a>IRI expanding</a></span> <var>value</var>
                       using <code>true</code> for <var>document relative</var>
                       and `false` for <var>vocab</var>.
                       <span class="changed">
@@ -2565,12 +2565,12 @@
                       is a <a>default object</a>, set <var>expanded value</var> to
                       a new <a>default object</a> with the value of `@default` set
                       to the result of
-                      <span class="changed"><a>iri expanding</a></span> <var>value</var>
+                      <span class="changed"><a>IRI expanding</a></span> <var>value</var>
                       using <var class="changed">type-scoped context</var> for <var>active context</var>,
                       and <code>true</code> for <var>document relative</var>.</li>
                     <li id="expansion-tsc">Otherwise,
                       set <var>expanded value</var> to the result of
-                      <span class="changed"><a>iri expanding</a></span>
+                      <span class="changed"><a>IRI expanding</a></span>
                       each of its values
                       using <var class="changed">type-scoped context</var> for <var>active context</var>,
                       and <code>true</code> for <var>document relative</var>.
@@ -2852,7 +2852,7 @@
                       as <var>local context</var>.</li>
                       <li>Otherwise, set <var>map context</var> to <var>active context</var>.</li>
                     <li>Initialize <var>expanded index</var> to the result of
-                      <span class="changed"><a>iri expanding</a></span> <var>index</var>.</li>
+                      <span class="changed"><a>IRI expanding</a></span> <var>index</var>.</li>
                     <li>If <var>index value</var> is not an <a>array</a>
                       set <var>index value</var> to an <a>array</a> containing only
                       <var>index value</var>.</li>
@@ -2880,7 +2880,7 @@
                               <var>index key</var> as <var>active property</var>,
                               and <var>index</var> as <var>value</var>.</li>
                             <li>Initialize <var>expanded index key</var> to the result of
-                              <span class="changed"><a>iri expanding</a></span> <var>index key</var>.</li>
+                              <span class="changed"><a>IRI expanding</a></span> <var>index key</var>.</li>
                             <li>Initialize <var>index property values</var> to the concatenation of
                               <var>re-expanded index</var> with any existing values of
                               <var>expanded index key</var> in <var>item</var>.</li>
@@ -2901,7 +2901,7 @@
                           and <var>expanded index</var> is not `@none`,
                           add the key-value pair (<code>@id</code>-<var>expanded index</var>) to <var>item</var>,
                           where <var>expanded index</var> is set to the result of
-                          <span class="changed"><a>iri expanding</a></span><var>index</var>
+                          <span class="changed"><a>IRI expanding</a></span><var>index</var>
                           using `true` for <var>document relative</var>
                           and `false` for <var>vocab</var>.</li>
                         <li id="alg-expand-container-mapping-type">Otherwise, if <var>container mapping</var> includes <code>@type</code>
@@ -3254,7 +3254,7 @@
           return a new
           <a class="changed">map</a> containing a single <a>entry</a> where the
           key is <code>@id</code> and the value is the result
-          <span class="changed"><a>iri expanding</a></span> <var>value</var>
+          <span class="changed"><a>IRI expanding</a></span> <var>value</var>
           using `true` for <var>document relative</var>
           and `false` for <var>vocab</var>.</li>
         <li>If <var>active property</var> has a <a>type mapping</a> in
@@ -3263,7 +3263,7 @@
           return a new
           <a class="changed">map</a> containing a single <a>entry</a> where the
           key is <code>@id</code> and the value is the result of
-          <span class="changed"><a>iri expanding</a></span> <var>value</var>
+          <span class="changed"><a>IRI expanding</a></span> <var>value</var>
           using <code>true</code> for <var>document relative</var>.</li>
         <li>Otherwise, initialize <var>result</var> to a <a class="changed">map</a>
           with an <code>@value</code> <a>entry</a> whose value is set to
@@ -3435,7 +3435,7 @@
           create a new array <var>compacted types</var> initialized
           by transforming each <var>expanded type</var> of that <a>entry</a>
           into its compacted form
-          <span class="changed">by <a>iri compacting</a> <var>expanded type</var></span>.
+          <span class="changed">by <a>IRI compacting</a> <var>expanded type</var></span>.
           Then, for each <var>term</var>
           in <var>compacted types</var> ordered lexicographically:
           <ol>
@@ -3461,10 +3461,10 @@
               <ol>
                 <li>If <var>expanded value</var> is a <a>string</a>,
                   then initialize <var>compacted value</var>
-                  <span class="changed">by <a>iri compacting</a> <var>expanded value</var>
+                  <span class="changed">by <a>IRI compacting</a> <var>expanded value</var>
                     with <var>vocab</var> set to `false`</span>.</li>
                 <li>Initialize <var>alias</var>
-                  <span class="changed">by <a>iri compacting</a> <var>expanded property</var></span>.</li>
+                  <span class="changed">by <a>IRI compacting</a> <var>expanded property</var></span>.</li>
                 <li>Add an <a>entry</a> <var>alias</var> to <var>result</var> whose value is
                   set to <var>compacted value</var> and continue to the next
                   <var>expanded property</var>.</li>
@@ -3474,7 +3474,7 @@
               <ol>
                 <li>If <var>expanded value</var> is a <a>string</a>,
                   then initialize <var>compacted value</var>
-                  <span class="changed">by <a>iri compacting</a> <var>expanded value</var>
+                  <span class="changed">by <a>IRI compacting</a> <var>expanded value</var>
                     using <var>type-scoped context</var> for <var>active context</var></span>.</li>
                 <li>Otherwise, <var>expanded value</var> must be a
                   <code>@type</code> <a>array</a>:
@@ -3485,7 +3485,7 @@
                       <var>expanded value</var>:
                       <ol>
                         <li>Set <var>term</var>
-                          <span class="changed">by <a>iri compacting</a> <var>expanded type</var>
+                          <span class="changed">by <a>IRI compacting</a> <var>expanded type</var>
                             using <var>type-scoped context</var> for <var>active context</var></span>.</li>
                         <li>Append <var>term</var>, to <var>compacted value</var>.</li>
                       </ol>
@@ -3493,7 +3493,7 @@
                   </ol>
                 </li>
                 <li>Initialize <var>alias</var>
-                  <span class="changed">by <a>iri compacting</a> <var>expanded property</var></span>.</li>
+                  <span class="changed">by <a>IRI compacting</a> <var>expanded property</var></span>.</li>
                 <li class="changed">Initialize <var>as array</var>
                   to <code>true</code> if the <a>container mapping</a> for <var>alias</var> in the
                   <var>active context</var> includes <code>@set</code>,
@@ -3536,7 +3536,7 @@
                   it is not an empty <a class="changed">map</a>:
                   <ol>
                     <li>Initialize <var>alias</var>
-                      <span class="changed">by <a>iri compacting</a> `@reverse`</span>.</li>
+                      <span class="changed">by <a>IRI compacting</a> `@reverse`</span>.</li>
                     <li>Set the value of the <var>alias</var> <a>entry</a> of <var>result</var> to
                       <var>compacted value</var>.</li>
                   </ol>
@@ -3571,7 +3571,7 @@
               or <code>@value</code>:
               <ol>
                 <li>Initialize <var>alias</var>
-                  <span class="changed">by <a>iri compacting</a> <var>expanded property</var></span>.</li>
+                  <span class="changed">by <a>IRI compacting</a> <var>expanded property</var></span>.</li>
                 <li>Add an <a>entry</a> <var>alias</var> to <var>result</var> whose value is
                   set to <var>expanded value</var> and continue with the next
                   <var>expanded property</var>.</li>
@@ -3580,7 +3580,7 @@
             <li>If <var>expanded value</var> is an empty <a>array</a>:
               <ol>
                 <li>Initialize <var>item active property</var>
-                  <span class="changed">by <a>iri compacting</a> <var>expanded property</var>
+                  <span class="changed">by <a>IRI compacting</a> <var>expanded property</var>
                     using <var>expanded value</var> for <var>value</var>
                     and <var>inside reverse</var> for <var>reverse</var></span>.</li>
                 <li class="changed">If the <a>term definition</a> for <var>item active property</var>
@@ -3609,7 +3609,7 @@
               For each item <var>expanded item</var> in <var>expanded value</var>:
               <ol>
                 <li>Initialize <var>item active property</var>
-                  <span class="changed">by <a>iri compacting</a> <var>expanded property</var>
+                  <span class="changed">by <a>IRI compacting</a> <var>expanded property</var>
                     using <var>expanded item</var> for <var>value</var>
                     and <var>inside reverse</var> for <var>reverse</var></span>.</li>
                 <li class="changed">If the <a>term definition</a> for <var>item active property</var>
@@ -3654,13 +3654,13 @@
                           <a>list object</a> by setting it to a
                           <a class="changed">map</a> containing an <a>entry</a>
                           where the key is the result of
-                          <span class="changed"><a>iri compacting</a> `@list`</span>
+                          <span class="changed"><a>IRI compacting</a> `@list`</span>
                           and the value is the original <var>compacted item</var>.</li>
                         <li>If <var>expanded item</var> contains the <a>entry</a>
                           <code>@index</code>-<var>value</var>, then add an <a>entry</a>
                           to <var>compacted item</var> where the key is the
                           result of
-                          <span class="changed"><a>iri compacting</a> `@index`</span>
+                          <span class="changed"><a>IRI compacting</a> `@index`</span>
                           and value is <var>value</var>.</li>
                         <li>Use <a>add value</a> to add <var>compacted item</var>
                           to the <var>item active property</var> <a>entry</a> in
@@ -3680,7 +3680,7 @@
                           in <var>nest result</var>,
                           initializing it to a new empty <a>map</a>, if necessary.</li>
                         <li>Initialize <var>map key</var>
-                          <span class="changed">by <a>iri compacting</a>
+                          <span class="changed">by <a>IRI compacting</a>
                             the value of `@id` in <var>expanded item</var>
                             or <code>@none</code> if no such value exists
                             with <var>vocab</var> set to <code>false</code>
@@ -3713,7 +3713,7 @@
                           as multiple objects would be interpreted as different named graphs.
                           Set <var>compacted item</var> to a new <a>map</a>,
                           containing the key
-                          from <span class="changed"><a>iri compacting</a> `@included`</span>
+                          from <span class="changed"><a>IRI compacting</a> `@included`</span>
                           and the original <var>compacted item</var> as the value. </li>
                         <li class="changed">Use <a>add value</a> to add <var>compacted item</var>
                           to the <var>item active property</var> entry in <var>nest result</var>
@@ -3725,17 +3725,17 @@
                       <ol>
                         <li>Set <var>compacted item</var> to a new map containing
                           the key
-                          from <span class="changed"><a>iri compacting</a> `@graph`</span>
+                          from <span class="changed"><a>IRI compacting</a> `@graph`</span>
                           using the original <var>compacted item</var> as a value.</li>
                         <li>If expanded item contains an <code>@id</code> <a>entry</a>,
                           add an entry in <var>compacted item</var> using the key
-                          from <span class="changed"><a>iri compacting</a> `@id`</span>
+                          from <span class="changed"><a>IRI compacting</a> `@id`</span>
                           using the value
-                          of <span class="changed"><a>iri compacting</a> the value of `@id` in <var>expanded item</var>
+                          of <span class="changed"><a>IRI compacting</a> the value of `@id` in <var>expanded item</var>
                             using `false` for <var>vocab</var></span>.</li>
                         <li>If expanded item contains an <code>@index</code> <a>entry</a>,
                           add an entry in <var>compacted item</var> using the key
-                          from <span class="changed"><a>iri compacting</a> `@index`</span>
+                          from <span class="changed"><a>IRI compacting</a> `@index`</span>
                           and the value of <code>@index</code> in <var>expanded item</var>.</li>
                         <li class="changed">Use <a>add value</a> to add <var>compacted item</var>
                           to the <var>item active property</var> entry in <var>nest result</var>
@@ -3754,7 +3754,7 @@
                       in <var>nest result</var>,
                       initializing it to a new empty <a>map</a>, if necessary.</li>
                     <li>Initialize <var>container key</var>
-                      by <span class="changed"><a>iri compacting</a></span>
+                      by <span class="changed"><a>IRI compacting</a></span>
                       either <code>@language</code>, <code>@index</code>, <code>@id</code>, or <code>@type</code>
                       based on the contents of <var>container</var>.</li>
                     <li class="changed">Initialize <var>index key</var> to the value of <a>index mapping</a> in
@@ -3803,7 +3803,7 @@
                     </li>
                     <li>If <var>map key</var> is <code>null</code>,
                       set it to the result of
-                      <span class="changed"><a>iri compacting</a> `@none`</span>.</li>
+                      <span class="changed"><a>IRI compacting</a> `@none`</span>.</li>
                     <li class="changed">Use <a>add value</a> to add <var>compacted item</var>
                       to the <var>map key</var> entry in <var>map object</var>
                       using <var>as array</var>.</li>
@@ -4081,7 +4081,7 @@
               and <var>value</var> has an <code>@id</code> <a>entry</a>:
               <ol>
                 <li>If the result of
-                  <span class="changed"><a>iri compacting</a>
+                  <span class="changed"><a>IRI compacting</a>
                     the value associated with the <code>@id</code> <a>entry</a> in <var>value</var></span>
                   has a <a>term definition</a> in the <var>active context</var>
                   with an <a>IRI mapping</a> that equals the value associated
@@ -4226,12 +4226,12 @@
           <ol>
             <li>If the <a>type mapping</a> of <var>active property</var>
               is set to <code>@id</code>, set <var>result</var> to the result of
-              <span class="changed"><a>iri compacting</a>
+              <span class="changed"><a>IRI compacting</a>
                 the value associated with the <code>@id</code> <a>entry</a>
                 using `false` for <var>vocab</var></span>.</li>
             <li>Otherwise, if the <a>type mapping</a> of <var>active property</var>
               is set to <code>@vocab</code>, set <var>result</var> to the result of
-              <span class="changed"><a>iri compacting</a>
+              <span class="changed"><a>IRI compacting</a>
                 the value associated with the <code>@id</code> <a>entry</a></span>.</li>
           </ol>
         </li>
@@ -4245,7 +4245,7 @@
           leave <var>value</var> as is, as value compaction is disabled.
           <ol>
             <li>Replace any value of <code>@type</code> in <var>result</var> with the result of
-              <span class="changed"><a>iri compacting</a></span>
+              <span class="changed"><a>IRI compacting</a></span>
               the value of the <code>@type</code> <a>entry</a>.</li>
           </ol>
         </li>
@@ -4274,7 +4274,7 @@
         </li>
         <li>If <var>result</var> is a <var>map</var>,
           replace each key in <var>result</var> with the result of
-          <span class="changed"><a>iri compacting</a> that key</span>.</li>
+          <span class="changed"><a>IRI compacting</a> that key</span>.</li>
         <li>Return <var>result</var>.</li>
       </ol>
     </section>
@@ -5689,7 +5689,7 @@
               <li>Otherwise, if <var>compacted output</var> is an <a>array</a>,
                 replace it with a new <a>map</a> with a single <a>entry</a>
                 whose key is the result of
-                <span class="changed"><a>iri compacting</a> `@graph`</span>
+                <span class="changed"><a>IRI compacting</a> `@graph`</span>
                 and value is <var>compacted output</var>.</li>
               <li>If <a data-lt="jsonldprocessor-compact-context">context</a> was not <code>null</code>,
                 add an <code>@context</code> <a>entry</a> to <var>compacted output</var> and set its value
@@ -6926,7 +6926,7 @@
     </li>
     <li>Other changes:
       <ul>
-        <li>Created <a>add value</a>, <a>iri expanding</a>, and <a>iri compacting</a>
+        <li>Created <a>add value</a>, <a>IRI expanding</a>, and <a>IRI compacting</a>
           macros to reduce boilerplate in algorithmic language.</li>
         <li>Added explanatory notes to step <a href="#alg-context-string">5.2</a>
           of <a href="#context-processing-algorithm" class="sectionRef"></a>,

--- a/index.html
+++ b/index.html
@@ -1381,12 +1381,9 @@
                   an <a>IRI</a>
                   or <a>blank node identifier</a>, the <a>vocabulary mapping</a>
                   of <var>result</var> is set to
-                  <span class="changed">the result of using the 
-                    <a href="#iri-expansion">IRI Expansion algorithm</a>,
-                    passing <var>result</var> for <var>active context</var>,
-                    <var>value</var>,
-                    <code>true</code> for <var>vocab</var>, and
-                    <code>true</code> for <var>document relative</var>.
+                  <span class="changed">the result of
+                    <a>iri expanding</a> <var>value</var>
+                    using <code>true</code> for <var>document relative</var>.
                   </span>.
                   If it is not an <a>IRI</a>, or a <a>blank node identifier</a>, an
                   <a data-link-for="JsonLdErrorCode">invalid vocab mapping</a>
@@ -1581,11 +1578,9 @@
               <code>@type</code> <a>entry</a>, which MUST be a <a>string</a>. Otherwise, an
               <a data-link-for="JsonLdErrorCode">invalid type mapping</a>
               error has been detected and processing is aborted.</li>
-            <li>Set <var>type</var> to the result of using the
-              <a href="#iri-expansion">IRI Expansion algorithm</a>, passing
-              <var>active context</var>, <var>type</var> for <var>value</var>,
-              <code>true</code> for <var>vocab</var>,
-              <var>local context</var>, and <var>defined</var>.</li>
+            <li>Set <var>type</var> to the result of
+              <span class="changed"><a>iri expanding</a> <var>type</var></span>,
+              using <var>local context</var>, and <var>defined</var>.</li>
             <li class="changed">If the expanded <var>type</var> is
               `@json` or `@none`, and <a>processing mode</a> is `json-ld-1.0`,
               an <a data-link-for="JsonLdErrorCode">invalid type mapping</a>
@@ -1614,12 +1609,10 @@
               (i.e., it matches the ABNF rule `"@"1*ALPHA` from [[RFC5234]]),
               return; processors SHOULD generate a warning.</li>
             <li>Otherwise, set the <a>IRI mapping</a> of <var>definition</var> to the
-              result of using the <a href="#iri-expansion">IRI Expansion algorithm</a>,
-              passing <var>active context</var>,
-              the value associated with the <code>@reverse</code> <a>entry</a> for <var>value</var>,
-              `true` for <var>vocab</var>,
-              <var>local context</var>,
-              and <var>defined</var>.
+              result of
+              <span class="changed"><a>iri expanding</a></span>
+              the value associated with the <code>@reverse</code> <a>entry</a>,
+              using <var>local context</var>, and <var>defined</var>.
               If the result does not have the <a href="https://tools.ietf.org/html/rfc3987#section-2.2">form</a> of an <a>IRI</a> or a <a>blank node identifier</a>,
               an <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
               error has been detected and processing is aborted.</li>
@@ -1658,11 +1651,11 @@
                   (i.e., it matches the ABNF rule `"@"1*ALPHA` from [[RFC5234]]),
                   return; processors SHOULD generate a warning.</li>
                 <li>Otherwise, set the <a>IRI mapping</a> of <var>definition</var> to the
-                  result of using the <a href="#iri-expansion">IRI Expansion algorithm</a>, passing
-                  <var>active context</var>, the value associated with the <code>@id</code> <a>entry</a> for
-                  <var>value</var>, <code>true</code> for <var>vocab</var>,
-                  <var>local context</var>, and <var>defined</var>. If the resulting
-                  <a>IRI mapping</a> is neither a <a>keyword</a>, nor an
+                  result of
+                  <span class="changed"><a>iri expanding</a></span>
+                  the value associated with the <code>@id</code> <a>entry</a>,
+                  using <var>local context</var>, and <var>defined</var>.
+                  If the resulting <a>IRI mapping</a> is neither a <a>keyword</a>, nor an
                   <a>IRI</a>, nor a <a>blank node identifier</a>, an
                   <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
                   error has been detected and processing is aborted; if it equals <code>@context</code>, an
@@ -1674,13 +1667,8 @@
                   <ol>
                     <li>Set the value associated with <var>defined</var>'s <var>term</var> <a>entry</a> to
                       <code>true</code>.</li>
-                    <li>If the result of expanding <var>term</var>
-                      using the <a href="#iri-expansion">IRI Expansion algorithm</a>,
-                      passing <var>active context</var>,
-                      <var>term</var> for <var>value</var>,
-                      <code>true</code> for <var>vocab</var>,
-                      <var>local context</var>,
-                      and <var>defined</var>,
+                    <li>If the result of <span class="changed"><a>iri expanding</a></span> <var>term</var>
+                      using <var>local context</var>, and <var>defined</var>,
                       is not the same as the <a>IRI mapping</a> of <var>definition</var>,
                       an <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
                       error has been detected and processing is aborted.</li>
@@ -1720,10 +1708,7 @@
           <ol>
             <li><var>Term</var> is a <a>relative IRI reference</a>.</li>
             <li>Set the <a>IRI mapping</a> of <var>definition</var> to the
-              result of using the <a href="#iri-expansion">IRI Expansion algorithm</a>, passing
-              <var>active context</var>,
-              <var>term</var> for <var>value</var>, and
-              <code>true</code> for <var>vocab</var>.
+              result of <span class="changed"><a>iri expanding</a></span> <var>term</var>.
               If the resulting <a>IRI mapping</a> is not an <a>IRI</a>, an
               <a data-link-for="JsonLdErrorCode">invalid IRI mapping</a>
               error has been detected and processing is aborted.</li>
@@ -2479,9 +2464,7 @@
           If <var>from map</var> is undefined or <code>false</code>,
           and <var>element</var> does not contain an <a>entry</a> expanding to <code>@value</code>,
           and <var>element</var> does not consist of a single <a>entry</a> expanding to <code>@id</code>
-          (where <a>entries</a> are expanded using the <a href="#iri-expansion">IRI Expansion algorithm</a>,
-          passing <var>active context</var>, the <a>entry</a> key for
-          <var>value</var>, and <code>true</code> for <var>vocab</var>),
+          (where <a>entries</a> are <span class="changed"><a data-lt="iri expanding">iri expanded</a></span>,
           set <var>active context</var> to <a>previous context</a> from <var>active context</var>,
           as the scope of a term-scoped <a>context</a> does not apply when processing new <a>node objects</a>.</li>
         <li id="alg-expand-property-scoped-context" class="changed">If <var>property-scoped context</var> is defined,
@@ -2499,10 +2482,7 @@
           <a>type-scoped context</a>.</li>
         <li class="changed">For each <var>key</var> and <var>value</var> in <var>element</var>
           ordered lexicographically by <var>key</var>
-          where <var>key</var> expands to <code>@type</code> using the
-          <a href="#iri-expansion">IRI Expansion algorithm</a>,
-          passing <var>active context</var>, <var>key</var> for
-          <var>value</var>, and <code>true</code> for <var>vocab</var>:
+          where <var>key</var> <span class="changed"><a data-lt="iri expanding">iri expands</a></span> to <code>@type</code>:
           <ol>
             <li>Convert <var>value</var> into an <a>array</a>, if necessary.</li>
             <li id="expand-type-scoped-context">For each <var>term</var> which is a value of <var>value</var> ordered lexicographically,
@@ -2520,9 +2500,8 @@
           <span class="changed">and <var>nests</var>.
             Initialize <var>input type</var> to expansion of the last value of the first <a>entry</a> in <var>element</var>
             expanding to <code>@type</code> (if any), ordering <a>entries</a> lexicographically by key</span>.
-            Both the key and value of the matched entry are expanded using the
-            <a href="#iri-expansion">IRI Expansion algorithm</a>,
-            passing <var>active context</var>, and <code>true</code> for <var>vocab</var>.
+            Both the key and value of the matched entry are
+            <span class="changed"><a data-lt="iri expanding">iri expanded</a></span>.
         </li>
         <li id="alg-expand-each-key-value">
           For each <var>key</var> and <var>value</var> in <var>element</var>,
@@ -2531,9 +2510,7 @@
             <li>If <var>key</var> is <code>@context</code>, continue to
               the next <var>key</var>.</li>
             <li>Initialize <var>expanded property</var> to the result of
-              using the <a href="#iri-expansion">IRI Expansion algorithm</a>,
-              passing <var>active context</var>, <var>key</var> for
-              <var>value</var>, and <code>true</code> for <var>vocab</var>.</li>
+              <span class="changed"><a>iri expanding</a></span> <var>key</var>.</li>
             <li>If <var>expanded property</var> is <code>null</code> or it neither
               contains a colon (<code>:</code>) nor it is a <a>keyword</a>,
               drop <var>key</var> by continuing to the next <var>key</var>.</li>
@@ -2557,10 +2534,10 @@
                         MAY be an empty <a>map</a>, or an <a>array</a> of one
                         or more <a>strings</a>.</span></li>
                     <li>Otherwise,
-                      set <var>expanded value</var> to the result of using the
-                      <a href="#iri-expansion">IRI Expansion algorithm</a>,
-                      passing <var>active context</var>, <var>value</var>, and <code>true</code>
-                      for <var>document relative</var>.
+                      set <var>expanded value</var> to the result of
+                      <span class="changed"><a>iri expanding</a></span> <var>value</var>
+                      using <code>true</code> for <var>document relative</var>
+                      and `false` for <var>vocab</var>.
                       <span class="changed">
                         When the {{JsonLdOptions/frameExpansion}} flag is set, <var>expanded value</var> will be
                         an <a>array</a> of one or more of the values, with <a>string</a>
@@ -2587,18 +2564,16 @@
                     <li class="changed">Otherwise, if <var>value</var>
                       is a <a>default object</a>, set <var>expanded value</var> to
                       a new <a>default object</a> with the value of `@default` set
-                      to the result of using the
-                      <a href="#iri-expansion">IRI Expansion algorithm</a>, passing
-                      <var class="changed">type-scoped context</var> for <var>active context</var>,
-                      <code>true</code> for <var>vocab</var>,
-                      and <code>true</code> for <var>document relative</var> to expand that value.</li>
+                      to the result of
+                      <span class="changed"><a>iri expanding</a></span> <var>value</var>
+                      using <var class="changed">type-scoped context</var> for <var>active context</var>,
+                      and <code>true</code> for <var>document relative</var>.</li>
                     <li id="expansion-tsc">Otherwise,
-                      set <var>expanded value</var> to the result of using the
-                      <a href="#iri-expansion">IRI Expansion algorithm</a>, passing
-                      <var class="changed">type-scoped context</var> for <var>active context</var>,
-                      <code>true</code> for <var>vocab</var>,
-                      and <code>true</code> for <var>document relative</var> to expand the <var>value</var>
-                      or each of its items.
+                      set <var>expanded value</var> to the result of
+                      <span class="changed"><a>iri expanding</a></span>
+                      each of its values
+                      using <var class="changed">type-scoped context</var> for <var>active context</var>,
+                      and <code>true</code> for <var>document relative</var>.
                     </li>
                     <li><span class="changed">If <var>result</var> already has an entry for `@type`,
                       prepend the value of `@type` in <var>result</var> to <var>expanded value</var>,
@@ -2876,10 +2851,8 @@
                       and the value of the <var>index</var>'s <a>local context</a>
                       as <var>local context</var>.</li>
                       <li>Otherwise, set <var>map context</var> to <var>active context</var>.</li>
-                    <li>Initialize <var>expanded index</var> to the result of using the
-                      <a href="#iri-expansion">IRI Expansion algorithm</a>,
-                      passing <var>active context</var>, <var>index</var>, and <code>true</code>
-                      for <var>vocab</var>.</li>
+                    <li>Initialize <var>expanded index</var> to the result of
+                      <span class="changed"><a>iri expanding</a></span> <var>index</var>.</li>
                     <li>If <var>index value</var> is not an <a>array</a>
                       set <var>index value</var> to an <a>array</a> containing only
                       <var>index value</var>.</li>
@@ -2906,10 +2879,8 @@
                               passing the <var>active context</var>,
                               <var>index key</var> as <var>active property</var>,
                               and <var>index</var> as <var>value</var>.</li>
-                            <li>Initialize <var>expanded index key</var> to the result of calling
-                              the <a href="#iri-expansion">IRI Expansion algorithm</a>,
-                              passing <var>active context</var>, <var>index key</var>, and <code>true</code>
-                              for <var>vocab</var>.</li>
+                            <li>Initialize <var>expanded index key</var> to the result of
+                              <span class="changed"><a>iri expanding</a></span> <var>index key</var>.</li>
                             <li>Initialize <var>index property values</var> to the concatenation of
                               <var>re-expanded index</var> with any existing values of
                               <var>expanded index key</var> in <var>item</var>.</li>
@@ -2929,10 +2900,10 @@
                           <var>item</var> does not have the <a>entry</a> <code>@id</code>,
                           and <var>expanded index</var> is not `@none`,
                           add the key-value pair (<code>@id</code>-<var>expanded index</var>) to <var>item</var>,
-                          where <var>expanded index</var> is set to the result of using the
-                          <a href="#iri-expansion">IRI Expansion algorithm</a>,
-                          passing <var>active context</var>, <var>index</var>, and <code>true</code>
-                          for <var>document relative</var>.</li>
+                          where <var>expanded index</var> is set to the result of
+                          <span class="changed"><a>iri expanding</a></span><var>index</var>
+                          using `true` for <var>document relative</var>
+                          and `false` for <var>vocab</var>.</li>
                         <li id="alg-expand-container-mapping-type">Otherwise, if <var>container mapping</var> includes <code>@type</code>
                           and <var>expanded index</var> is not <code>@none</code>,
                           initialize <var>types</var> to a new <a>array</a>
@@ -3282,20 +3253,18 @@
           <span class="changed">and the <var>value</var> is a <a>string</a>,</span>
           return a new
           <a class="changed">map</a> containing a single <a>entry</a> where the
-          key is <code>@id</code> and the value is the result of using the
-          <a href="#iri-expansion">IRI Expansion algorithm</a>, passing
-          <var>active context</var>, <var>value</var>, and <code>true</code> for
-          <var>document relative</var>.</li>
+          key is <code>@id</code> and the value is the result
+          <span class="changed"><a>iri expanding</a></span> <var>value</var>
+          using `true` for <var>document relative</var>
+          and `false` for <var>vocab</var>.</li>
         <li>If <var>active property</var> has a <a>type mapping</a> in
           <var>active context</var> that is <code>@vocab</code>,
           <span class="changed">and the <var>value</var> is a <a>string</a>,</span>
           return a new
           <a class="changed">map</a> containing a single <a>entry</a> where the
-          key is <code>@id</code> and the value is the result of using the
-          <a href="#iri-expansion">IRI Expansion algorithm</a>, passing
-          <var>active context</var>, <var>value</var>, <code>true</code> for
-          <var>vocab</var>, and <code>true</code> for
-          <var>document relative</var>.</li>
+          key is <code>@id</code> and the value is the result of
+          <span class="changed"><a>iri expanding</a></span> <var>value</var>
+          using <code>true</code> for <var>document relative</var>.</li>
         <li>Otherwise, initialize <var>result</var> to a <a class="changed">map</a>
           with an <code>@value</code> <a>entry</a> whose value is set to
           <var>value</var>.</li>
@@ -6957,6 +6926,8 @@
     </li>
     <li>Other changes:
       <ul>
+        <li>Created <a>add value</a>, <a>iri expanding</a>, and <a>iri compacting</a>
+          macros to reduce boilerplate in algorithmic language.</li>
         <li>Added explanatory notes to step <a href="#alg-context-string">5.2</a>
           of <a href="#context-processing-algorithm" class="sectionRef"></a>,
           and moved the former step 5.2.5 to <a href="#alg-context-deref-error">5.2.4.1</a>.


### PR DESCRIPTION
This is an attempt to simplify language by extracting common steps into "macros" described as algorithm terms.

* Be more clear about what it meant by "it" in "set it" in various parts of the text. Fixes #330.
* Added "add value" macro to algorithm terms to manage adding values entries in objects and properly deal with array conversion.
* Added _iri compacting_ macro and use where more verbose IRI Compaction language was used.
* Added _iri expanding_ macro and use where more verbose IRI Expansion language was used.
* Rewrite many entries in Compaction and elsewhere to use "add value" to simplify language.

For #327, #329, #330, and #332.

cc/ @kasei


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/339.html" title="Last updated on Jan 21, 2020, 9:56 PM UTC (191cab9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/339/16a8156...191cab9.html" title="Last updated on Jan 21, 2020, 9:56 PM UTC (191cab9)">Diff</a>