### PR TITLE
Update expand/pr39 and toRdf/pr39 to make them positive tests

### DIFF
--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -9121,7 +9121,7 @@ Test tpr38 Ignores a term mapping to a value in the form of a keyword (@reverse)
 <dt>id</dt>
 <dd>#tpr38</dd>
 <dt>Type</dt>
-<dd>jld:NegativeEvaluationTest, jld:ExpandTest</dd>
+<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
 <dt>Purpose</dt>
 <dd>Terms in the form of a keyword, which are not keywords, are ignored.</dd>
 <dt>input</dt>
@@ -9130,7 +9130,7 @@ Test tpr38 Ignores a term mapping to a value in the form of a keyword (@reverse)
 </dd>
 <dt>expect</dt>
 <dd>
-invalid IRI mapping
+<a href='expand/pr38-out.jsonld'>expand/pr38-out.jsonld</a>
 </dd>
 <dt>Options</dt>
 <dd>

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -1765,7 +1765,7 @@ Test t0077 expandContext option
 <dd>
 <dl class='options'>
 <dt>expandContext</dt>
-<dd>0077-context.jsonld</dd>
+<dd>expand/0077-context.jsonld</dd>
 </dl>
 </dd>
 </dl>
@@ -9149,7 +9149,7 @@ Test tpr39 Ignores a term mapping to a value in the form of a keyword (@reverse 
 <dt>id</dt>
 <dd>#tpr39</dd>
 <dt>Type</dt>
-<dd>jld:NegativeEvaluationTest, jld:ExpandTest</dd>
+<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
 <dt>Purpose</dt>
 <dd>Terms in the form of a keyword, which are not keywords, are ignored.</dd>
 <dt>input</dt>
@@ -9158,7 +9158,7 @@ Test tpr39 Ignores a term mapping to a value in the form of a keyword (@reverse 
 </dd>
 <dt>expect</dt>
 <dd>
-invalid IRI mapping
+<a href='expand/pr39-out.jsonld'>expand/pr39-out.jsonld</a>
 </dd>
 <dt>Options</dt>
 <dd>

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -2697,12 +2697,12 @@
       "expect": "expand/pr37-out.jsonld"
     }, {
       "@id": "#tpr38",
-      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "Ignores a term mapping to a value in the form of a keyword (@reverse).",
       "purpose": "Terms in the form of a keyword, which are not keywords, are ignored.",
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr38-in.jsonld",
-      "expectErrorCode": "invalid IRI mapping"
+      "expect": "expand/pr38-out.jsonld"
     }, {
       "@id": "#tpr39",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -2705,12 +2705,12 @@
       "expectErrorCode": "invalid IRI mapping"
     }, {
       "@id": "#tpr39",
-      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "Ignores a term mapping to a value in the form of a keyword (@reverse with @vocab).",
       "purpose": "Terms in the form of a keyword, which are not keywords, are ignored.",
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand/pr39-in.jsonld",
-      "expectErrorCode": "invalid IRI mapping"
+      "expect": "expand/pr39-out.jsonld"
     }, {
       "@id": "#tso01",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],

--- a/tests/expand/pr38-out.jsonld
+++ b/tests/expand/pr38-out.jsonld
@@ -1,0 +1,3 @@
+[{
+  "@type": ["http://example.com/IgnoreTest"]
+}]

--- a/tests/expand/pr39-in.jsonld
+++ b/tests/expand/pr39-in.jsonld
@@ -4,5 +4,5 @@
     "ignoreMe": {"@reverse": "@ignoreMe"}
   },
   "@type": "http://example.com/IgnoreTest",
-  "ignoreMe": {"text": "should not be here"}
+  "ignoreMe": {"text": "not reversed"}
 }

--- a/tests/expand/pr39-out.jsonld
+++ b/tests/expand/pr39-out.jsonld
@@ -1,0 +1,6 @@
+[{
+  "@type": ["http://example.com/IgnoreTest"],
+  "http://example.org/ignoreMe": [{
+    "http://example.org/text": [{"@value": "not reversed"}]
+  }]
+}]

--- a/tests/toRdf-manifest.html
+++ b/tests/toRdf-manifest.html
@@ -8993,7 +8993,7 @@ Test tpr38 Ignores a term mapping to a value in the form of a keyword (@reverse)
 <dt>id</dt>
 <dd>#tpr38</dd>
 <dt>Type</dt>
