### PR TITLE
Various

### DIFF
--- a/ack-script/acknowledgements.html
+++ b/ack-script/acknowledgements.html
@@ -6,7 +6,8 @@
     </p>
 
     <ul class="ack">
-                <li>Timothy Cole (University of Illinois at Urbana-Champaign)</li>
+        <li>Timothy Cole (University of Illinois at Urbana-Champaign)</li>
+        <li>Gregory Todd Williams (J. Paul Getty Trust)</li>
         <li>Ivan Herman (W3C Staff)</li>
         <li>Jeff Mixter (OCLC (Online Computer Library Center, Inc.))</li>
         <li>David Lehn (Digital Bazaar)</li>
@@ -22,7 +23,7 @@
     <p>Additionally, the following people were members of the Working Group at the time of publication:</p>
 
     <ul class="ack">
-                <li>Steve Blackmon (Apache Software Foundation)</li>
+        <li>Steve Blackmon (Apache Software Foundation)</li>
         <li>Dan Brickley (Google, Inc.)</li>
         <li>Newton Calegari (NIC.br - Brazilian Network Information Center)</li>
         <li>Victor Charpenay (Siemens AG)</li>

--- a/index.html
+++ b/index.html
@@ -4095,7 +4095,8 @@
             </li>
             <li>Otherwise, append <var>type/language value</var> and <code>@none</code>, in
               that order, to <var>preferred values</var>.
-              <span class="changed">If <var>value</var> is an empty <a>list object</a>,
+              <span class="changed">If <var>value</var> is a <a>list object</a>
+                with an empty <var>array</var> as the value of `@list`,
                 set <var>type/language</var> to <code>@any</code>.</span></li>
             <li class="changed">Append <code>@any</code> to <var>preferred values</var>.</li>
             <li class="changed">If <var>preferred values</var>

--- a/index.html
+++ b/index.html
@@ -5598,7 +5598,7 @@
 
     <p>It is important to highlight that implementations do not modify the input parameters.
       If an error is detected, the {{Promise}} is
-      rejected with a <a>JsonLdError</a> with an appropriate {{JsonLdError/code}}
+      rejected with a <a>JsonLdError</a> having an appropriate {{JsonLdError/code}}
       and processing is stopped.</p>
 
     <p>If the <a data-link-for="JsonLdOptions">documentLoader</a>
@@ -6189,7 +6189,7 @@
       <p>The <dfn>LoadDocumentCallback</dfn> defines a callback that custom document loaders
         have to implement to be used to retrieve remote documents and contexts.
         The callback returns a {{Promise}} resolving to a <a>RemoteDocument</a>.
