### PR TITLE
Various

### DIFF
--- a/common/algorithm-terms.html
+++ b/common/algorithm-terms.html
@@ -15,16 +15,11 @@
     to an <a>entry</a> in a <a>map</a> (<var>object</var>) using a specified <var>key</var>.
     The invocation may include an <var>as array</var> flag defaulting to <code>false</code>.
     <ol>
-      <li>If <var>as array</var> is <code>true</code>:
-        <ol>
-          <li>If <var>value</var> is not an <a>array</a>,
-            set it to an <a>array</a> containing <var>value</var>.</li>
-          <li>Use <a>add value</a> recursively to add
-            <var>value</var> to <var>key</var> in <var>entry</var>
-            using the default value of `false` for <var>as array</var>.</li>
-        </ol>
-      </li>
-      <li>Otherwise, if <var>value</var> is an <a>array</a>,
+      <li>If <var>as array</var> is <code>true</code>
+        and the value of <var>key</var> in <var>object</var> does not exist
+        or is not an <a>array</a>, set it to a new <a>array</a>
+        containing any original value.</li>
+      <li>If <var>value</var> is an <a>array</a>,
         then for each element <var>v</var> in <var>value</var>,
         use <a>add value</a> recursively to add <var>v</var> to <var>key</var> in <var>entry</var>.</li>
       <li>Otherwise:

--- a/common/algorithm-terms.html
+++ b/common/algorithm-terms.html
@@ -15,19 +15,32 @@
     to an <a>entry</a> in a <a>map</a> (<var>object</var>) using a specified <var>key</var>.
     The invocation may include an <var>as array</var> flag defaulting to <code>false</code>.
     <ol>
-      <li>If <var>as array</var> is <code>true</code>,
-        and <var>value</var> is not an <a>array</a>,
-        set it to an <a>array</a> containing <var>value</var>.</li>
-      <li>If <var>key</var> is not an entry in <var>object</var>,
-        add <var>value</var> as the value of <var>key</var> in <var>object</var>.</li>
-      <li>Otherwise
+      <li>If <var>as array</var> is <code>true</code>:
         <ol>
-          <li>If the value of <var>key</var> <a>entry</a> in <var>object</var> is not an <a>array</a>,
-            set it to a new <a>array</a> containing the original value.</li>
-          <li>If <var>value</var> is an <a>array</a>, concatenate <var>value</var>
-            to that <a>entry</a>.</li>
-          <li>Otherwise, append <var>value</var> to that <a>entry</a>.</li>
+          <li>If <var>value</var> is not an <a>array</a>,
+            set it to an <a>array</a> containing <var>value</var>.</li>
+          <li>Use <a>add value</a> recursively to add
+            <var>value</var> to <var>key</var> in <var>entry</var>
+            using the default value of `false` for <var>as array</var>.</li>
         </ol>
+      </li>
+      <li>Otherwise, if <var>value</var> is an <a>array</a>,
+        then for each element <var>v</var> in <var>value</var>,
+        use <a>add value</a> recursively to add <var>v</var> to <var>key</var> in <var>entry</var>.</li>
+      <li>Otherwise:
+        <ol>
+          <li>If <var>key</var> is not an entry in <var>object</var>,
+            add <var>value</var> as the value of <var>key</var> in <var>object</var>.</li>
+          <li>Otherwise
+            <ol>
+              <li>If the value of the <var>key</var> <a>entry</a> in <var>object</var> is not an <a>array</a>,
+                set it to a new <a>array</a> containing the original value.</li>
+              <li>Append <var>value</var>
+                to the value of the <var>key</var> <a>entry</a> in <var>object</var>.</li>
+            </ol>
+          </li>
+        </ol>
+      </li>
     </ol>
   </dd>
   <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-expicit-inclusion-flag">explicit inclusion flag</dfn></dt><dd>

