### PR TITLE
Describe @preserve

### DIFF
--- a/index.html
+++ b/index.html
@@ -7031,6 +7031,8 @@
     <li>Clarified step <a href="#alg-inv-lang-dir">3.13</a> in the
       <a href="#inverse-context-creation">Inverse Context Creation algorithm</a>
       by moving the preceding step to <a href=#alg-inv-lang-map>3.9</a>.</li>
+    <li>Added <a href="#api-keywords" class="sectionRef"></a> to describe
+      the `preserve` keyword, which is only used for framing.</li>
   </ul>
 </section>
 <section id="ack"

--- a/index.html
+++ b/index.html
@@ -425,6 +425,21 @@
          data-oninclude="restrictReferences">
     </div>
   </section>
+  <section id="api-keywords">
+    <h2>Syntax Tokens and Keywords</h2>
+
+    <p>In addition to the <a>keywords</a> defined in the JSON-LD 1.1 Syntax specification [[JSON-LD11]],
+      this specification adds an additional <a>keyword</a> to support
+      [[[JSON-LD11-FRAMING]]] [[JSON-lD11-FRAMING]]:</p>
+
+    <dl data-sort>
+      <dt><code>@preserve</code></dt>
+      <dd>Used in an expanded document created as the result of the
+        <a data-cite="JSON-LD11-FRAMING#framing-algorithm">Framing algorithm</a>
+        to represent values that might otherwise be removed as part of the
+        <a href="#expansion-algorithm">Expansion algorithm</a>.</dd>
+    </dl>
+  </section>
 
   </section>
 


### PR DESCRIPTION
Add a keyword section and describe `@preserve`.

Fixes w3c/json-ld-syntax#332.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/426.html" title="Last updated on Mar 21, 2020, 5:55 PM UTC (fa836ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/426/0fdafb0...fa836ae.html" title="Last updated on Mar 21, 2020, 5:55 PM UTC (fa836ae)">Diff</a>