### PR TITLE
Verify URI resolution relative to base without trailing slash

### DIFF
--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -3170,6 +3170,48 @@ Test t0128 Two scoped context may include a shared context
 </dd>
 </dl>
 </dd>
+<dt id='t0129'>
+Test t0129 Base without trailing slash, without path
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#t0129</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>Verify URI resolution relative to base (without trailing slash, without path) according to RFC 3986</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/0129-in.jsonld'>expand/0129-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='expand/0129-out.jsonld'>expand/0129-out.jsonld</a>
+</dd>
+</dl>
+</dd>
+<dt id='t0130'>
+Test t0130 Base without trailing slash, with path
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#t0130</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>Verify URI resolution relative to base (without trailing slash, with path) according to RFC 3986</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/0130-in.jsonld'>expand/0130-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='expand/0130-out.jsonld'>expand/0130-out.jsonld</a>
+</dd>
+</dl>
+</dd>
 <dt id='tc001'>
 Test tc001 adding new term
 </dt>
@@ -4114,6 +4156,34 @@ Test tc034 Remote scoped context.
 <dt>expect</dt>
 <dd>
 <a href='expand/c034-out.jsonld'>expand/c034-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='tc035'>
+Test tc035 Term scoping with embedded contexts.
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tc035</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>Terms should make use of @vocab relative to the scope in which the term was defined.</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/c035-in.jsonld'>expand/c035-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='expand/c035-out.jsonld'>expand/c035-out.jsonld</a>
 </dd>
 <dt>Options</dt>
 <dd>

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -965,6 +965,20 @@
       "expect": "expand/0128-out.jsonld",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#t0129",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Base without trailing slash, without path",
+      "purpose": "Verify URI resolution relative to base (without trailing slash, without path) according to RFC 3986",
+      "input": "expand/0129-in.jsonld",
+      "expect": "expand/0129-out.jsonld"
+    }, {
+      "@id": "#t0130",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Base without trailing slash, with path",
+      "purpose": "Verify URI resolution relative to base (without trailing slash, without path) according to RFC 3986",
+      "input": "expand/0130-in.jsonld",
+      "expect": "expand/0130-out.jsonld"
+    }, {
       "@id": "#tc001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "adding new term",

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -975,7 +975,7 @@
       "@id": "#t0130",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "Base without trailing slash, with path",
-      "purpose": "Verify URI resolution relative to base (without trailing slash, without path) according to RFC 3986",
+      "purpose": "Verify URI resolution relative to base (without trailing slash, with path) according to RFC 3986",
       "input": "expand/0130-in.jsonld",
       "expect": "expand/0130-out.jsonld"
     }, {

--- a/tests/expand/0129-in.jsonld
+++ b/tests/expand/0129-in.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context" : {"@base": "http://example"},
+  "@id": "relative-iri",
+  "http://prop": "value"
+}

--- a/tests/expand/0129-out.jsonld
+++ b/tests/expand/0129-out.jsonld
@@ -1,0 +1,4 @@
+[{
+  "@id": "http://example/relative-iri",
+  "http://prop": [{"@value": "value"}]
+}]

--- a/tests/expand/0130-in.jsonld
+++ b/tests/expand/0130-in.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context" : {"@base": "http://example/base"},
+  "@id": "relative-iri",
+  "http://prop": "value"
+}

--- a/tests/expand/0130-out.jsonld
+++ b/tests/expand/0130-out.jsonld
@@ -1,0 +1,4 @@
+[{
+  "@id": "http://example/relative-iri",
+  "http://prop": [{"@value": "value"}]
+}]

--- a/tests/toRdf-manifest.html
+++ b/tests/toRdf-manifest.html
@@ -2223,6 +2223,34 @@ Test tc034 Remote scoped context.
 </dd>
 </dl>
 </dd>