--- a/index.html
+++ b/index.html
@@ -3515,7 +3515,7 @@
           Then, for each <var>term</var>
           in <var>compacted types</var> ordered lexicographically:
           <ol>
-            <li>If the <a>term definition</a> for <var>term</var> in <var>type-scoped context</var> has a
+            <li id="alg-compact-11_1">If the <a>term definition</a> for <var>term</var> in <var>type-scoped context</var> has a
               <a>local context</a>
               set <var>active context</var> to the result of the
               <a href="#context-processing-algorithm">Context Processing algorithm</a>,
@@ -3523,7 +3523,8 @@
               <a>local context</a> in <var>type-scoped context</var> as <var>local context</var>
               <span class="changed">
                 <var>base URL</var> from the <a>term definition</a> for <var>term</var>
-                in <var>type-scoped context</var></span>.
+                in <var>type-scoped context</var>,
+                and `false` for <var>propagate</var></span>.
             </li>
           </ol>
         </li>
@@ -7016,6 +7017,10 @@
       This simplifies calling sequences and better represents actual implementation experience.</li>
     <li>Updated step <a href="#alg-iric-value-map">4.5</a> of the <a href="#iri-compaction">IRI Compaction algorithm</a>
       to use `@index` for any value with an `@index` entry.</li>
+    <li>Update step <a href="#alg-compact-11_1">11.1</a> of the
+      <a href="#compaction-algorithm">Compaction Algorithm</a>
+      to pass `false` for <var>propagate</var> when calling the
+       <a href="#context-processing-algorithm">Context Processing algorithm</a>.</li>
     <li>Updated step <a href="#alg-compact-12_2_4">12.2.4</a> of the
       <a href="#compaction-algorithm">Compaction Algorithm</a>
       to only look for `@set` if <a>processing mode</a> is json-ld-1.1.</li>

--- a/index.html
+++ b/index.html
@@ -3568,8 +3568,9 @@
                 </li>
                 <li>Initialize <var>alias</var>
                   <span class="changed">by <a>IRI compacting</a> <var>expanded property</var></span>.</li>
-                <li class="changed">Initialize <var>as array</var>
-                  to <code>true</code> if the <a>container mapping</a> for <var>alias</var> in the
+                <li id="alg-compact-12_2_4" class="changed">Initialize <var>as array</var>
+                  to <code>true</code> if <a>processing mode</a> is `json-ld-1.1` and
+                  the <a>container mapping</a> for <var>alias</var> in the
                   <var>active context</var> includes <code>@set</code>,
                   otherwise to the negation of {{JsonLdOptions/compactArrays}}.</li>
                 <li class="changed">Use <a>add value</a> to add <var>compacted value</var>
@@ -3707,16 +3708,16 @@
                   to <code>true</code> if <var>container</var> includes <code>@set</code>,
                   or if <var>item active property</var> is <code>@graph</code> or <code>@list</code>,
                   otherwise the negation of {{JsonLdOptions/compactArrays}}.</li>
-                <li>Initialize <var>compacted item</var> to the result of using
+                <li id="alg-compact-12_8_6">Initialize <var>compacted item</var> to the result of using
                   this algorithm recursively, passing
                   <var>active context</var>,
                   <var>item active property</var> for <var>active property</var>,
-                  <var>expanded item</var> for <var>element</var> if it does
-                  not contain the <a>entry</a> <code>@list</code>
-                  <span class="changed">and is not a <a>graph object</a> containing <code>@list</code></span>,
-                  otherwise pass the value of the <a>entry</a> for <var>element</var>.
-                  <span class="changed">Along with the {{JsonLdOptions/compactArrays}}
-                    and {{JsonLdOptions/ordered}} flags</span></li>
+                  <var>expanded item</var> for <var>element</var>,
+                  <span class="changed">along with the {{JsonLdOptions/compactArrays}}
+                    and {{JsonLdOptions/ordered}} flags</span>.
+                  If <var>expanded item</var> is a <a>list object</a> or a <a>graph object</a>,
+                  use the value of the `@list` <span class="changed">or `@graph`</span> entries,
+                  respectively, for <var>element</var> instead of <var>expanded item</var>.</li>
                 <li>If <var>expanded item</var> is a <a>list object</a>:
                   <ol>
                     <li>If <var>compacted item</var> is not an <a>array</a>,
