### PR TITLE
WebIDL cleanup

### DIFF
--- a/common/algorithm-terms.html
+++ b/common/algorithm-terms.html
@@ -53,7 +53,7 @@
     the <var>vocab</var> flag defaults to `true`,
     and the <var>reverse</var> flag defaults to `false`.
     <ol>
-      <li>Return the result of using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
+      <li>Return the result of using the <a data-cite="JSON-LD11-API#iri-compaction">IRI Compaction algorithm</a>,
         passing <var>active context</var>, <var>inverse context</var>,
         <var>var</var>,
         <var>value</var> (if supplied),

--- a/common/terms.html
+++ b/common/terms.html
@@ -28,7 +28,7 @@
       <dfn data-cite="INFRA#ordered-map" class="preserve">map</dfn> (see [[INFRA]]),
       composed of <dfn data-cite="INFRA#map-entry" data-lt="map entry|entry" data-ld-noDefault class="preserve">entries</dfn> with key/value pairs.</p>
     <p>In the <a data-cite="JSON-LD11-API#the-application-programming-interface">Application Programming Interface</a>,
-      a <a>map</a> is described using a [[WEBIDL]] <a data-cite="WEBIDL#dfn-dictionary">dictionary</a>.</p></dd>
+      a <a>map</a> is described using a [[WEBIDL]] <a data-cite="WEBIDL#idl-record">record</a>.</p></dd>
   <dt><dfn data-cite="INFRA#nulls" class="preserve">null</dfn></dt><dd>
     The use of the <a>null</a> value within JSON-LD
     is used to ignore or reset values.

--- a/index.html
+++ b/index.html
@@ -5672,10 +5672,6 @@
             for <a data-link-for="LoadDocumentCallback">url</a>,
             the {{JsonLdOptions/extractAllScripts}} option from <a data-lt="jsonldprocessor-compact-options">options</a>
             for <a data-link-for="LoadDocumentOptions">extractAllScripts</a>.</li>
-          <li class="changed">If {{RemoteDocument/document}}
-            from <var>remote document</var> is a <a>string</a>, transform into the <a>internal representation</a>.
-            If {{RemoteDocument/document}} cannot be transformed to the <a>internal representation</a>,
-            reject <var>promise</var> passing a <a data-link-for="JsonLdErrorCode">loading document failed</a> error.</li>
           <li>Set <var>expanded input</var> to the result of
             using the <a data-link-for="JsonLdProcessor">expand()</a> method
             using either <var>remote document</var>
@@ -5843,10 +5839,6 @@
             the {{JsonLdOptions/extractAllScripts}} option from <a data-lt="jsonldprocessor-flatten-options">options</a>
             for <a data-link-for="LoadDocumentOptions">extractAllScripts</a>.
           </li>
-          <li class="changed">If {{RemoteDocument/document}}
-            from <var>remote document</var> is a <a>string</a>, transform into the <a>internal representation</a>.
-            If {{RemoteDocument/document}} cannot be transformed to the <a>internal representation</a>,
-            reject <var>promise</var> passing a <a data-link-for="JsonLdErrorCode">loading document failed</a> error.</li>
           <li>Set <var>expanded input</var> to the result of
             using the <a data-link-for="JsonLdProcessor">expand()</a> method
             using either <var>remote document</var>

--- a/index.html
+++ b/index.html
@@ -4791,8 +4791,8 @@
                     <li>If <var>property</var> is <code>@type</code>, then for each
                       <var>type</var> in <var>values</var>,
                       create a new <a>RdfTriple</a>
-                      composed of <var>subject</var>, <code>rdf:type</code> for <a data-link-for="rdftriple">predicate</a>,
-                      and <var>type</var> for <a data-link-for="rdftriple">object</a>
+                      composed of <var>subject</var>, <code>rdf:type</code> for <a data-link-for="RdfTriple">predicate</a>,
+                      and <var>type</var> for <a data-link-for="RdfTriple">object</a>
                       <span class="changed">and add to <var>triples</var>
                       using its {{RdfGraph/add}} method,
                       unless <var>type</var> is not <a>well-formed</a></span>.</li>
@@ -6050,7 +6050,7 @@
         constructor();
         readonly attribute USVString subject;
         readonly attribute USVString predicate;
-        readonly attribute (USVString or RdfLiteral) obj;
+        readonly attribute (USVString or RdfLiteral) _object;
       };
     </pre>
 
