### PR TITLE
Add an embedded context which is unused, but should indicate an error.

### DIFF
--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -3896,6 +3896,34 @@ Test tc031 @context resolutions respects relative URLs.
 </dd>
 </dl>
 </dd>
+<dt id='tc032'>
+Test tc032 Unused embedded context with error.
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tc032</dd>
+<dt>Type</dt>
+<dd>jld:NegativeEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>An embedded context which is never used should still be checked.</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/c032-in.jsonld'>expand/c032-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+invalid scoped context
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
 <dt id='tdi01'>
 Test tdi01 Expand string using default and term directions
 </dt>

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -1173,6 +1173,14 @@
       "expect": "expand/c031-out.jsonld",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tc032",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "Unused embedded context with error.",
+      "purpose": "An embedded context which is never used should still be checked.",
+      "input": "expand/c032-in.jsonld",
+      "expectErrorCode": "invalid scoped context",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tdi01",
       "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Expand string using default and term directions",

--- a/tests/expand/c032-in.jsonld
+++ b/tests/expand/c032-in.jsonld
@@ -1,0 +1,14 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "t1": {
+      "@id": "ex:t1",
+      "@context": {
+        "t2": {
+          "@context": {"type": null}
+        }
+      }
+    }
+  },
+  "t1": "something"
+}

--- a/tests/toRdf-manifest.html
+++ b/tests/toRdf-manifest.html
@@ -2136,6 +2136,34 @@ Test tc031 @context resolutions respects relative URLs.
 </dd>
 </dl>
 </dd>
+<dt id='tc032'>
+Test tc032 Unused embedded context with error.
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tc032</dd>
+<dt>Type</dt>
+<dd>jld:NegativeEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>An embedded context which is never used should still be checked.</dd>
+<dt>input</dt>
+<dd>
+<a href='toRdf/c032-in.jsonld'>toRdf/c032-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+invalid scoped context
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
 <dt id='tdi01'>
 Test tdi01 Expand string using default and term directions
 </dt>

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -644,6 +644,14 @@
       "expect": "toRdf/c031-out.nq",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tc032",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
+      "name": "Unused embedded context with error.",
+      "purpose": "An embedded context which is never used should still be checked.",
+      "input": "toRdf/c032-in.jsonld",
+      "expectErrorCode": "invalid scoped context",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tdi01",
       "@type": [ "jld:PositiveEvaluationTest", "jld:ToRDFTest" ],
       "name": "Expand string using default and term directions",

--- a/tests/toRdf/c032-in.jsonld
+++ b/tests/toRdf/c032-in.jsonld
@@ -1,0 +1,14 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "t1": {
+      "@id": "ex:t1",
+      "@context": {
+        "t2": {
+          "@context": {"type": null}
+        }
+      }
+    }
+  },
+  "t1": "something"
+}


### PR DESCRIPTION
Fixes #331.