### PR TITLE
Add toRdf test for protected term override in prop-scoped context

### DIFF
--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -2715,6 +2715,14 @@
       "input": "toRdf/pr39-in.jsonld",
       "expect": "toRdf/pr39-out.nq"
     }, {
+      "@id": "#tpr40",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Protected terms and property-scoped contexts",
+      "purpose": "Check overriding of protected term from property-scoped context.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "toRdf/pr40-in.jsonld",
+      "expect": "toRdf/pr40-out.nq"
+    }, {
       "@id": "#trt01",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
       "name": "Representing numbers >= 1e21",

--- a/tests/toRdf/pr40-in.jsonld
+++ b/tests/toRdf/pr40-in.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "http://vocab.org/",
+    "@protected": true,
+    "bar": "http://ignored.org/bar",
+    "foo": {
+      "@context": {
+        "bar": "http://example.org/other"
+      }
+    }
+  },
+  "@id": "ex:outer",
+  "foo": {
+    "@id": "ex:inner",
+    "bar": "baz"
+  }
+}

--- a/tests/toRdf/pr40-out.nq
+++ b/tests/toRdf/pr40-out.nq
@@ -1,0 +1,2 @@
+<ex:inner> <http://example.org/other> "baz" .
+<ex:outer> <http://vocab.org/foo> <ex:inner> .


### PR DESCRIPTION
It appeared toRdf was missing a test for checking that protected terms can be overridden from property-scoped contexts.