### PR TITLE
Update Compaction algorithm to re-initialize _container key_

### DIFF
--- a/index.html
+++ b/index.html
@@ -3812,14 +3812,18 @@
                     <li>Otherwise, if <var>container</var> includes <code>@index</code>
                       and <var>index key</var> is <code>@index</code>,
                       set <var>map key</var> to the value of <code>@index</code> in <var>expanded item</var>, if any.</li>
-                    <li class="changed">Otherwise, if <var>container</var> includes <code>@index</code>
-                      and <var>index key</var> is not <code>@index</code>,
-                      set <var>map key</var> to the first value of <var>container key</var> in <var>compacted item</var>, if any.
-                      If there are remaining values in <var>compacted item</var>
-                      for <var>container key</var>, set the value of
-                      <var>container key</var> in <var>compacted item</var>
-                      to those remaining values. Otherwise, remove that
-                      <a>entry</a> from <var>compacted item</var>.
+                    <li id="alg-compact-2_8_9_6" class="changed">Otherwise, if <var>container</var> includes <code>@index</code>
+                      and <var>index key</var> is not <code>@index</code>:
+                      <ol>
+                        <li>Reinitialize <var>container key</var> by <a>IRI compacting</a>
+                          <var>index key</var>.</li>
+                        <li>Set <var>map key</var> to the first value of <var>container key</var> in <var>compacted item</var>, if any.</li>
+                        <li>If there are remaining values in <var>compacted item</var>
+                          for <var>container key</var>, set the value of
+                          <var>container key</var> in <var>compacted item</var>
+                          to those remaining values. Otherwise, remove that
+                          <a>entry</a> from <var>compacted item</var>.</li>
+                      </ol>
                     </li>
                     <li class="changed">Otherwise, if <var>container</var> includes <code>@id</code>, set
                       <var>map key</var> to the value of <var>container key</var> in

--- a/index.html
+++ b/index.html
@@ -3812,7 +3812,7 @@
                     <li>Otherwise, if <var>container</var> includes <code>@index</code>
                       and <var>index key</var> is <code>@index</code>,
                       set <var>map key</var> to the value of <code>@index</code> in <var>expanded item</var>, if any.</li>
-                    <li id="alg-compact-2_8_9_6" class="changed">Otherwise, if <var>container</var> includes <code>@index</code>
+                    <li id="alg-compact-12_8_9_6" class="changed">Otherwise, if <var>container</var> includes <code>@index</code>
                       and <var>index key</var> is not <code>@index</code>:
                       <ol>
                         <li>Reinitialize <var>container key</var> by <a>IRI compacting</a>
@@ -6981,6 +6981,7 @@
       but is retrieved from the <a data-lt="context-inverse">inverse context</a> field
       within an <a>active context</a>, and initialized as necessary.
       This simplifies calling sequences and better represents actual implementation experience.</li>
+    <li>Update step <a href="#alg-compact-12_8_9_6">12.8.9.6</a></li>
     <li>Update step <a href="#alg-compact-12_8_10">12.8.1</a> of the
       <a href="#compaction-algorithm">Compaction Algorithm</a>
       to add values to <var>nest result</var> instead of <var>result</var>


### PR DESCRIPTION
by compacting _index key_ in step 12.8.9.6.

Fixes #406.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 10, 2020, 9:50 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fjson-ld-api%2F680cee3367541e8576c2798133a94852995add39%2Findex.html%3FisPreview%3Dtrue)

```
Navigation timeout of 30000 ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/json-ld-api%23414.)._
</details>
