### PR TITLE
Fix "invalid context entry" codes and improve `@import` tests.

### DIFF
--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -3827,7 +3827,7 @@ Test tc029 @propagate is invalid in 1.0
 </dd>
 <dt>expect</dt>
 <dd>
-invalid context member
+invalid context entry
 </dd>
 <dt>Options</dt>
 <dd>
@@ -9182,7 +9182,7 @@ Test tso01 @import may not be used in an imported context.
 </dd>
 <dt>expect</dt>
 <dd>
-invalid context member
+invalid context entry
 </dd>
 <dt>Options</dt>
 <dd>
@@ -9238,7 +9238,7 @@ Test tso03 @import overflow
 </dd>
 <dt>expect</dt>
 <dd>
-invalid context member
+invalid context entry
 </dd>
 <dt>Options</dt>
 <dd>

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -9475,6 +9475,34 @@ invalid context entry
 </dd>
 </dl>
 </dd>
+<dt id='tso13'>
+Test tso13 @import can only reference a single context
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tso13</dd>
+<dt>Type</dt>
+<dd>jld:NegativeEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>@import can only reference a single context.</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/so13-in.jsonld'>expand/so13-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+invalid remote context
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
 <dt id='ttn01'>
 Test ttn01 @type: @none is illegal in 1.0.
 </dt>

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -9166,7 +9166,7 @@ invalid IRI mapping
 </dl>
 </dd>
 <dt id='tso01'>
-Test tso01 @import may not be used in an imported context.
+Test tso01 @import is invalid in 1.0.
 </dt>
 <dd>
 <dl class='entry'>
@@ -9175,7 +9175,7 @@ Test tso01 @import may not be used in an imported context.
 <dt>Type</dt>
 <dd>jld:NegativeEvaluationTest, jld:ExpandTest</dd>
 <dt>Purpose</dt>
-<dd>@import only valid within a term definition.</dd>
+<dd>@import is invalid in 1.0.</dd>
 <dt>input</dt>
 <dd>
 <a href='expand/so01-in.jsonld'>expand/so01-in.jsonld</a>
@@ -9189,6 +9189,8 @@ invalid context entry
 <dl class='options'>
 <dt>specVersion</dt>
 <dd>json-ld-1.1</dd>
+<dt>processingMode</dt>
+<dd>json-ld-1.0</dd>
 </dl>
 </dd>
 </dl>
@@ -9435,6 +9437,34 @@ Test tso11 Override protected terms in sourced context
 <dt>expect</dt>
 <dd>
 <a href='expand/so11-out.jsonld'>expand/so11-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='tso12'>
+Test tso12 @import may not be used in an imported context.
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tso12</dd>
+<dt>Type</dt>
+<dd>jld:NegativeEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>@import only valid within a term definition.</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/so12-in.jsonld'>expand/so12-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+invalid context entry
 </dd>
 <dt>Options</dt>
 <dd>

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -1154,7 +1154,7 @@
       "name": "@propagate is invalid in 1.0",
       "purpose": "@propagate is invalid in 1.0",
       "input": "expand/c029-in.jsonld",
