### PR TITLE
Add expansion test where scoped context is a URL.

### DIFF
--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -3956,6 +3956,34 @@ invalid scoped context
 </dd>
 </dl>
 </dd>
+<dt id='tc034'>
+Test tc034 Remote scoped context.
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tc034</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>Scoped contexts may be externally loaded.</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/c034-in.jsonld'>expand/c034-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='expand/c034-out.jsonld'>expand/c034-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
 <dt id='tdi01'>
 Test tdi01 Expand string using default and term directions
 </dt>

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -1189,6 +1189,14 @@
       "expectErrorCode": "invalid scoped context",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tc034",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Remote scoped context.",
+      "purpose": "Scoped contexts may be externally loaded.",
+      "input": "expand/c034-in.jsonld",
+      "expect": "expand/c034-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tdi01",
       "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Expand string using default and term directions",

--- a/tests/expand/c034-context.jsonld
+++ b/tests/expand/c034-context.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "bar": "http://example.org/bar"
+  }
+}

--- a/tests/expand/c034-in.jsonld
+++ b/tests/expand/c034-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "foo": {"@context": "c034-context.jsonld"}
+  },
+  "foo": {
+    "bar": "baz"
+  }
+}

--- a/tests/expand/c034-out.jsonld
+++ b/tests/expand/c034-out.jsonld
@@ -1,0 +1,5 @@
+[
+  {
+    "http://example/foo": [{"http://example.org/bar": [{"@value": "baz"}]}]
+  }
+]

--- a/tests/toRdf-manifest.html
+++ b/tests/toRdf-manifest.html
@@ -2195,6 +2195,34 @@ invalid scoped context
 </dd>
 </dl>
 </dd>
+<dt id='tc034'>
+Test tc034 Remote scoped context.
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tc034</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Scoped contexts may be externally loaded.</dd>
+<dt>input</dt>
+<dd>
+<a href='toRdf/c034-in.jsonld'>toRdf/c034-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='toRdf/c034-out.nq'>toRdf/c034-out.nq</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
 <dt id='tdi01'>
 Test tdi01 Expand string using default and term directions
 </dt>

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -661,6 +661,14 @@
       "expectErrorCode": "invalid scoped context",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tc034",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Remote scoped context.",
+      "purpose": "Scoped contexts may be externally loaded.",
+      "input": "toRdf/c034-in.jsonld",
+      "expect": "toRdf/c034-out.nq",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tdi01",
       "@type": [ "jld:PositiveEvaluationTest", "jld:ToRDFTest" ],
       "name": "Expand string using default and term directions",

--- a/tests/toRdf/c034-context.jsonld
+++ b/tests/toRdf/c034-context.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "bar": "http://example.org/bar"
+  }
+}

--- a/tests/toRdf/c034-in.jsonld
+++ b/tests/toRdf/c034-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "foo": {"@context": "c034-context.jsonld"}
+  },
+  "foo": {
+    "bar": "baz"
+  }
+}

--- a/tests/toRdf/c034-out.nq
+++ b/tests/toRdf/c034-out.nq
@@ -1,0 +1,2 @@
+_:b0 <http://example/foo> _:b1 .
+_:b1 <http://example.org/bar> "baz" .


### PR DESCRIPTION
We didn't have any tests where a scoped context was a URL, which affects implementations which preload remote contexts.