@@ -6065,7 +6065,7 @@
         <div class="note">The use of <a>blank node identifiers</a> to label properties is obsolete,
           and may be removed in a future version of JSON-LD, as is the support for <a>generalized RDF Datasets</a>.</div>
         </dd>
-      <dt><dfn data-dfn-for="RdfTriple">obj</dfn></dt>
+      <dt><dfn data-dfn-for="RdfTriple">object</dfn></dt>
       <dd>An absolute <a>IRI</a>, <a>blank node identifier</a>, or <a>literal</a>
         denoting the <a>object</a> of the <a>triple</a>.</dd>
     </dl>

--- a/index.html
+++ b/index.html
@@ -5670,7 +5670,7 @@
             is a <a>string</a> representing the <a>IRI</a> of a remote document, await and dereference it as <var>remote document</var>
             using <a>LoadDocumentCallback</a>, passing <a data-lt="jsonldprocessor-compact-input">input</a>
             for <a data-link-for="LoadDocumentCallback">url</a>,
-            the {{JsonLdOptions/extractAllScripts}} option from <a data-lt="jsonldprocessor-compact-options">options</a>
+            and the {{JsonLdOptions/extractAllScripts}} option from <a data-lt="jsonldprocessor-compact-options">options</a>
             for <a data-link-for="LoadDocumentOptions">extractAllScripts</a>.</li>
           <li>Set <var>expanded input</var> to the result of
             using the <a data-link-for="JsonLdProcessor">expand()</a> method

--- a/index.html
+++ b/index.html
@@ -5682,7 +5682,8 @@
             <span class="changed">with {{JsonLdOptions/ordered}} set to <code>false</code></span>,
             <span class="changed">and {{JsonLdOptions/extractAllScripts}} defaulting to <code>false</code></span>.</li>
           <li class="changed">Set <var>context base</var> to the {{RemoteDocument/documentUrl}}
-            from <var>remote document</var>, if available, otherwise to {{JsonLdOptions/base}}.</li>
+            from <var>remote document</var>, if available, otherwise to the {{JsonLdOptions/base}} option
+            from <a data-lt="jsonldprocessor-compact-options">options</a>.</li>
           <li>If <a data-lt="jsonldprocessor-compact-context">context</a> is a <a class="changed">map</a>
             having an <code>@context</code> <a>entry</a>,
             set <var>context</var> to that <a data-lt="entry">entry's</a> value,
@@ -5783,10 +5784,12 @@
             {{RemoteDocument/document}} from <var>remote document</var> or <a data-lt="jsonldprocessor-expand-input">input</a>
             if there is no <var>remote document</var> as <var>element</var>,
             `null` as <var>active property</var>,
-            {{RemoteDocument/documentUrl}} as <var>base URL</var>, if available, otherwise to {{JsonLdOptions/base}},
+            {{RemoteDocument/documentUrl}} as <var>base URL</var>, if available,
+            otherwise to the {{JsonLdOptions/base}} option
+            from <a data-lt="jsonldprocessor-expand-options">options</a>,
             and the <span class="changed">{{JsonLdOptions/frameExpansion}}</span>
             and <span class="changed">and {{JsonLdOptions/ordered}}</span>
-            flags from <a data-lt="jsonldprocessor-compact-options">options</a>.
+            flags from <a data-lt="jsonldprocessor-expand-options">options</a>.
             <div class="note changed">If there is no <var>remote document</var>,
               then <a data-lt="jsonldprocessor-expand-input">input</a> is
               a <a>JsonLdRecord</a> or a <code>sequence</code> of
@@ -5980,7 +5983,7 @@
     </pre>
 
     <p class="changed">The <dfn>JsonLdInput</dfn> interface is used to refer to an input value
-      that may be a <a>JsonLdRecord</a>,
+      that that may be a <a>JsonLdRecord</a>,
       a `sequence` of <a>JsonLdRecords</a>,
       a <a>string</a> representing an <a>IRI</a>,
       which can be dereferenced to retrieve a valid JSON document,

