### PR TITLE
Add term scoping test for toRdf

### DIFF
--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -1237,6 +1237,14 @@
       "expect": "expand/c034-out.jsonld",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tc035",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Term scoping with embedded contexts.",
+      "purpose": "Terms should make use of @vocab relative to the scope in which the term was defined.",
+      "input": "expand/c035-in.jsonld",
+      "expect": "expand/c035-out.nq",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tdi01",
       "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Expand string using default and term directions",

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -1242,7 +1242,7 @@
       "name": "Term scoping with embedded contexts.",
       "purpose": "Terms should make use of @vocab relative to the scope in which the term was defined.",
       "input": "expand/c035-in.jsonld",
-      "expect": "expand/c035-out.nq",
+      "expect": "expand/c035-out.jsonld",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tdi01",

--- a/tests/expand/c035-in.jsonld
+++ b/tests/expand/c035-in.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "http://vocab.org/",
+    "prop1": {}
+  },
+  "@id": "ex:outer",
+  "foo": {
+    "@context": {
+      "@vocab": "http://vocab.override.org/"
+    },
+    "@id": "ex:inner",
+    "prop1": "baz1",
+    "prop2": "baz2"
+  }
+}

--- a/tests/expand/c035-out.jsonld
+++ b/tests/expand/c035-out.jsonld
@@ -1,0 +1,20 @@
+[
+  {
+    "@id": "ex:outer",
+    "http://vocab.org/foo": [
+      {
+        "@id": "ex:inner",
+        "http://vocab.org/prop1": [
+          {
+            "@value": "baz1"
+          }
+        ],
+        "http://vocab.override.org/prop2": [
+          {
+            "@value": "baz2"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -669,6 +669,14 @@
       "expect": "toRdf/c034-out.nq",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tc035",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Term scoping with embedded contexts.",
+      "purpose": "Terms should make use of @vocab relative to the scope in which the term was defined.",
+      "input": "toRdf/c035-in.jsonld",
+      "expect": "toRdf/c035-out.nq",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tdi01",
       "@type": [ "jld:PositiveEvaluationTest", "jld:ToRDFTest" ],
       "name": "Expand string using default and term directions",

--- a/tests/toRdf/c035-in.jsonld
+++ b/tests/toRdf/c035-in.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "http://vocab.org/",
+    "prop1": {}
+  },
+  "@id": "ex:outer",
+  "foo": {
+    "@context": {
+      "@vocab": "http://vocab.override.org/"
+    },
+    "@id": "ex:inner",
+    "prop1": "baz1",
+    "prop2": "baz2"
+  }
+}

--- a/tests/toRdf/c035-out.nq
+++ b/tests/toRdf/c035-out.nq
@@ -1,0 +1,3 @@
+<ex:inner> <http://vocab.org/prop1> "baz1" .
+<ex:inner> <http://vocab.override.org/prop2> "baz2" .
+<ex:outer> <http://vocab.org/foo> <ex:inner> .


### PR DESCRIPTION
As discussed in #408, this adds a dedicated toRdf test for checking that terms should make use of @vocab relative to the scope in which the term was defined.