+<dt id='tc035'>
+Test tc035 Term scoping with embedded contexts.
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#tc035</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Terms should make use of @vocab relative to the scope in which the term was defined.</dd>
+<dt>input</dt>
+<dd>
+<a href='toRdf/c035-in.jsonld'>toRdf/c035-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='toRdf/c035-out.nq'>toRdf/c035-out.nq</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
 <dt id='tdi01'>
 Test tdi01 Expand string using default and term directions
 </dt>
@@ -5635,6 +5663,62 @@ Test te128 Two scoped context may include a shared context
 <dt>expect</dt>
 <dd>
 <a href='toRdf/e128-out.nq'>toRdf/e128-out.nq</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='te129'>
+Test te129 Base without trailing slash, without path
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#te129</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Verify URI resolution relative to base (without trailing slash, without path) according to RFC 3986</dd>
+<dt>input</dt>
+<dd>
+<a href='toRdf/e129-in.jsonld'>toRdf/e129-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='toRdf/e129-out.nq'>toRdf/e129-out.nq</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt id='te130'>
+Test te130 Base without trailing slash, with path
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#te130</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Verify URI resolution relative to base (without trailing slash, with path) according to RFC 3986</dd>
+<dt>input</dt>
+<dd>
+<a href='toRdf/e130-in.jsonld'>toRdf/e130-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='toRdf/e130-out.nq'>toRdf/e130-out.nq</a>
 </dd>
 <dt>Options</dt>
 <dd>

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -1741,6 +1741,22 @@
       "expect": "toRdf/e128-out.nq",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#te129",
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ToRDFTest" ],
+      "name": "Base without trailing slash, without path",
+      "purpose": "Verify URI resolution relative to base (without trailing slash, without path) according to RFC 3986",
+      "input": "toRdf/e129-in.jsonld",
+      "expect": "toRdf/e129-out.nq",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#te130",
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ToRDFTest" ],
+      "name": "Base without trailing slash, with path",
+      "purpose": "Verify URI resolution relative to base (without trailing slash, with path) according to RFC 3986",
+      "input": "toRdf/e130-in.jsonld",
+      "expect": "toRdf/e130-out.nq",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tec01",
       "@type": [ "jld:NegativeEvaluationTest", "jld:ToRDFTest" ],
       "name": "Invalid keyword in term definition",

--- a/tests/toRdf/e129-in.jsonld
+++ b/tests/toRdf/e129-in.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": { "@base": "http://example" },
+  "@id": "relative-iri",
+  "http://prop": "value"
+}

--- a/tests/toRdf/e129-out.nq
+++ b/tests/toRdf/e129-out.nq
@@ -1,0 +1,1 @@
+<http://example/relative-iri> <http://prop> "value" .

--- a/tests/toRdf/e130-in.jsonld
+++ b/tests/toRdf/e130-in.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": { "@base": "http://example/base" },
+  "@id": "relative-iri",
+  "http://prop": "value"
+}

--- a/tests/toRdf/e130-out.nq
+++ b/tests/toRdf/e130-out.nq
@@ -1,0 +1,1 @@
+<http://example/relative-iri> <http://prop> "value" .


### PR DESCRIPTION
This came up when fixing https://github.com/jsonld-java/jsonld-java/issues/279 in https://github.com/jsonld-java/jsonld-java/pull/280, where we noticed the original issue described on [the Apache Jena list](https://lists.apache.org/thread.html/r343f27b3390dfbfd7ce9dcee4576bc532705b39d26923dfb0baf5322%40%3Cusers.jena.apache.org%3E) was not covered by the spec tests.

Relative resolution in RFC 3986 [1][2] (see `8)` in spec [3]):

- `rel` relative to `example` is `example/rel`
- `rel` relative to `example/base` is also `example/rel`

Already tested elsewhere, for clarity here, with trailing slash:

- `rel` relative to `example/base/` is `example/base/rel`

[1] https://tools.ietf.org/html/rfc3986#section-5.2
[2] https://blog.cdivilly.com/2019/02/28/uri-trailing-slashes
[3] https://w3c.github.io/json-ld-api/#algorithm-4