--- a/index.html
+++ b/index.html
@@ -5625,18 +5625,18 @@
       [Exposed=(Window,Worker)]
       interface JsonLdProcessor {
         constructor();
-        static Promise&lt;JsonLdDictionary> compact(
+        static Promise&lt;JsonLdRecord> compact(
           JsonLdInput input,
           optional JsonLdContext context = null,
           optional JsonLdOptions options = {});
-        static Promise&lt;sequence&lt;JsonLdDictionary>> expand(
+        static Promise&lt;sequence&lt;JsonLdRecord>> expand(
           JsonLdInput input,
           optional JsonLdOptions options = {});
-        static Promise&lt;JsonLdDictionary> flatten(
+        static Promise&lt;JsonLdRecord> flatten(
           JsonLdInput input,
           optional JsonLdContext context = null,
           optional JsonLdOptions options = {});
-        static Promise&lt;sequence&lt;JsonLdDictionary>> fromRdf(
+        static Promise&lt;sequence&lt;JsonLdRecord>> fromRdf(
           RdfDataset input,
           optional JsonLdOptions options = {});
         static Promise&lt;RdfDataset> toRdf(
@@ -5936,14 +5936,14 @@
     </dl>
 
     <pre class="idl changed">
-      dictionary JsonLdDictionary {};
+      typedef record&lt;USVString, any> JsonLdRecord;
     </pre>
-    <p class="changed">The <dfn>JsonLdDictionary</dfn> is the definition of a <a>map</a>
+    <p class="changed">The <dfn>JsonLdRecord</dfn> is the definition of a <a>map</a>
       used to contain arbitrary <a>map entries</a>
       which are the result of parsing a <a>JSON Object</a>.
 
     <pre class="idl changed">
-      typedef (JsonLdDictionary or sequence&lt;JsonLdDictionary> or USVString) JsonLdInput;
+      typedef (JsonLdRecord or sequence&lt;JsonLdRecord> or USVString) JsonLdInput;
     </pre>
 
     <p class="changed">The <dfn>JsonLdInput</dfn> type is used to refer to an input value
@@ -5953,7 +5953,7 @@
       which can be dereferenced to retrieve a valid JSON document.</p>
 
     <pre class="idl">
-      typedef (JsonLdDictionary or USVString or sequence&lt;(JsonLdDictionary or USVString)>) JsonLdContext;
+      typedef (JsonLdRecord or USVString or sequence&lt;(JsonLdRecord or USVString)>) JsonLdContext;
     </pre>
 
     <p>The <dfn>JsonLdContext</dfn> type is used to refer to a value
@@ -6106,7 +6106,7 @@
         boolean                compactArrays = true;
         boolean                compactToRelative = true;
         LoadDocumentCallback?  documentLoader = null;
-        (JsonLdDictionary? or USVString) expandContext = null;
+        (JsonLdRecord? or USVString) expandContext = null;
         boolean                extractAllScripts = false;
         boolean                frameExpansion = false;
         boolean                ordered = false;

--- a/index.html
+++ b/index.html
@@ -5943,23 +5943,40 @@
       which are the result of parsing a <a>JSON Object</a>.
 
     <pre class="idl changed">
-      typedef (JsonLdRecord or sequence&lt;JsonLdRecord> or USVString) JsonLdInput;
+      typedef (JsonLdRecord or sequence&lt;JsonLdRecord> or USVString or RemoteDocument) JsonLdInput;
     </pre>
 
-    <p class="changed">The <dfn>JsonLdInput</dfn> type is used to refer to an input value
-      that that may be a <a>map</a>,
-      an array of <a>maps </a>,
-      or a <a>string</a> representing an <a>IRI</a>
-      which can be dereferenced to retrieve a valid JSON document.</p>
+    <p class="changed">The <dfn>JsonLdInput</dfn> interface is used to refer to an input value
+      that that may be a <a>JsonLdRecord</a>,
+      a `sequence` of <a>JsonLdRecords</a>,
+      a <a>string</a> representing an <a>IRI</a>,
+      which can be dereferenced to retrieve a valid JSON document,
+      <span class="changed">or an already dereferenced <a>RemoteDocument</a></span>.</p>
+
+    <p class="changed">When the value is a <a>JsonLdRecord</a> or sequence of <a>JsonLdRecords</a>,
+      the values are taken as their equivalent internal representation values,
+      where a <a>JsonLdRecord</a> is equivalent to a <a>map</a>,
+      and a sequence of <a>JsonLdRecords</a> is equivalent to an <a>array</a>
+      of <a>maps</a>. The <a>map entries</a> are converted to their equivalents
+      in [[INFRA]].</p>
 
     <pre class="idl">
-      typedef (JsonLdRecord or USVString or sequence&lt;(JsonLdRecord or USVString)>) JsonLdContext;
+      typedef (JsonLdRecord or sequence&lt;(JsonLdRecord or USVString)> or USVString or RemoteDocument) JsonLdContext;
     </pre>
 
-    <p>The <dfn>JsonLdContext</dfn> type is used to refer to a value
-      that may be a <a class="changed">map</a>,
+    <p>The <dfn>JsonLdContext</dfn> interface is used to refer to a value
+      that may be a <a>JsonLdRecord</a>,
+      a `sequence` of <a>JsonLdRecords</a>,
       a <a>string</a> representing an <a>IRI</a>,
-      or an array of <a class="changed">maps</a> and <a>strings</a>.</p>
+      which can be dereferenced to retrieve a valid JSON document,
+      <span class="changed">or an already dereferenced <a>RemoteDocument</a></span>.</p>
+
+    <p class="changed">When the value is a <a>JsonLdRecord</a> or sequence of <a>JsonLdRecords</a>,
+      the values are taken as their equivalent internal representation values,
+      where a <a>JsonLdRecord</a> is equivalent to a <a>map</a>,
+      and a sequence of <a>JsonLdRecords</a> is equivalent to an <a>array</a>
+      of <a>maps</a>. The <a>map entries</a> are converted to their equivalents
+      in [[INFRA]].</p>
   </section>
 
   <section><h3>RDF Dataset Interfaces</h3>
@@ -6275,10 +6292,12 @@
           nor any other media type using a
           <code>+json</code> suffix as defined in [[RFC6839]].
           Reject the <var>promise</var> passing a <a data-link-for="JsonLdErrorCode">loading document failed</a> error.</li>
-        <li>Create a new <a>RemoteDocument</a> <var>remote document</var> using <var>document</var>,
+        <li>Create a new <a>RemoteDocument</a> <var>remote document</var> using
+          <var>url</var> as {{RemoteDocument/documentUrl}},
+          <var>document</var> as {{RemoteDocument/document}},
           the returned <a>Content-Type</a> (without parameters) as {{RemoteDocument/contentType}},
-          any returned <code>profile</code> parameter,
-          and any <var>contextUrl</var>.</li>
+          any returned <code>profile</code> parameter, or `null` as {{RemoteDocument/profile}},
+          and <var>contextUrl</var>, or `null` as {{RemoteDocument/contextUrl}}.</li>
         <li>Resolve the <var>promise</var> with <var>remote document</var>.</li>
       </ol>
 
@@ -6325,12 +6344,14 @@
         to return information about a remote document or context.</p>
 
       <pre class="idl">
-        dictionary RemoteDocument {
-          USVString contextUrl = null;
-          USVString documentUrl;
-          any       document;
-          USVString contentType;
-          USVString profile = null;
+        [Exposed=(Window,Worker)]
+        interface RemoteDocument {
+          constructor();
+          readonly attribute USVString contentType;
+          readonly attribute USVString contextUrl;
+          readonly attribute USVString documentUrl;
+          readonly attribute any document;
+          readonly attribute USVString profile;
         };
       </pre>
 

--- a/index.html
+++ b/index.html
@@ -5665,7 +5665,7 @@
             The following steps are then deferred.</li>
           <li class="changed">If the provided <a data-lt="jsonldprocessor-compact-input">input</a>
             is a <a>RemoteDocument</a>,
-            initialize it as <var>remote document</var>.</li>
+            initialize <var>remote document</var> to <a data-lt="jsonldprocessor-compact-input">input</a>.</li>
           <li>Otherwise, if the provided <a data-lt="jsonldprocessor-compact-input">input</a>
             is a <a>string</a> representing the <a>IRI</a> of a remote document, await and dereference it as <var>remote document</var>
             using <a>LoadDocumentCallback</a>, passing <a data-lt="jsonldprocessor-compact-input">input</a>
@@ -5753,7 +5753,7 @@
             The following steps are then deferred.</li>
           <li class="changed">If the provided <a data-lt="jsonldprocessor-expand-input">input</a>
             is a <a>RemoteDocument</a>,
-            initialize it as <var>remote document</var>.</li>
+            initialize <var>remote document</var> to <a data-lt="jsonldprocessor-expand-input">input</a>.</li>
           <li>Otherwise, if the provided <a data-lt="jsonldprocessor-expand-input">input</a>
             is a <a>string</a> representing the <a>IRI</a> of a remote document, await and dereference it as <var>remote document</var>
             using <a>LoadDocumentCallback</a>, passing <a data-lt="jsonldprocessor-expand-input">input</a>
@@ -5834,12 +5834,12 @@
             The following steps are then deferred.</li>
           <li class="changed">If the provided <a data-lt="jsonldprocessor-flatten-input">input</a>
             is a <a>RemoteDocument</a>,
-            initialize it as <var>remote document</var>.</li>
+            initialize <var>remote document</var> to <a data-lt="jsonldprocessor-flatten-input">input</a>.</li>
           <li>Otherwise, if the provided <a data-lt="jsonldprocessor-flatten-input">input</a>
             is a <a>string</a> representing the <a>IRI</a> of a remote document, await and dereference it as <var>remote document</var>
             using <a>LoadDocumentCallback</a>, passing <a data-lt="jsonldprocessor-flatten-input">input</a>
             for <a data-link-for="LoadDocumentCallback">url</a>,
-            the {{JsonLdOptions/extractAllScripts}} option from <a data-lt="jsonldprocessor-flatten-options">options</a>
+            and the {{JsonLdOptions/extractAllScripts}} option from <a data-lt="jsonldprocessor-flatten-options">options</a>
             for <a data-link-for="LoadDocumentOptions">extractAllScripts</a>.
           </li>
           <li>Set <var>expanded input</var> to the result of
@@ -6385,7 +6385,7 @@
           readonly attribute USVString contentType;
           readonly attribute USVString contextUrl;
           readonly attribute USVString documentUrl;
-          readonly attribute any document;
+         attribute any document;
           readonly attribute USVString profile;
         };
       </pre>

--- a/index.html
+++ b/index.html
@@ -6050,7 +6050,7 @@
         constructor();
         readonly attribute USVString subject;
         readonly attribute USVString predicate;
-        readonly attribute (USVString or RdfLiteral) object;
+        readonly attribute (USVString or RdfLiteral) obj;
       };
     </pre>
 
@@ -6065,7 +6065,7 @@
         <div class="note">The use of <a>blank node identifiers</a> to label properties is obsolete,
           and may be removed in a future version of JSON-LD, as is the support for <a>generalized RDF Datasets</a>.</div>
         </dd>
-      <dt><dfn data-dfn-for="RdfTriple">object</dfn></dt>
+      <dt><dfn data-dfn-for="RdfTriple">obj</dfn></dt>
       <dd>An absolute <a>IRI</a>, <a>blank node identifier</a>, or <a>literal</a>
         denoting the <a>object</a> of the <a>triple</a>.</dd>
     </dl>

--- a/index.html
+++ b/index.html
@@ -5663,14 +5663,30 @@
         <ol>
           <li>Create a new {{Promise}} <var>promise</var> and return it.
             The following steps are then deferred.</li>
+          <li class="changed">If the provided <a data-lt="jsonldprocessor-compact-input">input</a>
+            is a <a>RemoteDocument</a>,
+            initialize it as <var>remote document</var>.</li>
+          <li>Otherwise, if the provided <a data-lt="jsonldprocessor-compact-input">input</a>
+            is a <a>string</a> representing the <a>IRI</a> of a remote document, await and dereference it as <var>remote document</var>
+            using <a>LoadDocumentCallback</a>, passing <a data-lt="jsonldprocessor-compact-input">input</a>
+            for <a data-link-for="LoadDocumentCallback">url</a>,
+            the {{JsonLdOptions/extractAllScripts}} option from <a data-lt="jsonldprocessor-compact-options">options</a>
+            for <a data-link-for="LoadDocumentOptions">extractAllScripts</a>.</li>
+          <li class="changed">If {{RemoteDocument/document}}
+            from <var>remote document</var> is a <a>string</a>, transform into the <a>internal representation</a>.
+            If {{RemoteDocument/document}} cannot be transformed to the <a>internal representation</a>,
+            reject <var>promise</var> passing a <a data-link-for="JsonLdErrorCode">loading document failed</a> error.</li>
           <li>Set <var>expanded input</var> to the result of
             using the <a data-link-for="JsonLdProcessor">expand()</a> method
-            using <a data-lt="jsonldprocessor-compact-input">input</a>
+            using either <var>remote document</var>
+            or <a data-lt="jsonldprocessor-compact-input">input</a>
+            if there is no <var>remote document</var>
+            for <a data-lt="jsonldprocessor-expand-input">input</a>,
             and <a data-lt="jsonldprocessor-compact-options">options</a>,
             <span class="changed">with {{JsonLdOptions/ordered}} set to <code>false</code></span>,
             <span class="changed">and {{JsonLdOptions/extractAllScripts}} defaulting to <code>false</code></span>.</li>
-          <li class="changed">Set <var>context base</var> to the {{RemoteDocument/documentUrl}} obtained
-            when loading the document in the previous step.</li>
+          <li class="changed">Set <var>context base</var> to the {{RemoteDocument/documentUrl}}
+            from <var>remote document</var>, if available, otherwise to {{JsonLdOptions/base}}.</li>
           <li>If <a data-lt="jsonldprocessor-compact-context">context</a> is a <a class="changed">map</a>
             having an <code>@context</code> <a>entry</a>,
             set <var>context</var> to that <a data-lt="entry">entry's</a> value,
@@ -5738,13 +5754,15 @@
         <ol>
           <li>Create a new {{Promise}} <var>promise</var> and return it.
             The following steps are then deferred.</li>
-          <li>If the provided <a data-lt="jsonldprocessor-expand-input">input</a>
+          <li class="changed">If the provided <a data-lt="jsonldprocessor-expand-input">input</a>
+            is a <a>RemoteDocument</a>,
+            initialize it as <var>remote document</var>.</li>
+          <li>Otherwise, if the provided <a data-lt="jsonldprocessor-expand-input">input</a>
             is a <a>string</a> representing the <a>IRI</a> of a remote document, await and dereference it as <var>remote document</var>
             using <a>LoadDocumentCallback</a>, passing <a data-lt="jsonldprocessor-expand-input">input</a>
             for <a data-link-for="LoadDocumentCallback">url</a>,
             the {{JsonLdOptions/extractAllScripts}} option from <a data-lt="jsonldprocessor-expand-options">options</a>
-            for <a data-link-for="LoadDocumentOptions">extractAllScripts</a>.
-          </li>
+            for <a data-link-for="LoadDocumentOptions">extractAllScripts</a>.</li>
           <li class="changed">If {{RemoteDocument/document}}
             from <var>remote document</var> is a <a>string</a>, transform into the <a>internal representation</a>.
             If {{RemoteDocument/document}} cannot be transformed to the <a>internal representation</a>,
@@ -5773,6 +5791,11 @@
             and the <span class="changed">{{JsonLdOptions/frameExpansion}}</span>
             and <span class="changed">and {{JsonLdOptions/ordered}}</span>
             flags from <a data-lt="jsonldprocessor-compact-options">options</a>.
+            <div class="note changed">If there is no <var>remote document</var>,
+              then <a data-lt="jsonldprocessor-expand-input">input</a> is
+              a <a>JsonLdRecord</a> or a <code>sequence</code> of
+              <a>JsonLdRecords</a>, which are implicitly alread in the
+              <a>internal representation</a>.</div>
             <ol id="api-expand-post-processing" class="changed">
               <li>If <var>expanded output</var> is a
                 <a class="changed">map</a> that contains only an <code>@graph</code> <a>entry</a>,
@@ -5810,8 +5833,26 @@
         <ol>
           <li>Create a new {{Promise}} <var>promise</var> and return it.
             The following steps are then deferred.</li>
-          <li>Set <var>expanded input</var> to the result of using the <a data-link-for="JsonLdProcessor">expand()</a> method
-            using <a data-lt="jsonldprocessor-flatten-input">input</a>
+          <li class="changed">If the provided <a data-lt="jsonldprocessor-flatten-input">input</a>
+            is a <a>RemoteDocument</a>,
+            initialize it as <var>remote document</var>.</li>
+          <li>Otherwise, if the provided <a data-lt="jsonldprocessor-flatten-input">input</a>
+            is a <a>string</a> representing the <a>IRI</a> of a remote document, await and dereference it as <var>remote document</var>
+            using <a>LoadDocumentCallback</a>, passing <a data-lt="jsonldprocessor-flatten-input">input</a>
+            for <a data-link-for="LoadDocumentCallback">url</a>,
+            the {{JsonLdOptions/extractAllScripts}} option from <a data-lt="jsonldprocessor-flatten-options">options</a>
+            for <a data-link-for="LoadDocumentOptions">extractAllScripts</a>.
+          </li>
+          <li class="changed">If {{RemoteDocument/document}}
+            from <var>remote document</var> is a <a>string</a>, transform into the <a>internal representation</a>.
+            If {{RemoteDocument/document}} cannot be transformed to the <a>internal representation</a>,
+            reject <var>promise</var> passing a <a data-link-for="JsonLdErrorCode">loading document failed</a> error.</li>
+          <li>Set <var>expanded input</var> to the result of
+            using the <a data-link-for="JsonLdProcessor">expand()</a> method
+            using either <var>remote document</var>
+            or <a data-lt="jsonldprocessor-flatten-input">input</a>
+            if there is no <var>remote document</var>
+            for <a data-lt="jsonldprocessor-expand-input">input</a>,
             and <a data-lt="jsonldprocessor-flatten-options">options</a>
             <span class="changed">with {{JsonLdOptions/ordered}} set to <code>false</code></span>.</li>
           <li class="changed">Initialize the <a>base IRI</a> to the {{JsonLdOptions/base}} option
@@ -5961,15 +6002,14 @@
       in [[INFRA]].</p>
 
     <pre class="idl">
-      typedef (JsonLdRecord or sequence&lt;(JsonLdRecord or USVString)> or USVString or RemoteDocument) JsonLdContext;
+      typedef (JsonLdRecord or sequence&lt;(JsonLdRecord or USVString)> or USVString) JsonLdContext;
     </pre>
 
     <p>The <dfn>JsonLdContext</dfn> interface is used to refer to a value
       that may be a <a>JsonLdRecord</a>,
       a `sequence` of <a>JsonLdRecords</a>,
-      a <a>string</a> representing an <a>IRI</a>,
-      which can be dereferenced to retrieve a valid JSON document,
-      <span class="changed">or an already dereferenced <a>RemoteDocument</a></span>.</p>
+      or a <a>string</a> representing an <a>IRI</a>,
+      which can be dereferenced to retrieve a valid JSON document.</p>
 
     <p class="changed">When the value is a <a>JsonLdRecord</a> or sequence of <a>JsonLdRecords</a>,
       the values are taken as their equivalent internal representation values,
@@ -6899,6 +6939,11 @@
     <li>Remove normative text for canonicalizing `rdf:JSON` literals and
       reference the `rdf:JSON` datatype of the syntax document
       for the conversion of the <a>JSON Literals</a> in <a href="#data-round-tripping" class="sectionRef"></a>.</li>
+    <li>Updated interfaces in <a href="#the-application-programming-interface" class="sectionRef"></a>
+      to use <a data-cite="WEBIDL#idl-record">record</a>,
+      instead of <a data-cite="WEBIDL#dfn-dictionary">dictionary</a>,
+      and to allow <a>RemoteDocument</a> to be used
+      as a direct input, which resolves a {{Promise}} boundary issue.</li>
   </ul>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -6385,7 +6385,7 @@
           readonly attribute USVString contentType;
           readonly attribute USVString contextUrl;
           readonly attribute USVString documentUrl;
-         attribute any document;
+          attribute any document;
           readonly attribute USVString profile;
         };
       </pre>

--- a/index.html
+++ b/index.html
@@ -5980,7 +5980,7 @@
     </pre>
 
     <p class="changed">The <dfn>JsonLdInput</dfn> interface is used to refer to an input value
-      that that may be a <a>JsonLdRecord</a>,
+      that may be a <a>JsonLdRecord</a>,
       a `sequence` of <a>JsonLdRecords</a>,
       a <a>string</a> representing an <a>IRI</a>,
       which can be dereferenced to retrieve a valid JSON document,


### PR DESCRIPTION
* [x] Use `_object_ instead of `object` in `RdfTriple` WebIDL definition.
* [x] Change `JsonLdDictionary` to `JsonLdRecord` and use `record<USVString, any>` instead of `dictionary`.
* [x] Document relationship between WebIDL primitive types and Infra (e.g., `record` vs `map`.
* [x] Add `RemoteDocument` to `JsonLdInput`.
* [x] Avoid leakage of `documentUrl` between `compact()` and `expand()` by retrieving `input` in `compact()` (and friends) and passing that to `expand()`.

Fixes #383.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/384.html" title="Last updated on Feb 27, 2020, 6:13 PM UTC (d3966e9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/384/ad97b98...d3966e9.html" title="Last updated on Feb 27, 2020, 6:13 PM UTC (d3966e9)">Diff</a>