### PR TITLE
Update step 2.2.1 of Merge Node Maps

### DIFF
--- a/index.html
+++ b/index.html
@@ -4647,7 +4647,7 @@
             with a new <a>map</a> consisting of a single <a>entry</a> <code>@id</code> whose value is <var>id</var>, if it does not exist.</li>
           <li>For each <var>property</var> and <var>values</var> in <var>node</var>:
             <ol>
-              <li>If <var>property</var> is a <a>keyword</a>, add <var>property</var> and values to <var>merged node</var>.</li>
+              <li id='alg-merge-node-maps-2_2_1'>If <var>property</var> is a <a>keyword</a> <span class="changed">other than `@type`</span>, add <var>property</var> and values to <var>merged node</var>.</li>
               <li>Otherwise, merge each element from <var>values</var> into the values for <var>property</var>
                 in <var>merged node</var>, initializing it to an empty <a>array</a> if necessary.</li>
             </ol>
@@ -6981,6 +6981,10 @@
       <a href="#compaction-algorithm">Compaction Algorithm</a>
       to add values to <var>nest result</var> instead of <var>result</var>
       as was originally intended.</li>
+    <li>Update step <a href="#alg-merge-node-maps-2_2_1">2.2.1</a>
+      of <a href="#merge-node-maps" class="sectionRef"></a> to
+      exclude `@type`, leaving it to the next step.
+      This could cause type values from a node to be left out of the merge.</li>
   </ul>
 </section>
 <section id="ack"


### PR DESCRIPTION
to exclude `@type` from copied values, leaving it to 2.2.2.

Fixes #407.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 10, 2020, 8:53 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fjson-ld-api%2F680cee3367541e8576c2798133a94852995add39%2Findex.html%3FisPreview%3Dtrue)

```
Navigation timeout of 30000 ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/json-ld-api%23413.)._
</details>
