### PR TITLE
Added missing values for `@container` 

### DIFF
--- a/index.html
+++ b/index.html
@@ -6689,7 +6689,11 @@
           whose value was not one of the following <a>strings</a>:
           <code>@list</code>,
           <code>@set</code>,
-          or <code>@index</code>.</dd>
+          <code>@language</code>,
+          <code>@index</code>,
+          <span class="changed"><code>@id</code></span>,
+          <span class="changed"><code>@graph</code></span>, or
+          <span class="changed"><code>@type</code></span>.</dd>
         <dt class="changed"><dfn>invalid context entry</dfn></dt>
         <dd class="changed">An <a>entry</a> in a context is invalid due to processing mode incompatibility.</dd>
         <dt class="changed"><dfn>invalid context nullification</dfn></dt>
@@ -7013,6 +7017,8 @@
       which in turn uses it with the value `false` when recursively calling
       the <a href="#context-processing-algorithm">Context Processing algorithm</a>
       when validating a <a>scoped context</a>.</li>
+    <li>Added missing values for `@container` in the description of
+      <a data-link-for="JsonLdErrorCode">invalid container mapping</a>.</li>
     <li>Clarified step <a href="#alg-inv-lang-dir">3.13</a> in the
       <a href="#inverse-context-creation">Inverse Context Creation algorithm</a>
       by moving the preceding step to <a href=#alg-inv-lang-map>3.9</a>.</li>


### PR DESCRIPTION
in the description of _invalid container mapping_.

Fixes #424.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/427.html" title="Last updated on Mar 21, 2020, 6:04 PM UTC (66f0f60)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/427/0fdafb0...66f0f60.html" title="Last updated on Mar 21, 2020, 6:04 PM UTC (66f0f60)">Diff</a>