### PR TITLE
Normalize language tags to lower case

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: git://github.com/ruby-rdf/json-ld.git
-  revision: d0bfdefb6cddac6a22683ff9733a94936c4e5dbe
+  revision: 241ef57e096cefdff55ef6d39a917049eec04529
   branch: develop
   specs:
     json-ld (3.1.0)
       htmlentities (~> 4.3)
-      json-canonicalization (~> 0.1)
+      json-canonicalization (~> 0.2)
       link_header (~> 0.0, >= 0.0.8)
       multi_json (~> 1.14)
       rack (~> 2.0)
@@ -33,9 +33,9 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     htmlentities (4.3.4)
-    i18n (1.7.0)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
-    json-canonicalization (0.1.0)
+    json-canonicalization (0.2.0)
     json-ld-preloaded (3.1.0)
       json-ld (~> 3.1)
       rdf (~> 3.1)
@@ -79,10 +79,10 @@ GEM
       mini_portile2 (~> 2.4.0)
     nokogumbo (2.0.2)
       nokogiri (~> 1.8, >= 1.8.4)
-    public_suffix (4.0.1)
-    rack (2.0.8)
+    public_suffix (4.0.3)
+    rack (2.1.2)
     rake (13.0.1)
-    rdf (3.1.0)
+    rdf (3.1.1)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
     rdf-aggregate-repo (3.1.0)
@@ -133,7 +133,7 @@ GEM
     rdf-turtle (3.1.0)
       ebnf (~> 1.2)
       rdf (~> 3.1)
-    rdf-vocab (3.1.0)
+    rdf-vocab (3.1.1)
       rdf (~> 3.1)
     rdf-xsd (3.1.0)
       rdf (~> 3.1)

--- a/index.html
+++ b/index.html
@@ -4913,8 +4913,13 @@
           <var>item</var> is a <a>value object</a> which is serialized using special rules.
           <ol>
             <li id="alg-obj2rdf-direction-language">
-              Initialize <var>language</var> to the value of `@language` in <var>item</var>,
-              or the empty string (`""`) if there is no such entry.</li>
+              Initialize <var>language</var> to the value of `@language` in <var>item</var>
+              normalized to lower case,
+              or the empty string (`""`) if there is no such entry.
+              <div class="note">Generally, language tags are not normalized,
+                but when creating an `i18n-datatype` or `compound-literal`
+                values are normalized to lower case for improved interoperability.</div>
+            </li>
             <li>If {{JsonLdOptions/rdfDirection}} is `i18n-datatype`,
               set <var>datatype</var> to the result of appending <var>language</var>
               and the value of `@direction` in <var>item</var> separated by an underscore (`"_"`)
@@ -4933,9 +4938,8 @@
                   as the object, and add it to <var>list triples</var>.</li>
                 <li>If the <var>item</var> has an entry for `@language`,
                   create a new triple using <var>literal</var> as the subject,
-                  `rdf:language` as the predicate, and the value of `@language` in <var>item</var>
-                  as the object, and add it to <var>list triples</var>.
-                  <div class="changed note">Processors MAY normalize <a>language tags</a> to lower case.</div></li>
+                  `rdf:language` as the predicate, and <var>language</var>
+                  as the object, and add it to <var>list triples</var>.</li>
                 <li>Create a new triple using <var>literal</var> as the subject,
                   `rdf:direction` as the predicate, and the value of `@direction` in <var>item</var>
                   as the object, and add it to <var>list triples</var>.</li>
@@ -6836,6 +6840,8 @@
       <a href="#node-map-generation" class="sectionRef"></a>,
       and <a href="#deserialize-json-ld-to-rdf-algorithm" class="sectionRef"></a>.
     </li>
+    <li>When creating an `i18n` datatype or `rdf:CompoundLiteral`, <a>language tags</a> are
+      normalized to lower case to improve interoperability between implementations.</li>
   </ul>
 </section>
 <!--section class="appendix informative" id="changes-from-cr">


### PR DESCRIPTION
when creating i18n datatype or compound literal.

For #337.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/363.html" title="Last updated on Jan 28, 2020, 11:47 PM UTC (7771d14)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/363/2f57a54...7771d14.html" title="Last updated on Jan 28, 2020, 11:47 PM UTC (7771d14)">Diff</a>