@@ -6932,7 +6933,7 @@
       expand to an <a>IRI</a> other than the expansion of the key itself.</li>
     <li>Consolidate <a>RemoteDocument</a> processing into the <a>LoadDocumentCallback</a>
       including variations on HTML processing.</li>
-    <li>The <a href="#iri-compaction">IRI compaction algorithm</a> may generate an error if the result is an
+    <li>The <a href="#iri-compaction">IRI Compaction algorithm</a> may generate an error if the result is an
       <a>IRI</a> which could be confused with a <a>compact IRI</a> in the
       <a>active context</a>.</li>
     <li>By default, all contexts are propagated when traversing <a>node objects</a>, other than
@@ -7015,8 +7016,14 @@
       but is retrieved from the <a data-lt="context-inverse">inverse context</a> field
       within an <a>active context</a>, and initialized as necessary.
       This simplifies calling sequences and better represents actual implementation experience.</li>
-    <li>Updated step <a href="#alg-iric-value-map">4.5</a> of the <a href="#iri-compaction">IRI compaction algorithm</a>
+    <li>Updated step <a href="#alg-iric-value-map">4.5</a> of the <a href="#iri-compaction">IRI Compaction algorithm</a>
       to use `@index` for any value with an `@index` entry.</li>
+    <li>Updated step <a href="#alg-compact-12_2_4">12.2.4</a> of the
+      <a href="#compaction-algorithm">Compaction Algorithm</a>
+      to only look for `@set` if <a>processing mode</a> is json-ld-1.1.</li>
+    <li>Update step <a href="#alg-compact-12_8_6">12.8.6</a> of the
+      <a href="#compaction-algorithm">Compaction Algorithm</a>
+      to clarify the value passed for <var>element</var>.</li>
     <li>Update step <a href="#alg-compact-12_8_10">12.8.10</a> of the
       <a href="#compaction-algorithm">Compaction Algorithm</a>
       to add values to <var>nest result</var> instead of <var>result</var>

--- a/index.html
+++ b/index.html
@@ -3849,11 +3849,10 @@
                         <li>Reinitialize <var>container key</var> by <a>IRI compacting</a>
                           <var>index key</var>.</li>
                         <li>Set <var>map key</var> to the first value of <var>container key</var> in <var>compacted item</var>, if any.</li>
-                        <li>If there are remaining values in <var>compacted item</var>
-                          for <var>container key</var>, set the value of
-                          <var>container key</var> in <var>compacted item</var>
-                          to those remaining values. Otherwise, remove that
-                          <a>entry</a> from <var>compacted item</var>.</li>
+                        <li id="alg-compact-12_8_9_6_3">If there are remaining values in <var>compacted item</var>
+                          for <var>container key</var>, use <a>add value</a> to
+                          add those remaining values to the <var>container key</var> in <var>compacted item</var>.
+                          Otherwise, remove that <a>entry</a> from <var>compacted item</var>.</li>
                       </ol>
                     </li>
                     <li class="changed">Otherwise, if <var>container</var> includes <code>@id</code>, set
@@ -3862,10 +3861,9 @@
                     <li class="changed">Otherwise, if <var>container</var> includes <code>@type</code>:
                       <ol>
                         <li>Set <var>map key</var> to the first value of <var>container key</var> in <var>compacted item</var>, if any.</li>