-        On failure, the {{Promise}} is rejected with an appropriate error <a data-link-for="JsonLdError">code</a>.</p>
+        On failure, the {{Promise}} with a a <a>JsonLdError</a> having an appropriate error <a data-link-for="JsonLdError">code</a>.</p>
 
       <pre class="idl">
         callback LoadDocumentCallback = Promise&lt;RemoteDocument> (

--- a/index.html
+++ b/index.html
@@ -4061,7 +4061,7 @@
               be the last <a>container mapping</a> value to be checked as it
               is the most generic.</li>
             <li class="changed">
-              If <a>processing mode</a> not `json-ld-1.0` and value does not contain an <code>@index</code> <a>entry</a>,
+              If <a>processing mode</a> not `json-ld-1.0` and <var>value</var> does not contain an <code>@index</code> <a>entry</a>,
               append <code>@index</code> and <code>@index@set</code> to <var>containers</var>.
             </li>
             <li class="changed">

--- a/index.html
+++ b/index.html
@@ -3549,10 +3549,11 @@
               then:
               <ol>
                 <li>Initialize <var>compacted value</var> to the result of using this
-                  algorithm recursively, passing <var>active context</var>,
-                  <var>inverse context</var>, <var>property</var> for
-                  <var>active property</var>, <var>expanded value</var>
-                  for <var>element</var>,
+                  algorithm recursively, passing
+                  <var>active context</var>,
+                  <var>inverse context</var>,
+                  <var>active property</var>,
+                  <var>expanded value</var> for <var>element</var>,
                   <span class="changed">and the {{JsonLdOptions/compactArrays}}
                     and {{JsonLdOptions/ordered}} flags</span>.</li>
                 <li>Add <var>compacted value</var> as the value of <code>@preserve</code>

--- a/index.html
+++ b/index.html
@@ -6822,143 +6822,27 @@
       explicitly to `json-ld-1.0`.</li>
     <li>Improve notation using <a>IRI</a>, <a>IRI reference</a>, and <a>relative IRI reference</a>.</li>
     <li>Ignore terms and IRIs that have the form of a keyword (`"@"1*ALPHA`).</li>
+    <li>Add `application/xhtml+xml` as an allowed media type in <a href="#process-html" class="sectionRef"></a>,
+      in the note in <a href="#loaddocumentcallback" class="sectionRef"></a>,
+      and as a use of the {{LoadDocumentOptions/profile}} API option.</li>
+    <li>Added <a>add value</a>, <a>IRI expanding</a>, and <a>IRI compacting</a>
+      macros to reduce boilerplate in algorithmic language.</li>
+    <li>Improved algorithms in
+      <a href="#context-processing-algorithm" class="sectionRef"></a>,
+      <a href="#create-term-definition" class="sectionRef"></a>,
+      <a href="#expansion" class="sectionRef"></a>,
+      <a href="#compaction" class="sectionRef"></a>,
+      <a href="#value-compaction" class="sectionRef"></a>,
+      <a href="#node-map-generation" class="sectionRef"></a>,
+      and <a href="#deserialize-json-ld-to-rdf-algorithm" class="sectionRef"></a>.
+    </li>
   </ul>
 </section>
-<section class="appendix informative" id="changes-from-cr">
+<!--section class="appendix informative" id="changes-from-cr">
   <h2>Changes since Candidate Release of 12 December 2019</h2>
   <ul>
-    <li>Miscellaneous updates to <a href="#create-term-definition" class="sectionRef"></a>:
-      <ul>
-        <li>Added missing `@none` in <a href="#ctd-invalid-type">13.4</a>.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/259">Issue 259</a>.</li>
-        <li>Moved step <a href="#ctd-id-not-null">16.2</a>,
-          and subsequent substeps of step 16 into a new grouping, to separate the logic
-          from step <a href="#ctd-id-not-null">16.1</a>.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/241">Issue 241</a>.</li>
-        <li>Updated step <a href="#ctd-contains-colon">16.4</a>
-          to prevent an issue where <var>term</var> might not be defined at the time it is expanded.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/245">Issue 245</a>.</li>
-        <li>Clarified step <a href="#ctd-container">21.1</a>
-          that `@graph` may be used with `@set`.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/242">Issue 242</a>.</li>
-        <li>Added missing keywords to step <a href="#ctd-invalid-entries">28</a>.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/261">Issue 261</a>.</li>
-      </ul>
-    </li>
-    <li>Miscellaneous updates to <a href="#expansion" class="sectionRef"></a>:
-      <ul>
-        <li>Update step <a href="#alg-expand-prev-context">7</a>
-          to describe using the <a href="#iri-expansion">IRI Expansion algorithm</a> for expanding entries.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/309">Issue 309</a>.</li>
-        <li>Update step <a href="#alg-expand-property-scoped-context">8</a>
-          to pass <var>override context</var> when creating a property-scoped context.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/301">Issue 301</a>.</li>
-        <li>Update step <a href="#expand-type-scoped-context">11.2</a>
-          to make sure the <a>type-scoped context</a> is not propagated by default
-          and to use the <a>type-scoped context</a> when finding a <a>local context</a>.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/243">Issue 246</a>
-          and <a href="https://github.com/w3c/json-ld-api/issues/304">Issue 304</a>.</li>
-        <li>Updated step <a href="#alg-expand-initialize-vars">12</a>
-          <var>input type</var> to use the expanded value.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/269">Issue 269</a>.</li>
-        <li>Remove text from  <a href="#expansion-tsc">13.4.4.4</a>
-          that duplicate the following step.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/243">Issue 243</a>.</li>
-        <li>Add text to step  <a href="#alg-expand-list-value">13.4.11.2</a>
-          to ensure that the result is an array.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/310">Issue 310</a>.</li>
-        <li>Changed text in step <a href="#alg-expand-container-index-not-index">3.8.3.7.2</a>
-          to re-expand the index as a value before using it to update any existing
-          value for the associated property.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/264">Issue 290</a>.</li>
-        <li>Improved text in step <a href="#alg-expand-container-mapping-type">13.8.3.7.5</a>
-          to exclude the <var>expanded index</var> being `@none`.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/264">Issue 264</a>.</li>
-        <li>Update step <a href="#alg-expand-resolve-nest">14</a>
-          to order by <var>nesting-key</var>, if `ordered` is `true`.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/295">Issue 295</a>.</li>
-        <li>Move step 13.15 of the expansion algorithm up one level to step <a href="#alg-expand-resolve-nest">14</a>,
-          as it had accidentally been set to run for every entry in the object, rather than
-          after all entries had been expanded.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/262">Issue 262</a>.</li>
-        <li>Move step <a href="#alg-expand-null-value">15.3</a> down one, and return `null`.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/292">Issue 292</a>.</li>
-        <li>Changed step <a href="#alg-expand-only-language">18</a>
-          to return `null`, not set <var>result</var> to `null`.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/284">Issue 284</a>.</li>
-        <li>Moved three steps prior to step <a href="#alg-expand-return">20</a> to
-          step <a href="#api-expand-post-processing">7.1</a> of
-          the <a data-link-for="JsonLdProcessor">expand()</a> method of the
-          <a>JsonLdProcessor</a> interface.
-          Additionally, in step <a href="#alg-expand-container-index-graph">13.8.3.7.1</a>,
-          when expanding properties where container includes both `@index` and `@graph`,
-          don't transform an item into a <a>graph object</a> repetitively.
-          This corrects an issue introduced in <a href="https://github.com/w3c/json-ld-api/pull/184">PR 184</a> and is
-          in response to <a href="https://github.com/w3c/json-ld-api/issues/294">Issue 294</a>.</li>
-      </ul>
-    </li>
-    <li>Miscellaneous updates to <a href="#deserialize-json-ld-to-rdf-algorithm" class="sectionRef"></a>:
-      <ul>
-        <li>Changed step <a href="#alg-jld2rdf-init-triples">1.2</a>
-          to initialize <var>triple</var>, not <var>graph</var>, which is an input.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/281">Issue 281</a>.</li>
-        <li>Changed step <a href="#alg-jld2rdf-init-list-triples">1.3.2.5.1</a>
-          to be a note on the following step, as it was non-procedural.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/278">Issue 278</a>.</li>
-        <li>Changed step <a href="#alg-jld2rdf-add-list-triples">1.3.2.5.2</a>
-          to use the {{RdfGraph/add}} method, rather than use "append".
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/279">Issue 279</a>.</li>
-      </ul>
-    </li>
-    <li>Miscellaneous updates to <a href="#object-to-rdf-conversion" class="sectionRef"></a>:
-      <ul>
-        <li>Updated step <a href="#alg-obj2rdf-datatype">6</a>
-          to only check that a datatype is well-formed if it is not `null` or `@json`,
-          and to specify that the check is for a well-formed IRI.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/282">Issue 282</a>
-          and <a href="https://github.com/w3c/json-ld-api/issues/298">Issue 298</a>.</li>
-        <li>Updated step <a href="#alg-obj2rdf-double">10</a>
-          to also catch big integers.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/312">Issue 312</a>.</li>
-        <li>Simplified step <a href="#alg-obj2rdf-integer">11</a>
-          to remove redundant conditions, adding a note instead.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/312">Issue 312</a>.</li>
-        <li>Added a new step <a href="#alg-obj2rdf-direction-language">13.1</a> to create a variable for `@language`.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/277">Issue 277</a>.</li>
-      </ul>
-    </li>
-    <li>Other changes:
-      <ul>
-        <li>Created <a>add value</a>, <a>IRI expanding</a>, and <a>IRI compacting</a>
-          macros to reduce boilerplate in algorithmic language.</li>
-        <li>Added explanatory notes to step <a href="#alg-context-string">5.2</a>
-          of <a href="#context-processing-algorithm" class="sectionRef"></a>,
-          and moved the former step 5.2.5 to <a href="#alg-context-deref-error">5.2.4.1</a>.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/265">Issue 265</a>.</li>
-        <li>Add `application/xhtml+xml` as an allowed media type in <a href="#process-html" class="sectionRef"></a>,
-          in the note in <a href="#loaddocumentcallback" class="sectionRef"></a>,
-          and as a use of the {{LoadDocumentOptions/profile}} API option.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/244">Issue 244</a>.</li>
-        <li>Improved text in step <a href="#alg-nmg-each-type">3</a> of the
-          <a href="#node-map-generation">Node Map Generation algorithm</a> to clarify
-          that the steps iterates over any `@type` entries.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/276">Issue 276</a>.</li>
-        <li>Clarify sub-steps of step <a href="#alg-compval-id-index">4</a>
-          of the <a href="#value-compaction">Value Compaction algorithm</a>.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/321">Issue 321</a>.</li>
-        <li>Updated the language in step <a href="alg-valcompact-lang-dir">8</a>
-          of <a href="#value-compaction" class="sectionRef"></a> to be consistent with other steps.
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/313">Issue 313</a>.</li>
-        <li>Moved the last part of the compaction algorithm to
-          step <a href="#api-compact-post-processing">7</a> of
-          the <a data-link-for="JsonLdProcessor">compact()</a> method of the
-          <a>JsonLdProcessor</a> interface.</li>
-        <li>Clarified the handling of big integers in <a href="#data-round-tripping" class="sectionRef"></a>
-          This is in response to <a href="https://github.com/w3c/json-ld-api/issues/312">Issue 312</a>.</li>
-      </ul>
-    </li>
   </ul>
-</section>
+</section-->
 
 <section id="ack"
 class="appendix informative"

--- a/index.html
+++ b/index.html
@@ -3768,8 +3768,7 @@
                       Set <var>map key</var> to the value of <code>@language</code> in <var>expanded item</var>, if any.</li>
                     <li>Otherwise, if <var>container</var> includes <code>@index</code>
                       and <var>index key</var> is <code>@index</code>,
-                      set <var>map key</var> to the value of <code>@index</code> in <var>expanded item</var>, if any,
-                      and remove <var>container key</var> from <var>compacted item</var>.</li>
+                      set <var>map key</var> to the value of <code>@index</code> in <var>expanded item</var>, if any.</li>
                     <li class="changed">Otherwise, if <var>container</var> includes <code>@index</code>
                       and <var>index key</var> is not <code>@index</code>,
                       set <var>map key</var> to the first value of <var>container key</var> in <var>compacted item</var>, if any.

--- a/index.html
+++ b/index.html
@@ -5597,7 +5597,7 @@
 
     <p>It is important to highlight that implementations do not modify the input parameters.
       If an error is detected, the {{Promise}} is
-      rejected passing a <a>JsonLdError</a> with the corresponding error
+      rejected <a>JsonLdError</a> with the corresponding error
       <a data-link-for="JsonLdError">code</a>
       and processing is stopped.</p>
 

--- a/index.html
+++ b/index.html
@@ -4123,26 +4123,24 @@
           Try to create a <a>compact IRI</a>, starting by initializing
           <var>compact IRI</var> to <code>null</code>. This variable will be used to
           store the created <a>compact IRI</a>, if any.</li>
-        <li>For each key <a>term</a> and value <a>term definition</a> in
-          the <var>active context</var>:
+        <li>For each <a>term definition</a> <var>definition</var> in <var>active context</var>:
           <ol>
-            <li>If the <a>term definition</a> is <code>null</code>,
-              its <a>IRI mapping</a> equals <var>var</var>, its
-              <a>IRI mapping</a> is not a substring at the beginning of
+            <li>If the <a>IRI mapping</a> of <var>definition</var> is `null`,
+              its <a>IRI mapping</a> equals <var>var</var>,
+              its <a>IRI mapping</a> is not a substring at the beginning of
               <var>var</var>,
-              <span class="changed"> or the term definition does not contain
-                the <a>prefix flag</a> having a value of <code>true</code>,</span>
-              the <a>term</a> cannot be used as a <a>prefix</a>.
-              Continue with the next <a>term</a>.</li>
-            <li>Initialize <var>candidate</var> by concatenating <a>term</a>,
+              <span class="changed"> or <var>definition</var> does not have
+                a <code>true</code> <a>prefix flag</a>,</span>
+              <var>definition</var>'s key cannot be used as a <a>prefix</a>.
+              Continue with the next <var>definition</var>.</li>
+            <li>Initialize <var>candidate</var> by concatenating <var>definition</var> key,
               a colon (<code>:</code>), and the substring of <var>var</var>
               that follows after the value of the
-              <a data-lt="term definition">term definition's</a>
-              <a>IRI mapping</a>.</li>
+              <var>definition</var>'s <a>IRI mapping</a>.</li>
             <li>If either <var>compact IRI</var> is <code>null</code>, <var>candidate</var> is
               shorter or the same length but lexicographically less than
               <var>compact IRI</var> and <var>candidate</var> does not have a
-              <a>term definition</a> in <var>active context</var>, or if the
+              <a>term definition</a> in <var>active context</var>, or if that
               <a>term definition</a> has an <a>IRI mapping</a>
               that equals <var>var</var> and <var>value</var> is <code>null</code>,
               set <var>compact IRI</var> to <var>candidate</var>.</li>

--- a/index.html
+++ b/index.html
@@ -4037,9 +4037,9 @@
                       <var>containers</var>.</li>
                     <li>Otherwise, if <var>value</var> contains an <code>@language</code> <a>entry</a>
                       and does not contain an <code>@index</code> <a>entry</a>,
-                      then set <var>type/language value</var> to its associated
-                      value and, append <code>@language</code>,
-                      normalized to lower case,
+                      then set <var>type/language value</var> to
+                      the value of `@langauge` normalized to lower case,
+                      and append <code>@language</code>,
                       <span class="changed">and <code>@language@set</code></span> to
                       <var>containers</var>.</li>
                     <li>Otherwise, if <var>value</var> contains a

--- a/index.html
+++ b/index.html
@@ -5598,8 +5598,7 @@
 
     <p>It is important to highlight that implementations do not modify the input parameters.
       If an error is detected, the {{Promise}} is
-      rejected <a>JsonLdError</a> with the corresponding error
-      <a data-link-for="JsonLdError">code</a>
+      rejected with a <a>JsonLdError</a> with an appropriate {{JsonLdError/code}}
       and processing is stopped.</p>
 
     <p>If the <a data-link-for="JsonLdOptions">documentLoader</a>
@@ -6239,7 +6238,7 @@
           and the response has an HTTP Link Header [[RFC8288]] using the <code>http://www.w3.org/ns/json-ld#context</code> link relation,
           set <var>contextUrl</var> to the associated <code>href</code>.
           <p>If multiple HTTP Link Headers using the <code>http://www.w3.org/ns/json-ld#context</code> link relation are found,
-            the <var>promise</var> is rejected with a <a>JsonLdError</a> whose code is set to <a data-link-for="JsonLdErrorCode">multiple context link headers</a>
+            the <var>promise</var> is rejected with a <a>JsonLdError</a> whose {{JsonLdError/code}} is set to <a data-link-for="JsonLdErrorCode">multiple context link headers</a>
             and processing is terminated.</p>
           <p>Processors MAY transform <var>document</var> to the <a>internal representation</a>.</p>
           <p class="note">The HTTP Link Header is ignored for documents served as <code>application/ld+json</code>,
@@ -6319,7 +6318,7 @@
           the HTTP Link Header is ignored.
           If multiple HTTP Link Headers using the <code>http://www.w3.org/ns/json-ld#context</code> link relation are found,
           the {{Promise}} of the <a>LoadDocumentCallback</a> is rejected
-          with a <a>JsonLdError</a> whose code is set to <a data-link-for="JsonLdErrorCode">multiple context link headers</a>.</dd>
+          with a <a>JsonLdError</a> whose {{JsonLdError/code}} is set to <a data-link-for="JsonLdErrorCode">multiple context link headers</a>.</dd>
         <dt><dfn data-dfn-for="RemoteDocument">documentUrl</dfn></dt>
         <dd>The final URL of the loaded document.
           This is important to handle HTTP redirects properly.</dd>
@@ -6368,7 +6367,7 @@
           that matches the fragment identifier, after decoding <a data-cite="RFC3986#section-2.1">percent encoded sequences</a>.
           <p>If no such element is found,
             or the located element is not a <a>JSON-LD script element</a>,
-            the <var>promise</var> is rejected with a <a>JsonLdError</a> whose code is set to <a data-link-for="JsonLdErrorCode">loading document failed</a>
+            the <var>promise</var> is rejected with a <a>JsonLdError</a> whose {{JsonLdError/code}} is set to <a data-link-for="JsonLdErrorCode">loading document failed</a>
             and processing is terminated.</p>
         </li>
         <li>Otherwise, if the <a data-link-for="LoadDocumentOptions">profile</a>
@@ -6384,7 +6383,7 @@
           of the first <a>JSON-LD script element</a> in <var>document</var>.
           <p>If no such element is found,
             or the located element is not a <a>JSON-LD script element</a>,
-            the <var>promise</var> is rejected with a <a>JsonLdError</a> whose code is set to <a data-link-for="JsonLdErrorCode">loading document failed</a>
+            the <var>promise</var> is rejected with a <a>JsonLdError</a> whose {{JsonLdError/code}} is set to <a data-link-for="JsonLdErrorCode">loading document failed</a>
             and processing is terminated.</p></li>
         <li>If <var>source</var> is defined,
           set <var>document</var> to the result of the
@@ -6396,7 +6395,7 @@
         <li>Otherwise, <var>source</var> is undefined.
           <ol>
             <li>If the <a data-link-for="LoadDocumentOptions">extractAllScripts</a> option is not present, or <code>false</code>,
-              the <var>promise</var> is rejected with a <a>JsonLdError</a> whose code is set to <a data-link-for="JsonLdErrorCode">loading document failed</a>
+              the <var>promise</var> is rejected with a <a>JsonLdError</a> whose {{JsonLdError/code}} is set to <a data-link-for="JsonLdErrorCode">loading document failed</a>
               and processing is terminated.</li>              
             <li>Otherwise, the <a data-link-for="LoadDocumentOptions">extractAllScripts</a> option is <code>true</code>.
               Set <var>document</var> to a new empty <a>array</a>.

--- a/index.html
+++ b/index.html
@@ -4210,7 +4210,7 @@
         to be compacted.</p>
 
       <ol>
-        <li>Initialize <var>result</var> to <var>value</var>.</li>
+        <li>Initialize <var>result</var> to a copy of <var>value</var>.</li>
         <li>Initialize <var>language</var> to the <a>language mapping</a> for <var>active property</var>
           in <var>active context</var>, if any, otherwise to the <a>default language</a>
           of <var>active context</var>.</li>

--- a/index.html
+++ b/index.html
@@ -4250,6 +4250,7 @@
             <li>If <var>value</var> has an `@index` <a>entry</a>,
               and the <a>container mapping</a> associated to <var>active property</var>
               includes <code>@index</code>,
+              or if <var>value</var> has no `@index` <a>entry</a>,
               set <var>result</var> to the value associated with the `@value` <a>entry</a>.</li>
           </ol>
         </li>

--- a/index.html
+++ b/index.html
@@ -3910,8 +3910,7 @@
                   otherwise to `@none`.</li>
               </ol>
             </li>
-            <li class="changed">If <var>value</var> is a <a>map</a> containing
-              the <a>entry</a> <code>@preserve</code>, use the first
+            <li class="changed">If `@preserve` is an <a>entry</a> in <var>value</var>, use the first
               element from the value of <code>@preserve</code> as <var>value</var>.</li>
             <li>Initialize <var>containers</var> to an empty <a>array</a>. This
               <a>array</a> will be used to keep track of an ordered list of
@@ -3927,8 +3926,7 @@
               variables will keep track of the preferred
               <a>type mapping</a> or <a>language mapping</a> for
               a <a>term</a>, based on what is compatible with <var>value</var>.</li>
-            <li>If <var>value</var> is a <a class="changed">map</a>,
-              that contains an <code>@index</code> <a>entry</a>,
+            <li>If `@index` is an <a>entry</a> in <var>value</var> is a <a class="changed">map</a>,
               <span class="changed">and <var>value</var> is not a <a>graph object</a></span>
               then append the values <code>@index</code> <span class="changed">and <code>@index@set</code></span> to <var>containers</var>.</li>
             <li>If <var>reverse</var> is <code>true</code>, set <var>type/language</var>
@@ -4002,19 +4000,19 @@
             <li class="changed">Otherwise, if <var>value</var> is a <a>graph object</a>,
               prefer a mapping most appropriate for the particular value.
               <ol>
-                <li>If value contains an <code>@index</code> <a>entry</a>,
+                <li>If <var>value</var> contains an <code>@index</code> <a>entry</a>,
                   append the values <code>@graph@index</code> and <code>@graph@index@set</code>
                   to <var>containers</var>.</li>
-                <li>If the value contains an <code>@id</code> <a>entry</a>,
+                <li>If <var>value</var> contains an <code>@id</code> <a>entry</a>,
                   append the values <code>@graph@id</code> and <code>@graph@id@set</code>
                   to <var>containers</var>.</li>
                 <li>Append the values <code>@graph</code> <code>@graph@set</code>,
                   and <code>@set</code>
                   to <var>containers</var>.</li>
-                <li>If value does not contain an <code>@index</code> <a>entry</a>,
+                <li>If <var>value</var> does not contain an <code>@index</code> <a>entry</a>,
                   append the values <code>@graph@index</code> and <code>@graph@index@set</code>
                   to <var>containers</var>.</li>
-                <li>If the value does not contain an <code>@id</code> <a>entry</a>,
+                <li>If the <var>value</var> does not contain an <code>@id</code> <a>entry</a>,
                   append the values <code>@graph@id</code> and <code>@graph@id@set</code>
                   to <var>containers</var>.</li>
                 <li>Append the values <code>@index</code> and <code>@index@set</code>
@@ -4030,11 +4028,10 @@
                     <li class="changed">If <var>value</var> contains an `@direction` <a>entry</a>
                       and does not contain an `@index` <a>entry</a>,
                       then set <var>type/language value</var> to the concatenation of
-                      the <var>value</var>'s `@language` entry (if any)
-                      the <var>value</var>'s `@direction`, separated by an underscore (`"_"`),
+                      the <var>value</var>'s `@language` <a>entry</a> (if any)
+                      and the <var>value</var>'s `@direction` <a>entry</a>, separated by an underscore (`"_"`),
                       normalized to lower case.
-                      Append `@language` and `@language@set` to
-                      <var>containers</var>.</li>
+                      Append `@language` and `@language@set` to <var>containers</var>.</li>
                     <li>Otherwise, if <var>value</var> contains an <code>@language</code> <a>entry</a>
                       and does not contain an <code>@index</code> <a>entry</a>,
                       then set <var>type/language value</var> to
@@ -4061,11 +4058,11 @@
               be the last <a>container mapping</a> value to be checked as it
               is the most generic.</li>
             <li class="changed">
-              If <a>processing mode</a> not `json-ld-1.0` and <var>value</var> does not contain an <code>@index</code> <a>entry</a>,
+              If <a>processing mode</a> is not `json-ld-1.0` and <var>value</var> does not contain an <code>@index</code> <a>entry</a>,
               append <code>@index</code> and <code>@index@set</code> to <var>containers</var>.
             </li>
             <li class="changed">
-              If <a>processing mode</a> is not `json-ld-1.0` and value contains only an <code>@value</code> <a>entry</a>,
+              If <a>processing mode</a> is not `json-ld-1.0` and `@value` is the only <a>entry</a> in <var>value</var>,
               append <code>@language</code> and <code>@language@set</code> to <var>containers</var>.
             </li>
             <li>If <var>type/language value</var> is <code>null</code>,
@@ -4079,14 +4076,13 @@
             <li>If <var>type/language value</var> is <code>@reverse</code>, append
               <code>@reverse</code> to <var>preferred values</var>.</li>
             <li>If <var>type/language value</var> is <code>@id</code> or <code>@reverse</code>
-              and <var>value</var> has an <code>@id</code> <a>entry</a>:
+              and `@id` is an <a>entry</a> in <var>value</var>:
               <ol>
                 <li>If the result of
                   <span class="changed"><a>IRI compacting</a>
-                    the value associated with the <code>@id</code> <a>entry</a> in <var>value</var></span>
+                    the value of the <code>@id</code> <a>entry</a> in <var>value</var></span>
                   has a <a>term definition</a> in the <var>active context</var>
-                  with an <a>IRI mapping</a> that equals the value associated
-                  with the <code>@id</code> <a>entry</a> in <var>value</var>,
+                  with an <a>IRI mapping</a> that equals the value of the <code>@id</code> <a>entry</a> in <var>value</var>,
                   then append <code>@vocab</code>, <code>@id</code>, and
                   <code>@none</code>, in that order, to <var>preferred values</var>.</li>
                 <li>Otherwise, append <code>@id</code>, <code>@vocab</code>, and


### PR DESCRIPTION
* Change "empty list object" to "list object with an empty array as a value of `@list`. Fixes #345.
* Fix language in IRI compaction on setting type/language to the normalized value of `@language`. Fixes #346.
* Add missing variable markup for _value_ in IRI compaction 2.11. Fixes #347.
* Change some other uses of _value_ and **entry** in IRI compaction. Fixes #348.
* Cleanup language in step 5 of IRI Compaction. Fixes #349.
* Update step 1 in value compaction to set result to a copy of value. Fixes #350.
* Account for value compacting a value object which is not a string, and there is no `@index` entry. Fixes #351.
* Don't remove "container key" from "compacted item" for `@index` in Compaction, as it will have been left out when compacting.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/352.html" title="Last updated on Jan 27, 2020, 6:05 PM UTC (a8a4c10)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/352/581ae99...a8a4c10.html" title="Last updated on Jan 27, 2020, 6:05 PM UTC (a8a4c10)">Diff</a>