-      "expectErrorCode": "invalid context member",
+      "expectErrorCode": "invalid context entry",
       "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.0"}
     }, {
       "@id": "#tc030",
@@ -2718,7 +2718,7 @@
       "purpose": "@import only valid within a term definition.",
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/so01-in.jsonld",
-      "expectErrorCode": "invalid context member"
+      "expectErrorCode": "invalid context entry"
     }, {
       "@id": "#tso02",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
@@ -2734,7 +2734,7 @@
       "purpose": "Processors must detect source contexts that include @import.",
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/so03-in.jsonld",
-      "expectErrorCode": "invalid context member"
+      "expectErrorCode": "invalid context entry"
     }, {
       "@id": "#tso05",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -2714,9 +2714,9 @@
     }, {
       "@id": "#tso01",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
-      "name": "@import may not be used in an imported context.",
-      "purpose": "@import only valid within a term definition.",
-      "option": {"specVersion": "json-ld-1.1"},
+      "name": "@import is invalid in 1.0.",
+      "purpose": "@import is invalid in 1.0.",
+      "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.0"},
       "input": "expand/so01-in.jsonld",
       "expectErrorCode": "invalid context entry"
     }, {
@@ -2791,6 +2791,14 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/so11-in.jsonld",
       "expect": "expand/so11-out.jsonld"
+    }, {
+      "@id": "#tso12",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "@import may not be used in an imported context.",
+      "purpose": "@import only valid within a term definition.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/so12-in.jsonld",
+      "expectErrorCode": "invalid context entry"
     }, {
       "@id": "#ttn01",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -2800,6 +2800,14 @@
       "input": "expand/so12-in.jsonld",
       "expectErrorCode": "invalid context entry"
     }, {
+      "@id": "#tso13",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
+      "name": "@import can only reference a single context",
+      "purpose": "@import can only reference a single context.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/so13-in.jsonld",
+      "expectErrorCode": "invalid remote context"
+    }, {
       "@id": "#ttn01",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "@type: @none is illegal in 1.0.",

--- a/tests/expand/so12-in.jsonld
+++ b/tests/expand/so12-in.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "@import": "so01-in.jsonld"
+  }
+}

--- a/tests/expand/so12-in.jsonld
+++ b/tests/expand/so12-in.jsonld
@@ -1,5 +1,5 @@
 {
   "@context": {
-    "@import": "so01-in.jsonld"
+    "@import": "so12-in.jsonld"
   }
 }

--- a/tests/expand/so13-context.jsonld
+++ b/tests/expand/so13-context.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": [{
+    "term": "http://example.org/term"
+  }, {
+    "term2": "http://example.org/term2"
+  }]
+}

--- a/tests/expand/so13-in.jsonld
+++ b/tests/expand/so13-in.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@import": "so13-context.jsonld"
+  },
+  "term": "value"
+}

--- a/tests/toRdf-manifest.html
+++ b/tests/toRdf-manifest.html
@@ -9080,6 +9080,8 @@ invalid context entry
 <dl class='options'>
 <dt>specVersion</dt>
 <dd>json-ld-1.1</dd>
+<dt>processingMode</dt>
+<dd>json-ld-1.0</dd>
 </dl>
 </dd>
 </dl>
@@ -9326,6 +9328,34 @@ Test tso11 Override protected terms in sourced context
 <dt>expect</dt>
 <dd>
 <a href='toRdf/so11-out.nq'>toRdf/so11-out.nq</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='tso12'>
+Test tso12 @import may not be used in an imported context.
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tso12</dd>
+<dt>Type</dt>
+<dd>jld:NegativeEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>@import only valid within a term definition.</dd>
+<dt>input</dt>
+<dd>
+<a href='toRdf/so12-in.jsonld'>toRdf/so12-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+invalid context entry
 </dd>
 <dt>Options</dt>
 <dd>

--- a/tests/toRdf-manifest.html
+++ b/tests/toRdf-manifest.html
@@ -2067,7 +2067,7 @@ Test tc029 @propagate is invalid in 1.0
 </dd>
 <dt>expect</dt>
 <dd>
-invalid context member
+invalid context entry
 </dd>
 <dt>Options</dt>
 <dd>
@@ -9073,7 +9073,7 @@ Test tso01 @import is invalid in 1.0.
 </dd>
 <dt>expect</dt>
 <dd>
-invalid context member
+invalid context entry
 </dd>
 <dt>Options</dt>
 <dd>
@@ -9129,7 +9129,7 @@ Test tso03 @import overflow
 </dd>
 <dt>expect</dt>
 <dd>
-invalid context member
+invalid context entry
 </dd>
 <dt>Options</dt>
 <dd>

--- a/tests/toRdf-manifest.html
+++ b/tests/toRdf-manifest.html
@@ -9366,6 +9366,34 @@ invalid context entry
 </dd>
 </dl>
 </dd>