-<dd>jld:NegativeEvaluationTest, jld:ToRDFTest</dd>
+<dd>jld:PositiveEvaluationTest, jld:ToRDFTest</dd>
 <dt>Purpose</dt>
 <dd>Terms in the form of a keyword, which are not keywords, are ignored.</dd>
 <dt>input</dt>
@@ -9002,7 +9002,7 @@ Test tpr38 Ignores a term mapping to a value in the form of a keyword (@reverse)
 </dd>
 <dt>expect</dt>
 <dd>
-invalid IRI mapping
+<a href='toRdf/pr38-out.nq'>toRdf/pr38-out.nq</a>
 </dd>
 <dt>Options</dt>
 <dd>

--- a/tests/toRdf-manifest.html
+++ b/tests/toRdf-manifest.html
@@ -4254,7 +4254,7 @@ Test te077 expandContext option
 <dd>
 <dl class='options'>
 <dt>expandContext</dt>
-<dd>e077-context.jsonld</dd>
+<dd>toRdf/e077-context.jsonld</dd>
 </dl>
 </dd>
 </dl>
@@ -9021,7 +9021,7 @@ Test tpr39 Ignores a term mapping to a value in the form of a keyword (@reverse 
 <dt>id</dt>
 <dd>#tpr39</dd>
 <dt>Type</dt>
-<dd>jld:NegativeEvaluationTest, jld:ToRDFTest</dd>
+<dd>jld:PositiveEvaluationTest, jld:ToRDFTest</dd>
 <dt>Purpose</dt>
 <dd>Terms in the form of a keyword, which are not keywords, are ignored.</dd>
 <dt>input</dt>
@@ -9030,7 +9030,7 @@ Test tpr39 Ignores a term mapping to a value in the form of a keyword (@reverse 
 </dd>
 <dt>expect</dt>
 <dd>
-invalid IRI mapping
+<a href='toRdf/pr39-out.nq'>toRdf/pr39-out.nq</a>
 </dd>
 <dt>Options</dt>
 <dd>

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -2676,12 +2676,12 @@
       "expect": "toRdf/pr37-out.nq"
     }, {
       "@id": "#tpr38",
-      "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
       "name": "Ignores a term mapping to a value in the form of a keyword (@reverse).",
       "purpose": "Terms in the form of a keyword, which are not keywords, are ignored.",
       "option": {"specVersion": "json-ld-1.1"},
       "input": "toRdf/pr38-in.jsonld",
-      "expectErrorCode": "invalid IRI mapping"
+      "expect": "toRdf/pr38-out.nq"
     }, {
       "@id": "#tpr39",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -2684,12 +2684,12 @@
       "expectErrorCode": "invalid IRI mapping"
     }, {
       "@id": "#tpr39",
-      "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
       "name": "Ignores a term mapping to a value in the form of a keyword (@reverse with @vocab).",
       "purpose": "Terms in the form of a keyword, which are not keywords, are ignored.",
       "option": {"specVersion": "json-ld-1.1"},
       "input": "toRdf/pr39-in.jsonld",
-      "expectErrorCode": "invalid IRI mapping"
+      "expect": "toRdf/pr39-out.nq"
     }, {
       "@id": "#trt01",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],

--- a/tests/toRdf/pr38-out.nq
+++ b/tests/toRdf/pr38-out.nq
@@ -1,0 +1,1 @@
+_:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/IgnoreTest> .

--- a/tests/toRdf/pr39-in.jsonld
+++ b/tests/toRdf/pr39-in.jsonld
@@ -4,5 +4,5 @@
     "ignoreMe": {"@reverse": "@ignoreMe"}
   },
   "@type": "http://example.com/IgnoreTest",
-  "ignoreMe": {"text": "should not be here"}
+  "ignoreMe": {"text": "not reversed"}
 }

--- a/tests/toRdf/pr39-out.nq
+++ b/tests/toRdf/pr39-out.nq
@@ -1,0 +1,3 @@
+_:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/IgnoreTest> .
+_:b0 <http://example.org/ignoreMe> _:b1 .
+_:b1 <http://example.org/text> "not reversed" .


### PR DESCRIPTION
as the keyword-like value of `@reverse` is ignored, and does not generate an error.

Fixes #386.