### PR TITLE
Update step 12.8.1 of the Compaction Algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -3852,8 +3852,8 @@
                       using <var>as array</var>.</li>
                   </ol>
                 </li>
-                <li class="changed">Otherwise, use <a>add value</a> to add <var>compacted item</var>
-                  to the <var>item active property</var> entry in <var>result</var>
+                <li id="alg-compact-12_8_10" class="changed">Otherwise, use <a>add value</a> to add <var>compacted item</var>
+                  to the <var>item active property</var> entry in <var>nest result</var>
                   using <var>as array</var>.</li>
               </ol>
             </li>
@@ -6976,7 +6976,11 @@
       and <a href="#value-compaction">Value Compaction</a> algorithms,
       but is retrieved from the <a data-lt="context-inverse">inverse context</a> field
       within an <a>active context</a>, and initialized as necessary.
-      This simplifies calling sequences and better represents actual implementation experience.
+      This simplifies calling sequences and better represents actual implementation experience.</li>
+    <li>Update step <a href="#alg-compact-12_8_10">12.8.1</a> of the
+      <a href="#compaction-algorithm">Compaction Algorithm</a>
+      to add values to <var>nest result</var> instead of <var>result</var>
+      as was originally intended.</li>
   </ul>
 </section>
 <section id="ack"


### PR DESCRIPTION
to add values to <var>nest result</var> instead of <var>result</var> as was originally intended.

Fixes #403.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 6, 2020, 12:14 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fjson-ld-api%2Fe524070b17016ae36154307ae5ebd7abbbf46ec2%2Findex.html%3FisPreview%3Dtrue)

```
Navigation timeout of 30000 ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/json-ld-api%23405.)._
</details>
