### PR TITLE
More context processing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1069,7 +1069,7 @@
     <ul>
       <li>the active <a>term definitions</a> which specify how
         keys and values have to be interpreted (<a>array</a> of <a>term definitions</a>),</li>
-      <li>the current <a>base IRI</a> (<a>IRI</a>),</li>
+      <li>the current <dfn data-lt="context-base-iri" data-lt-noDefault>base IRI</dfn> (<a>IRI</a>),</li>
       <li class="changed">the <dfn>original base URL</dfn> (<a>IRI</a>),</li>
       <li>an optional <a>vocabulary mapping</a> (<a>IRI</a>),</li>
       <li>an optional <a>default language</a> (<a>string</a>),</li>
@@ -1131,7 +1131,7 @@
       <p>If <a>context</a> is a <a class="changed">map</a>,
         it is a <a data-cite="JSON-LD11#dfn-context-definition">context definition</a>.
         We first update
-        the <a>base IRI</a>,
+        the <a class="changed" data-lt="context-base-iri">base IRI</a>,
         <span class="changed">the <a>default base direction</a></span>,
         the <a>default language</a>,
         <span class="changed">context propagation</span>,
@@ -1163,7 +1163,7 @@
         otherwise from the {{JsonLdOptions/base}} API option.
         This is necessary when resetting the <a>active context</a>
         by setting it to `null`
-        to retain the original default <a>base IRI</a>.</p>
+        to retain the original default <a class="changed" data-lt="context-base-iri">base IRI</a>.</p>
 
       <p>Then, for every other <a>entry</a> in <a>local context</a>, we update
         the <a>term definition</a> in <var>result</var>. Since
@@ -1225,7 +1225,7 @@
                 <li>Initialize <var>result</var> as a
                   newly-initialized <a>active context</a>,
                   <span class="changed">
-                    setting both <a>base IRI</a> and <a>original base URL</a> to the value of
+                    setting both <a data-lt="context-base-iri">base IRI</a> and <a>original base URL</a> to the value of
                     <a>original base URL</a> in <var>active context</var></span>,
                     and, if <var>propagate</var> is <code>false</code>,
                     <a>previous context</a> in <var>result</var>
@@ -1242,7 +1242,7 @@
                   has been detected and processing is aborted.
                   <div class="note">
                     <var>base URL</var> is often not the same as {{JsonLdOptions/base}}
-                    or the <a>base IRI</a> of the <var>active context</var>.
+                    or the <a class="changed" data-lt="context-base-iri">base IRI</a> of the <var>active context</var>.
                   </div>
                 </li>
                 <li>If the number of entries in the <var>remote contexts</var> array
@@ -1359,13 +1359,13 @@
                 <li>Initialize <var>value</var> to the value associated with the
                   <code>@base</code> <a>entry</a>.</li>
                 <li>If <var>value</var> is <code>null</code>, remove the
-                  <a>base IRI</a> of <var>result</var>.</li>
+                  <a class="changed" data-lt="context-base-iri">base IRI</a> of <var>result</var>.</li>
                 <li>Otherwise, if <var>value</var> is an <a>IRI</a>,
-                  the <a>base IRI</a> of <var>result</var> is set to <var>value</var>.</li>
+                  the <a class="changed" data-lt="context-base-iri">base IRI</a> of <var>result</var> is set to <var>value</var>.</li>
                 <li>Otherwise, if <var>value</var> is a <a>relative IRI reference</a> and
-                  the <a>base IRI</a> of <var>result</var> is not <code>null</code>,
-                  set the <a>base IRI</a> of <var>result</var> to the result of
-                  resolving <var>value</var> against the current <a>base IRI</a>
+                  the <a class="changed" data-lt="context-base-iri">base IRI</a> of <var>result</var> is not <code>null</code>,
+                  set the <a class="changed" data-lt="context-base-iri">base IRI</a> of <var>result</var> to the result of
+                  resolving <var>value</var> against the current <a class="changed" data-lt="context-base-iri">base IRI</a>
                   of <var>result</var>.</li>
                 <li>Otherwise, an
                   <a data-link-for="JsonLdErrorCode">invalid base IRI</a>
