### PR TITLE
Update test expectations for HTML tests

### DIFF
--- a/tests/html-manifest.html
+++ b/tests/html-manifest.html
@@ -403,7 +403,7 @@ Test te011 Errors if no element found at target
 </dd>
 <dt>expect</dt>
 <dd>
-invalid script element
+loading document failed
 </dd>
 <dt>Options</dt>
 <dd>
@@ -431,7 +431,7 @@ Test te012 Errors if targeted element is not a script element
 </dd>
 <dt>expect</dt>
 <dd>
-invalid script element
+loading document failed
 </dd>
 <dt>Options</dt>
 <dd>
@@ -459,7 +459,7 @@ Test te013 Errors if targeted element does not have type application/ld+json
 </dd>
 <dt>expect</dt>
 <dd>
-invalid script element
+loading document failed
 </dd>
 <dt>Options</dt>
 <dd>
@@ -1237,7 +1237,7 @@ Test tr011 Errors if no element found at target
 </dd>
 <dt>expect</dt>
 <dd>
-invalid script element
+loading document failed
 </dd>
 <dt>Options</dt>
 <dd>
@@ -1265,7 +1265,7 @@ Test tr012 Errors if targeted element is not a script element
 </dd>
 <dt>expect</dt>
 <dd>
-invalid script element
+loading document failed
 </dd>
 <dt>Options</dt>
 <dd>
@@ -1293,7 +1293,7 @@ Test tr013 Errors if targeted element does not have type application/ld+json
 </dd>
 <dt>expect</dt>
 <dd>
-invalid script element
+loading document failed
 </dd>
 <dt>Options</dt>
 <dd>

--- a/tests/html-manifest.jsonld
+++ b/tests/html-manifest.jsonld
@@ -83,7 +83,7 @@
     "name": "Errors if no element found at target",
     "purpose": "Tests embedded JSON-LD in HTML with fragment identifier that doesn't exist",
     "input": "html/e011-in.html#third",
-    "expectErrorCode": "invalid script element",
+    "expectErrorCode": "loading document failed",
     "option": {"specVersion": "json-ld-1.1"}
   }, {
     "@id": "#te012",
@@ -91,7 +91,7 @@
     "name": "Errors if targeted element is not a script element",
     "purpose": "Tests embedded JSON-LD in HTML which isn't a script element",
     "input": "html/e012-in.html#first",
-    "expectErrorCode": "invalid script element",
+    "expectErrorCode": "loading document failed",
     "option": {"specVersion": "json-ld-1.1"}
   }, {
     "@id": "#te013",
@@ -99,7 +99,7 @@
     "name": "Errors if targeted element does not have type application/ld+json",
     "purpose": "Tests embedded JSON-LD in HTML with wrong type",
     "input": "html/e013-in.html#first",
-    "expectErrorCode": "invalid script element",
+    "expectErrorCode": "loading document failed",
     "option": {"specVersion": "json-ld-1.1"}
   }, {
     "@id": "#te014",
@@ -315,7 +315,7 @@
     "name": "Errors if no element found at target",
     "purpose": "Tests embedded JSON-LD in HTML with fragment identifier that doesn't exist",
     "input": "html/r011-in.html#third",
-    "expectErrorCode": "invalid script element",
+    "expectErrorCode": "loading document failed",
     "option": {"specVersion": "json-ld-1.1"}
   }, {
     "@id": "#tr012",
@@ -323,7 +323,7 @@
     "name": "Errors if targeted element is not a script element",
     "purpose": "Tests embedded JSON-LD in HTML which isn't a script element",
     "input": "html/r012-in.html#first",
-    "expectErrorCode": "invalid script element",
+    "expectErrorCode": "loading document failed",
     "option": {"specVersion": "json-ld-1.1"}
   }, {
     "@id": "#tr013",
@@ -331,7 +331,7 @@
     "name": "Errors if targeted element does not have type application/ld+json",
     "purpose": "Tests embedded JSON-LD in HTML with wrong type",
     "input": "html/r013-in.html#first",
-    "expectErrorCode": "invalid script element",
+    "expectErrorCode": "loading document failed",
     "option": {"specVersion": "json-ld-1.1"}
   }, {
     "@id": "#tr014",


### PR DESCRIPTION
e011, e012, e013, r011, r012, and r013 from "invalid script element" to "load document failed",

Fixes #399.