### PR TITLE
Reference the rdf:JSON datatype of the syntax document

### DIFF
--- a/common/jsonld.js
+++ b/common/jsonld.js
@@ -61,11 +61,11 @@ const jsonld = {
     },
     "JCS": {
       title: "JSON Canonicalization Scheme (JCS)",
-      href: 'https://tools.ietf.org/html/draft-rundgren-json-canonicalization-scheme-05',
+      href: 'https://tools.ietf.org/html/draft-rundgren-json-canonicalization-scheme-17',
       authors: ['A. Rundgren', 'B. Jordan', 'S. Erdtman'],
       publisher: 'Network Working Group',
       status: 'Internet-Draft',
-      date: 'February 16, 2019'
+      date: '20 January 2020'
     },
     // These necessary as specref uses the wrong URLs
     "RFC7231": {

--- a/index.html
+++ b/index.html
@@ -5470,33 +5470,9 @@
       <code>true</code> and <code>false</code>.</p>
 
     <p class="changed">The <a>canonical lexical form</a> of a <a>JSON literal</a>
-      value is non-normative, as a normative recommendation for
-      JSON canonicalization is not yet defined. Implementations
-      SHOULD use the following guidelines when creating the lexical
-      representation of a <a>JSON literal</a>:</p>
-    <ul class="changed">
-      <li>Serialize JSON using no unnecessary whitespace,</li>
-      <li>Keys in objects SHOULD be ordered lexicographically,</li>
-      <li>Native Numeric values SHOULD be serialized according to
-        <a data-cite="?ECMASCRIPT#sec-tostring-applied-to-the-number-type">Section 7.1.12.1</a> of [[?ECMASCRIPT]],</li>
-      <li>Strings SHOULD be serialized with Unicode codepoints from <code>U+0000</code> through <code>U+001F</code>
-        using lower case hexadecimal Unicode notation (<code>\uhhhh</code>) unless in the set
-        of predefined JSON control characters <code>U+0008</code>, <code>U+0009</code>,
-        <code>U+000A</code>, <code>U+000C</code> or <code>U+000D</code>
-        which SHOULD be serialized as <code>\b</code>, <code>\t</code>, <code>\n</code>, <code>\f</code> and <code>\r</code> respectively.
-        All other Unicode characters SHOULD be serialized "as is", other than
-        <code>U+005C</code> (<code>\</code>) and <code>U+0022</code> (<code>"</code>)
-        which SHOULD be serialized as <code>\\</code> and <code>\"</code> respectively.</li>
-    </ul>
-
-    <p class="issue changed">The JSON Canonicalization Scheme [[?JCS]]
-      is an emerging standard for JSON canonicalization
-      not yet ready to be referenced.
-      When a JSON canonicalization standard becomes available,
-      this specification will likely be updated to require such a canonical representation.
-      Users are cautioned from depending on the
-      <a>JSON literal</a> lexical representation as an <a>RDF literal</a>,
-      as the specifics of serialization may change in a future revision of this document.</p>
+      is the result of serializing the <a>internal representation</a>
+      into the JSON format [[RFC8259]] in compliance with the constraints of the <strong>value space</strong> description within
+      <a data-cite="JSON-LD11#the-rdf-json-datatype">The <code>rdf:JSON</code> Datatype</a> of [[JSON-LD11]].</p>
 
     <aside class="example changed" data-ignore
            title="Canonicalized JSON literal">


### PR DESCRIPTION
for the conversion of the JSON Literals in the round tripping section.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/366.html" title="Last updated on Jan 29, 2020, 7:17 PM UTC (81375d9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/366/c6f437a...81375d9.html" title="Last updated on Jan 29, 2020, 7:17 PM UTC (81375d9)">Diff</a>