+<dt id='tso13'>
+Test tso13 @import can only reference a single context
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tso13</dd>
+<dt>Type</dt>
+<dd>jld:NegativeEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>@import can only reference a single context.</dd>
+<dt>input</dt>
+<dd>
+<a href='toRdf/so13-in.jsonld'>toRdf/so13-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+invalid remote context
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
 <dt id='ttn01'>
 Test ttn01 @type: @none is illegal in 1.0.
 </dt>

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -625,7 +625,7 @@
       "name": "@propagate is invalid in 1.0",
       "purpose": "@propagate is invalid in 1.0",
       "input": "toRdf/c029-in.jsonld",
-      "expectErrorCode": "invalid context member",
+      "expectErrorCode": "invalid context entry",
       "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.0"}
     }, {
       "@id": "#tc030",
@@ -2699,7 +2699,7 @@
       "purpose": "@import is invalid in 1.0.",
       "option": {"specVersion": "json-ld-1.1"},
       "input": "toRdf/so01-in.jsonld",
-      "expectErrorCode": "invalid context member"
+      "expectErrorCode": "invalid context entry"
     }, {
       "@id": "#tso02",
       "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
@@ -2715,7 +2715,7 @@
       "purpose": "Processors must detect source contexts that include @import.",
       "option": {"specVersion": "json-ld-1.1"},
       "input": "toRdf/so03-in.jsonld",
-      "expectErrorCode": "invalid context member"
+      "expectErrorCode": "invalid context entry"
     }, {
       "@id": "#tso05",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -2781,6 +2781,14 @@
       "input": "toRdf/so12-in.jsonld",
       "expectErrorCode": "invalid context entry"
     }, {
+      "@id": "#tso13",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
+      "name": "@import can only reference a single context",
+      "purpose": "@import can only reference a single context.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "toRdf/so13-in.jsonld",
+      "expectErrorCode": "invalid remote context"
+    }, {
       "@id": "#ttn01",
       "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
       "name": "@type: @none is illegal in 1.0.",

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -2697,7 +2697,7 @@
       "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
       "name": "@import is invalid in 1.0.",
       "purpose": "@import is invalid in 1.0.",
-      "option": {"specVersion": "json-ld-1.1"},
+      "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.0"},
       "input": "toRdf/so01-in.jsonld",
       "expectErrorCode": "invalid context entry"
     }, {
@@ -2772,6 +2772,14 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "toRdf/so11-in.jsonld",
       "expect": "toRdf/so11-out.nq"
+    }, {
+      "@id": "#tso12",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
+      "name": "@import may not be used in an imported context.",
+      "purpose": "@import only valid within a term definition.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "toRdf/so12-in.jsonld",
+      "expectErrorCode": "invalid context entry"
     }, {
       "@id": "#ttn01",
       "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],

--- a/tests/toRdf/so12-in.jsonld
+++ b/tests/toRdf/so12-in.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "@import": "so01-in.jsonld"
+  }
+}

--- a/tests/toRdf/so12-in.jsonld
+++ b/tests/toRdf/so12-in.jsonld
@@ -1,5 +1,5 @@
 {
   "@context": {
-    "@import": "so01-in.jsonld"
+    "@import": "so12-in.jsonld"
   }
 }

--- a/tests/toRdf/so13-context.jsonld
+++ b/tests/toRdf/so13-context.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": [{
+    "term": "http://example.org/term"
+  }, {
+    "term2": "http://example.org/term2"
+  }]
+}

--- a/tests/toRdf/so13-in.jsonld
+++ b/tests/toRdf/so13-in.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@import": "so13-context.jsonld"
+  },
+  "term": "value"
+}


### PR DESCRIPTION
- Looks like an oversight that test error codes don't match the spec. This fix will break any implementations running against those tests.
- Synced the expand/toRdf `@import` tests and use 1.0 mode for the 1.0 tests.