@@ -3215,7 +3215,7 @@
           with <var>value</var>.</li>
         <li>Otherwise, if <var>document relative</var> is <code>true</code>
           set <var>value</var> to the result of resolving <var>value</var> against
-          the <a>base IRI</a> from <var>active context</var>. Only the basic algorithm in
+          the <a class="changed" data-lt="context-base-iri">base IRI</a> from <var>active context</var>. Only the basic algorithm in
           <a data-cite="RFC3986#section-5.2">section 5.2</a>
           of [[RFC3986]] is used; neither
           <a data-cite="RFC3986#section-6.2.2">Syntax-Based Normalization</a> nor
@@ -4187,7 +4187,7 @@
           and processing is aborted.</li>
         <li>If <var>vocab</var> is <code>false</code>,
           transform <var>var</var> to a <a>relative IRI reference</a> using
-          the <span class="changed"><a>base IRI</a> from <var>active context</var>, if it exists</span>.</li>
+          the <span class="changed"><a data-lt="context-base-iri">base IRI</a> from <var>active context</var>, if it exists</span>.</li>
         <li>Finally, return <var>var</var> as is.</li>
       </ol>
     </section>
@@ -5750,10 +5750,10 @@
             If {{RemoteDocument/document}} cannot be transformed to the <a>internal representation</a>,
             reject <var>promise</var> passing a <a data-link-for="JsonLdErrorCode">loading document failed</a> error.</li>
           <li>Initialize a new empty <var>active context</var>.
-            The <a>base IRI</a> and <a>original base URL</a> of the <var>active context</var> is set to the {{RemoteDocument/documentUrl}}
+            The <a data-lt="context-base-iri">base IRI</a> and <a>original base URL</a> of the <var>active context</var> is set to the {{RemoteDocument/documentUrl}}
             from <var>remote document</var>, if available;
             otherwise to the {{JsonLdOptions/base}} option from <a data-lt="jsonldprocessor-expand-options">options</a>.
-            If set, the {{JsonLdOptions/base}} option from <a data-lt="jsonldprocessor-expand-options">options</a> overrides the <a>base IRI</a>.</li>
+            If set, the {{JsonLdOptions/base}} option from <a data-lt="jsonldprocessor-expand-options">options</a> overrides the <a data-lt="context-base-iri">base IRI</a>.</li>
           <li>If the {{JsonLdOptions/expandContext}} option in <a data-lt="jsonldprocessor-expand-options">options</a> is set, 
             update the <var>active context</var> using the <a href="#context-processing-algorithm">Context Processing algorithm</a>,
             passing the {{JsonLdOptions/expandContext}} as <var>local context</var>

--- a/index.html
+++ b/index.html
@@ -1224,10 +1224,12 @@
                   has been detected and processing is aborted.</li>
                 <li>Initialize <var>result</var> as a
                   newly-initialized <a>active context</a>,
-                  <span class="changed">setting <a>previous context</a> in <var>result</var>
-                    to the previous value of <var>result</var> if <var>propagate</var> is <code>false</code>
-                    and both <a>base IRI</a> and <a>original base URL</a> to the value of
-                    <a>original base URL</a> in <var>active context</var></span>.</li>
+                  <span class="changed">
+                    setting both <a>base IRI</a> and <a>original base URL</a> to the value of
+                    <a>original base URL</a> in <var>active context</var></span>,
+                    and, if <var>propagate</var> is <code>false</code>,
+                    <a>previous context</a> in <var>result</var>
+                    to the previous value of <var>result</var>.</li>
                 <li>Continue with the next <var>context</var>.</li>
               </ol>
             </li>

--- a/index.html
+++ b/index.html
@@ -1159,7 +1159,8 @@
         When an <a>active context</a> is initialized, the value
         of the <a>original base URL</a>
         is initialized from the original {{RemoteDocument/documentUrl}}
-        of the document containing the initial <a>context</a>.
+        of the document containing the initial <a>context</a>, if available,
+        otherwise from the {{JsonLdOptions/base}} API option.
         This is necessary when resetting the <a>active context</a>
         by setting it to `null`
         to retain the original default <a>base IRI</a>.</p>