-                        <li>If there are remaining values in <var>compacted item</var>
-                          for <var>container key</var>, set the value of
-                          <var>container key</var> in <var>compacted item</var>
-                          to those remaining values.</li>
+                        <li id="alg-compact-12_8_9_8_2">If there are remaining values in <var>compacted item</var>
+                          for <var>container key</var>, use <a>add value</a> to
+                          add those remaining values to the <var>container key</var> in <var>compacted item</var>.</li>
                         <li>Otherwise, remove that <a>entry</a> from <var>compacted item</var>.</li>
                         <li>If <var>compacted item</var> contains a single <a>entry</a> with a key expanding
                           to `@id`, set <var>compacted item</var>
@@ -7024,6 +7022,10 @@
     <li>Update step <a href="#alg-compact-12_8_6">12.8.6</a> of the
       <a href="#compaction-algorithm">Compaction Algorithm</a>
       to clarify the value passed for <var>element</var>.</li>
+    <li>Update steps <a href="#alg-compact-12_8_9_6_3">12.8.9.6.3</a>
+      and <a href="#alg-compact-12_8_9_8_2">12.8.9.2.2</a> of the
+      <a href="#compaction-algorithm">Compaction Algorithm</a>
+      to invoke the <a>add value</a> macro for adding remaining values back to <var>compacted item</var>.</li>
     <li>Update step <a href="#alg-compact-12_8_10">12.8.10</a> of the
       <a href="#compaction-algorithm">Compaction Algorithm</a>
       to add values to <var>nest result</var> instead of <var>result</var>

--- a/index.html
+++ b/index.html
@@ -4010,7 +4010,7 @@
               variables will keep track of the preferred
               <a>type mapping</a> or <a>language mapping</a> for
               a <a>term</a>, based on what is compatible with <var>value</var>.</li>
-            <li class="changed">If <var>value</var> is a <a>map</a> containing an `@index` <a>entry</a> which is also a <a>map</a>,
+            <li id="alg-iric-value-map" class="changed">If <var>value</var> is a <a>map</a> containing an `@index` <a>entry</a>,
               and <var>value</var> is not a <a>graph object</a>
               then append the values <code>@index</code> and <code>@index@set</code> to <var>containers</var>.</li>
             <li>If <var>reverse</var> is <code>true</code>, set <var>type/language</var>
@@ -7015,7 +7015,8 @@
       but is retrieved from the <a data-lt="context-inverse">inverse context</a> field
       within an <a>active context</a>, and initialized as necessary.
       This simplifies calling sequences and better represents actual implementation experience.</li>
-    <li>Update step <a href="#alg-compact-12_8_9_6">12.8.9.6</a></li>
+    <li>Updated step <a href="#alg-iric-value-map">4.5</a> of the <a href="#iri-compaction">IRI compaction algorithm</a>
+      to use `@index` for any value with an `@index` entry.</li>
     <li>Update step <a href="#alg-compact-12_8_10">12.8.10</a> of the
       <a href="#compaction-algorithm">Compaction Algorithm</a>
       to add values to <var>nest result</var> instead of <var>result</var>


### PR DESCRIPTION
* Update IRI Compaction to use `@index` for any value with an `@index` entry. Fixes #434.
* Update step 12.2.4 of the Compaction Algorithm to only look for `@set` if _processing mode_ is json-ld-1.1. Update the description of the _add\_value_ macro. Fixes #437.
* Update step 12.8.6 of the Comapation Algorithm to to clarify the value passed for _element_. Fixes #436.
* Update steps 12.8.9.6.3 and 12.8.9.2.2 of the Compaction Algorithm to invoke the _add value_ macro for adding remaining values back to _compacted item_. Fixes #438.
* Update step 11.1 of the Compaction Algorithm to pass `false` for _propagate_ when calling theContext Processing algorithm. Fixes #439.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/440.html" title="Last updated on Mar 30, 2020, 5:44 PM UTC (b63a6f9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/440/d519b2c...b63a6f9.html" title="Last updated on Mar 30, 2020, 5:44 PM UTC (b63a6f9)">Diff</a>