@@ -5743,7 +5744,7 @@
           <li>Initialize a new empty <var>active context</var>.
             The <a>base IRI</a> and <a>original base URL</a> of the <var>active context</var> is set to the {{RemoteDocument/documentUrl}}
             from <var>remote document</var>, if available;
-            otherwise to {{JsonLdOptions/base}}.
+            otherwise to the {{JsonLdOptions/base}} option from <a data-lt="jsonldprocessor-expand-options">options</a>.
             If set, the {{JsonLdOptions/base}} option from <a data-lt="jsonldprocessor-expand-options">options</a> overrides the <a>base IRI</a>.</li>
           <li>If the {{JsonLdOptions/expandContext}} option in <a data-lt="jsonldprocessor-expand-options">options</a> is set, 
             update the <var>active context</var> using the <a href="#context-processing-algorithm">Context Processing algorithm</a>,
@@ -6092,7 +6093,7 @@
 
     <pre class="idl">
       dictionary JsonLdOptions {
-        USVString?             base;
+        USVString?             base = null;
         boolean                compactArrays = true;
         boolean                compactToRelative = true;
         LoadDocumentCallback?  documentLoader = null;

--- a/index.html
+++ b/index.html
@@ -1236,7 +1236,10 @@
             <li id="alg-context-string">If <var>context</var> is a <a>string</a>,
               <ol>
                 <li>Initialize <var>context</var> to the result of resolving <var>context</var> against
-                  <var>base URL</var>.
+                  <var>base URL</var>. If <var>base URL</var> is not a valid <a>IRI</a>,
+                  then <var>context</var> MUST be a valid <a>IRI</a>, otherwise
+                  a <a data-link-for="JsonLdErrorCode">loading document failed</a> error
+                  has been detected and processing is aborted.
                   <div class="note">
                     <var>base URL</var> is often not the same as {{JsonLdOptions/base}}
                     or the <a>base IRI</a> of the <var>active context</var>.
@@ -5754,9 +5757,9 @@
           <li>If the {{JsonLdOptions/expandContext}} option in <a data-lt="jsonldprocessor-expand-options">options</a> is set, 
             update the <var>active context</var> using the <a href="#context-processing-algorithm">Context Processing algorithm</a>,
             passing the {{JsonLdOptions/expandContext}} as <var>local context</var>
-            and {{JsonLdOptions/expandContext}} as <var>base URL</var>.
+            and the <a>original base URL</a> from <var>active context</var> as <var>base URL</var>.
             If {{JsonLdOptions/expandContext}} is a <a class="changed">map</a> having an <code>@context</code> <a>entry</a>,
-            pass that <a data-lt="entry">entry's</a> value instead.</li>
+            pass that <a data-lt="entry">entry's</a> value instead for <var>local context</var>.</li>
           <li>If <var>remote document</var> has a {{RemoteDocument/contextUrl}},
             update the <var>active context</var> using the <a href="#context-processing-algorithm">Context Processing algorithm</a>,
             passing the {{RemoteDocument/contextUrl}} as <var>local context</var>,

--- a/index.html
+++ b/index.html
@@ -5768,8 +5768,9 @@
             passing the <var>active context</var>,
             {{RemoteDocument/document}} from <var>remote document</var> or <a data-lt="jsonldprocessor-expand-input">input</a>
             if there is no <var>remote document</var> as <var>element</var>,
+            `null` as <var>active property</var>,
             {{RemoteDocument/documentUrl}} as <var>base URL</var>, if available, otherwise to {{JsonLdOptions/base}},
-            and <span class="changed">{{JsonLdOptions/frameExpansion}}</span>
+            and the <span class="changed">{{JsonLdOptions/frameExpansion}}</span>
             and <span class="changed">and {{JsonLdOptions/ordered}}</span>
             flags from <a data-lt="jsonldprocessor-compact-options">options</a>.
             <ol id="api-expand-post-processing" class="changed">

--- a/index.html
+++ b/index.html
@@ -5743,7 +5743,7 @@
           <li>Initialize a new empty <var>active context</var>.
             The <a>base IRI</a> and <a>original base URL</a> of the <var>active context</var> is set to the {{RemoteDocument/documentUrl}}
             from <var>remote document</var>, if available;
-            otherwise to <code>null</code>.
+            otherwise to {{JsonLdOptions/base}}.
             If set, the {{JsonLdOptions/base}} option from <a data-lt="jsonldprocessor-expand-options">options</a> overrides the <a>base IRI</a>.</li>
           <li>If the {{JsonLdOptions/expandContext}} option in <a data-lt="jsonldprocessor-expand-options">options</a> is set, 
             update the <var>active context</var> using the <a href="#context-processing-algorithm">Context Processing algorithm</a>,
@@ -5759,7 +5759,7 @@
             passing the <var>active context</var>,
             {{RemoteDocument/document}} from <var>remote document</var> or <a data-lt="jsonldprocessor-expand-input">input</a>
             if there is no <var>remote document</var> as <var>element</var>,
-            {{RemoteDocument/documentUrl}} as <var>base URL</var>,
+            {{RemoteDocument/documentUrl}} as <var>base URL</var>, if available, otherwise to {{JsonLdOptions/base}},
             and <span class="changed">{{JsonLdOptions/frameExpansion}}</span>
             and <span class="changed">and {{JsonLdOptions/ordered}}</span>
             flags from <a data-lt="jsonldprocessor-compact-options">options</a>.

--- a/index.html
+++ b/index.html
@@ -1517,7 +1517,7 @@
         a <var>term</var>,
         and a map <var>defined</var>.
         <span class="changed">The optional inputs are
-          <var>base URL</var>,
+          <var>base URL</var> defaulting to <code>null</code>,
           <var>protected</var> which defaults to <code>false</code>,
           and <var>override protected</var>, defaulting to <code>false</code>,
           which is used to allow changes to protected terms.</span>.

--- a/index.html
+++ b/index.html
@@ -1250,7 +1250,10 @@
                 <li class="changed">If <var>context</var> was previously dereferenced,
                   then the processor MUST NOT do a further dereference, and
                   <a>context</a> is set to the
-                  previously established <a>internal representation</a>.
+                  previously established <a>internal representation</a>,
+                  set <var>context document</var> to the previously dereferenced document,
+                  and set <var>loaded context</var> to the value of the `@context`
+                  <a>entry</a> from the document in <var>context document</var>.
                   <div class="note">Only the `@context` <a>entry</a> need be retained.</div>
                 </li>
                 <li class="changed">Otherwise, set <var>context document</var>

--- a/index.html
+++ b/index.html
@@ -1253,7 +1253,7 @@
                 <li class="changed">If <var>context</var> was previously dereferenced,
                   then the processor MUST NOT do a further dereference, and
                   <a>context</a> is set to the
-                  previously established <a>internal representation</a>,
+                  previously established <a>internal representation</a>:
                   set <var>context document</var> to the previously dereferenced document,
                   and set <var>loaded context</var> to the value of the `@context`
                   <a>entry</a> from the document in <var>context document</var>.

--- a/tests/README.md
+++ b/tests/README.md
@@ -18,6 +18,9 @@ Tests driven from a top-level [manifest](manifest.jsonld) and are defined into [
 * [expand](expand-manifest.jsonld) tests have _input_ and _expected_ documents.
   The _expected_ results can be compared using [JSON-LD object comparison](#json-ld-object-comparison) with the processor output.
 
+  Expansion tests may have a `expandContext` option, which is treated
+  as an IRI relative to the manifest.
+
   For *NegativeEvaluationTests*, the result is a string associated with the expected error code.
 * [html](html.jsonld) tests have _input_ and _expected_ documents and an optional _context_ document.
   The _expected_ results can be compared using [JSON-LD object comparison](#json-ld-object-comparison) with the processor output
@@ -45,6 +48,9 @@ Tests driven from a top-level [manifest](manifest.jsonld) and are defined into [
   The _expected_ results  can be compared using [JSON-LD object comparison](#json-ld-object-comparison) with the processor output.
 * [toRdf](toRdf-manifest.jsonld) tests have _input_ and _expected_ documents.
   The _expected_ results can be compared using [RDF Dataset Isomorphism](https://www.w3.org/TR/rdf11-concepts/#dfn-dataset-isomorphism).
+
+  ToRdf tests may have a `expandContext` option, which is treated
+  as an IRI relative to the manifest.
 
 Unless `processingMode` is set explicitly in a test entry, `processingMode` is compatible with both `json-ld-1.0` and `json-ld-1.1`.
 

--- a/tests/context.jsonld
+++ b/tests/context.jsonld
@@ -23,7 +23,7 @@
     "compactArrays":        { "@type": "xsd:boolean" },
     "compactToRelative":    { "@type": "xsd:boolean" },
     "contentType":          { "@type": "xsd:boolean" },
-    "expandContext":        { "@type": "xsd:string" },
+    "expandContext":        { "@type": "@id" },
     "httpLink":             { "@type": "xsd:string", "@container": "@set" },
     "httpStatus":           { "@type": "xsd:integer" },
     "processingMode":       { "@type": "xsd:string" },

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -32,6 +32,9 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 
 <p>The <em>expected</em> results can be compared using <a href="#json-ld-object-comparison">JSON-LD object comparison</a> with the processor output.</p>
 
+<p>Expansion tests may have a <code>expandContext</code> option, which is treated
+as an IRI relative to the manifest.</p>
+
 <p>For <em>NegativeEvaluationTests</em>, the result is a string associated with the expected error code.</p>
 <p>Unless <code>processingMode</code> is set explicitly in a test entry, <code>processingMode</code> is compatible with both <code>json-ld-1.0</code> and <code>json-ld-1.1</code>.</p>
 

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -550,7 +550,7 @@
       "name": "expandContext option",
       "purpose": "Use of the expandContext option to expand the input document",
       "option": {
-        "expandContext": "0077-context.jsonld"
+        "expandContext": "expand/0077-context.jsonld"
       },
       "input": "expand/0077-in.jsonld",
       "expect": "expand/0077-out.jsonld"

--- a/tests/html-manifest.html
+++ b/tests/html-manifest.html
@@ -37,6 +37,9 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 
 <p>The <em>expected</em> results can be compared using <a href="#json-ld-object-comparison">JSON-LD object comparison</a> with the processor output.</p>
 
+<p>Expansion tests may have a <code>expandContext</code> option, which is treated
+as an IRI relative to the manifest.</p>
+
 <p>For <em>NegativeEvaluationTests</em>, the result is a string associated with the expected error code.</p>
 <h3><a href="html.jsonld">html</a> tests have <em>input</em> and <em>expected</em> documents and an optional <em>context</em> document.</h3>
 

--- a/tests/manifest.html
+++ b/tests/manifest.html
@@ -37,6 +37,9 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 
 <p>The <em>expected</em> results can be compared using <a href="#json-ld-object-comparison">JSON-LD object comparison</a> with the processor output.</p>
 
+<p>Expansion tests may have a <code>expandContext</code> option, which is treated
+as an IRI relative to the manifest.</p>
+
 <p>For <em>NegativeEvaluationTests</em>, the result is a string associated with the expected error code.</p>
 <h3><a href="html.jsonld">html</a> tests have <em>input</em> and <em>expected</em> documents and an optional <em>context</em> document.</h3>
 
@@ -70,6 +73,9 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 <p>Some tests require the use of <a href="https://tools.ietf.org/html/draft-rundgren-json-canonicalization-scheme-05">JSON Canonicalization Scheme</a> to properly generate RDF Literals from JSON literal values. This algorithm is non-normative, but is assumed to be used to properly compare results. These tests are marked using the <code>useJCS</code> option.</p>
 
 <p>The <em>expected</em> results can be compared using <a href="https://www.w3.org/TR/rdf11-concepts/#dfn-dataset-isomorphism">RDF Dataset Isomorphism</a>.</p>
+
+<p>ToRdf tests may have a <code>expandContext</code> option, which is treated
+as an IRI relative to the manifest.</p>
 <p>Unless <code>processingMode</code> is set explicitly in a test entry, <code>processingMode</code> is compatible with both <code>json-ld-1.0</code> and <code>json-ld-1.1</code>.</p>
 
 <p>Test results that include a context input presume that the context is provided locally, and not from the referenced location, thus the results will include the content of the context file, rather than a reference.</p>

--- a/tests/remote-doc-manifest.html
+++ b/tests/remote-doc-manifest.html
@@ -32,6 +32,9 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 
 <p>The <em>expected</em> results can be compared using <a href="#json-ld-object-comparison">JSON-LD object comparison</a> with the processor output.</p>
 
+<p>Expansion tests may have a <code>expandContext</code> option, which is treated
+as an IRI relative to the manifest.</p>
+
 <p>For <em>NegativeEvaluationTests</em>, the result is a string associated with the expected error code.</p>
 <h3><a href="remote-doc-manifest.jsonld">remote-doc</a> tests have <em>input</em> and <em>expected</em> documents.</h3>
 

--- a/tests/template.haml
+++ b/tests/template.haml
@@ -42,6 +42,9 @@
 
         The _expected_ results can be compared using [JSON-LD object comparison](#json-ld-object-comparison) with the processor output.
 
+        Expansion tests may have a `expandContext` option, which is treated
+        as an IRI relative to the manifest.
+
         For *NegativeEvaluationTests*, the result is a string associated with the expected error code.
 
     - if manifest['sequence'].first.is_a?(String) || manifest['sequence'].any? {|te| te['@type'].include?('jld:HtmlTest')}
@@ -88,6 +91,9 @@
         Some tests require the use of [JSON Canonicalization Scheme](https://tools.ietf.org/html/draft-rundgren-json-canonicalization-scheme-05) to properly generate RDF Literals from JSON literal values. This algorithm is non-normative, but is assumed to be used to properly compare results. These tests are marked using the `useJCS` option.
 
         The _expected_ results can be compared using [RDF Dataset Isomorphism](https://www.w3.org/TR/rdf11-concepts/#dfn-dataset-isomorphism).
+
+        ToRdf tests may have a `expandContext` option, which is treated
+        as an IRI relative to the manifest.
 
     :markdown
       Unless `processingMode` is set explicitly in a test entry, `processingMode` is compatible with both `json-ld-1.0` and `json-ld-1.1`.

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -1324,7 +1324,7 @@
       "name": "expandContext option",
       "purpose": "Use of the expandContext option to expand the input document",
       "option": {
-        "expandContext": "e077-context.jsonld"
+        "expandContext": "toRdf/e077-context.jsonld"
       },
       "input": "toRdf/e077-in.jsonld",
       "expect": "toRdf/e077-out.nq"


### PR DESCRIPTION
* Make _expandContext_ `@type: @id` and set option values to be relative to the manifest location. Fixes #369.
* Set a fallback in `expand()` processing if there is no `documentUrl`. This uses `JsonLdOptions/base`, which could be null, or something else appropriate for when the `input` or `expandContext` is not a URL. For #370.
* Describe that if `documentUrl` is not available, values come from `JsonLdOptions/base`, which now defaults to `null`. Fixes #375.
* Reorder clauses in 5.1.2 to make it more clear that setting _base IRI_ and _original base URL_ of the new _active context_ is unconditional, unlinke _previous_context_.
* Create values for _context document_ and _loaded context_ in the case that the previous document was cached in 5.2.3 of the Create Context Algorithm. Fixes #372.
* Describe how to handle a remote context that is not a valid IRI (not absolute) when it can't be resolved against _base URL_, because it is also not a valid IRI. For #373.
* Update `expand()` to pass the _original base URL_ from the current _active context_ when creating a new _active context_ using _expandContext_. Fixes #373.
* Pass `null` for _active property_ on initial call to the Expansion algorithm from `expand()`. Fixes #374.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/377.html" title="Last updated on Feb 18, 2020, 7:38 PM UTC (45f077a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/377/dcd4869...45f077a.html" title="Last updated on Feb 18, 2020, 7:38 PM UTC (45f077a)">Diff</a>