### PR TITLE
Fix links to/from HTML manifests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -22,7 +22,7 @@ Tests driven from a top-level [manifest](manifest.jsonld) and are defined into [
   as an IRI relative to the manifest.
 
   For *NegativeEvaluationTests*, the result is a string associated with the expected error code.
-* [html](html.jsonld) tests have _input_ and _expected_ documents and an optional _context_ document.
+* [html](html-manifest.jsonld) tests have _input_ and _expected_ documents and an optional _context_ document.
   The _expected_ results can be compared using [JSON-LD object comparison](#json-ld-object-comparison) with the processor output
   after potentially remapping blank node identifiers (see below).
   Additionally, if the result is compacted and the `ordered` option is not set, result should be expanded and compared with the expanded _expected_ document also using [JSON-LD object comparison](#json-ld-object-comparison).

--- a/tests/compact-manifest.html
+++ b/tests/compact-manifest.html
@@ -28,7 +28,7 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 
 <h2>General instructions for running the JSON-LD Test suites</h2>
 
-<h3><a href="compact-manifest.jsonld">compact</a> tests have <em>input</em>, <em>expected</em> and <em>context</em> documents.</h3>
+<h3><a href="compact-manifest.html">compact</a> tests have <em>input</em>, <em>expected</em> and <em>context</em> documents.</h3>
 
 <p>The <em>expected</em> results can be compared using <a href="#json-ld-object-comparison">JSON-LD object comparison</a> with the processor output. Additionally, if the <code>ordered</code> option is not set, result should be expanded and compared with the expanded <em>expected</em> document also using <a href="#json-ld-object-comparison">JSON-LD object comparison</a>.</p>
 

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -28,7 +28,7 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 
 <h2>General instructions for running the JSON-LD Test suites</h2>
 
-<h3><a href="expand-manifest.jsonld">expand</a> tests have <em>input</em> and <em>expected</em> documents.</h3>
+<h3><a href="expand-manifest.html">expand</a> tests have <em>input</em> and <em>expected</em> documents.</h3>
 
 <p>The <em>expected</em> results can be compared using <a href="#json-ld-object-comparison">JSON-LD object comparison</a> with the processor output.</p>
 

--- a/tests/flatten-manifest.html
+++ b/tests/flatten-manifest.html
@@ -28,7 +28,7 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 
 <h2>General instructions for running the JSON-LD Test suites</h2>
 
-<h3><a href="flatten-manifest.jsonld">flatten</a> tests have <em>input</em> and <em>expected</em> documents and an optional <em>context</em> document.</h3>
+<h3><a href="flatten-manifest.html">flatten</a> tests have <em>input</em> and <em>expected</em> documents and an optional <em>context</em> document.</h3>
 
 <p>The <em>expected</em> results can be compared using <a href="#json-ld-object-comparison">JSON-LD object comparison</a> with the processor output after potentially remapping blank node identifiers (see below). Additionally, if the result is compacted and the <code>ordered</code> option is not set, result should be expanded and compared with the expanded <em>expected</em> document also using <a href="#json-ld-object-comparison">JSON-LD object comparison</a>.</p>
 

--- a/tests/html-manifest.html
+++ b/tests/html-manifest.html
@@ -28,12 +28,12 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 
 <h2>General instructions for running the JSON-LD Test suites</h2>
 
-<h3><a href="compact-manifest.jsonld">compact</a> tests have <em>input</em>, <em>expected</em> and <em>context</em> documents.</h3>
+<h3><a href="compact-manifest.html">compact</a> tests have <em>input</em>, <em>expected</em> and <em>context</em> documents.</h3>
 
 <p>The <em>expected</em> results can be compared using <a href="#json-ld-object-comparison">JSON-LD object comparison</a> with the processor output. Additionally, if the <code>ordered</code> option is not set, result should be expanded and compared with the expanded <em>expected</em> document also using <a href="#json-ld-object-comparison">JSON-LD object comparison</a>.</p>
 
 <p>For <em>NegativeEvaluationTests</em>, the result is a string associated with the expected error code.</p>
-<h3><a href="expand-manifest.jsonld">expand</a> tests have <em>input</em> and <em>expected</em> documents.</h3>
+<h3><a href="expand-manifest.html">expand</a> tests have <em>input</em> and <em>expected</em> documents.</h3>
 
 <p>The <em>expected</em> results can be compared using <a href="#json-ld-object-comparison">JSON-LD object comparison</a> with the processor output.</p>
 
@@ -41,12 +41,12 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 as an IRI relative to the manifest.</p>
 
 <p>For <em>NegativeEvaluationTests</em>, the result is a string associated with the expected error code.</p>
-<h3><a href="html.jsonld">html</a> tests have <em>input</em> and <em>expected</em> documents and an optional <em>context</em> document.</h3>
+<h3><a href="html-manifest.html">html</a> tests have <em>input</em> and <em>expected</em> documents and an optional <em>context</em> document.</h3>
 
 <p>The <em>expected</em> results can be compared using <a href="#json-ld-object-comparison">JSON-LD object comparison</a> with the processor output after potentially remapping blank node identifiers (see below). Additionally, if the result is compacted and the <code>ordered</code> option is not set, result should be expanded and compared with the expanded <em>expected</em> document also using <a href="#json-ld-object-comparison">JSON-LD object comparison</a>.</p>
 
 <p>For <em>NegativeEvaluationTests</em>, the result is a string associated with the expected error code.</p>
-<h3><a href="flatten-manifest.jsonld">flatten</a> tests have <em>input</em> and <em>expected</em> documents and an optional <em>context</em> document.</h3>
+<h3><a href="flatten-manifest.html">flatten</a> tests have <em>input</em> and <em>expected</em> documents and an optional <em>context</em> document.</h3>
 
 <p>The <em>expected</em> results can be compared using <a href="#json-ld-object-comparison">JSON-LD object comparison</a> with the processor output after potentially remapping blank node identifiers (see below). Additionally, if the result is compacted and the <code>ordered</code> option is not set, result should be expanded and compared with the expanded <em>expected</em> document also using <a href="#json-ld-object-comparison">JSON-LD object comparison</a>.</p>
 

--- a/tests/manifest.html
+++ b/tests/manifest.html
@@ -28,12 +28,12 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 
 <h2>General instructions for running the JSON-LD Test suites</h2>
 
-<h3><a href="compact-manifest.jsonld">compact</a> tests have <em>input</em>, <em>expected</em> and <em>context</em> documents.</h3>
+<h3><a href="compact-manifest.html">compact</a> tests have <em>input</em>, <em>expected</em> and <em>context</em> documents.</h3>
 
 <p>The <em>expected</em> results can be compared using <a href="#json-ld-object-comparison">JSON-LD object comparison</a> with the processor output. Additionally, if the <code>ordered</code> option is not set, result should be expanded and compared with the expanded <em>expected</em> document also using <a href="#json-ld-object-comparison">JSON-LD object comparison</a>.</p>
 
 <p>For <em>NegativeEvaluationTests</em>, the result is a string associated with the expected error code.</p>
-<h3><a href="expand-manifest.jsonld">expand</a> tests have <em>input</em> and <em>expected</em> documents.</h3>
+<h3><a href="expand-manifest.html">expand</a> tests have <em>input</em> and <em>expected</em> documents.</h3>
 
 <p>The <em>expected</em> results can be compared using <a href="#json-ld-object-comparison">JSON-LD object comparison</a> with the processor output.</p>
 
@@ -41,17 +41,17 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 as an IRI relative to the manifest.</p>
 
 <p>For <em>NegativeEvaluationTests</em>, the result is a string associated with the expected error code.</p>
-<h3><a href="html.jsonld">html</a> tests have <em>input</em> and <em>expected</em> documents and an optional <em>context</em> document.</h3>
+<h3><a href="html-manifest.html">html</a> tests have <em>input</em> and <em>expected</em> documents and an optional <em>context</em> document.</h3>
 
 <p>The <em>expected</em> results can be compared using <a href="#json-ld-object-comparison">JSON-LD object comparison</a> with the processor output after potentially remapping blank node identifiers (see below). Additionally, if the result is compacted and the <code>ordered</code> option is not set, result should be expanded and compared with the expanded <em>expected</em> document also using <a href="#json-ld-object-comparison">JSON-LD object comparison</a>.</p>
 
 <p>For <em>NegativeEvaluationTests</em>, the result is a string associated with the expected error code.</p>
-<h3><a href="flatten-manifest.jsonld">flatten</a> tests have <em>input</em> and <em>expected</em> documents and an optional <em>context</em> document.</h3>
+<h3><a href="flatten-manifest.html">flatten</a> tests have <em>input</em> and <em>expected</em> documents and an optional <em>context</em> document.</h3>
 
 <p>The <em>expected</em> results can be compared using <a href="#json-ld-object-comparison">JSON-LD object comparison</a> with the processor output after potentially remapping blank node identifiers (see below). Additionally, if the result is compacted and the <code>ordered</code> option is not set, result should be expanded and compared with the expanded <em>expected</em> document also using <a href="#json-ld-object-comparison">JSON-LD object comparison</a>.</p>
 
 <p>For <em>NegativeEvaluationTests</em>, the result is a string associated with the expected error code.</p>
-<h3><a href="remote-doc-manifest.jsonld">remote-doc</a> tests have <em>input</em> and <em>expected</em> documents.</h3>
+<h3><a href="remote-doc-manifest.html">remote-doc</a> tests have <em>input</em> and <em>expected</em> documents.</h3>
 
 <p>The <em>expected</em> results can be compared using <a href="#json-ld-object-comparison">JSON-LD object comparison</a> with the processor output.</p>
 
@@ -65,10 +65,10 @@ as an IRI relative to the manifest.</p>
 <li><em>redirectTo</em>: The HTTP <em>Content-Location</em> header value.</li>
 <li><em>httpLink</em>: The HTTP <em>Link</em> header value.</li>
 </ul>
-<h3><a href="fromRdf-manifest.jsonld">fromRdf</a> tests have <em>input</em> and <em>expected</em> documents.</h3>
+<h3><a href="fromRdf-manifest.html">fromRdf</a> tests have <em>input</em> and <em>expected</em> documents.</h3>
 
 <p>The <em>expected</em> results  can be compared using <a href="#json-ld-object-comparison">JSON-LD object comparison</a> with the processor output.</p>
-<h3><a href="toRdf-manifest.jsonld">toRdf</a> tests have <em>input</em> and <em>expected</em> documents.</h3>
+<h3><a href="toRdf-manifest.html">toRdf</a> tests have <em>input</em> and <em>expected</em> documents.</h3>
 
 <p>Some tests require the use of <a href="https://tools.ietf.org/html/draft-rundgren-json-canonicalization-scheme-05">JSON Canonicalization Scheme</a> to properly generate RDF Literals from JSON literal values. This algorithm is non-normative, but is assumed to be used to properly compare results. These tests are marked using the <code>useJCS</code> option.</p>
 

--- a/tests/remote-doc-manifest.html
+++ b/tests/remote-doc-manifest.html
@@ -28,7 +28,7 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 
 <h2>General instructions for running the JSON-LD Test suites</h2>
 
-<h3><a href="expand-manifest.jsonld">expand</a> tests have <em>input</em> and <em>expected</em> documents.</h3>
+<h3><a href="expand-manifest.html">expand</a> tests have <em>input</em> and <em>expected</em> documents.</h3>
 
 <p>The <em>expected</em> results can be compared using <a href="#json-ld-object-comparison">JSON-LD object comparison</a> with the processor output.</p>
 
@@ -36,7 +36,7 @@ comprehensive JSON-LD testing solution for developers creating JSON-LD Processor
 as an IRI relative to the manifest.</p>
 
 <p>For <em>NegativeEvaluationTests</em>, the result is a string associated with the expected error code.</p>
-<h3><a href="remote-doc-manifest.jsonld">remote-doc</a> tests have <em>input</em> and <em>expected</em> documents.</h3>
+<h3><a href="remote-doc-manifest.html">remote-doc</a> tests have <em>input</em> and <em>expected</em> documents.</h3>
 
 <p>The <em>expected</em> results can be compared using <a href="#json-ld-object-comparison">JSON-LD object comparison</a> with the processor output.</p>
 

--- a/tests/template.haml
+++ b/tests/template.haml
@@ -30,7 +30,7 @@
 
     - if manifest['sequence'].first.is_a?(String) || manifest['sequence'].any? {|te| te['@type'].include?('jld:CompactTest')}
       :markdown
-        ### [compact](compact-manifest.jsonld) tests have _input_, _expected_ and _context_ documents.
+        ### [compact](compact-manifest.html) tests have _input_, _expected_ and _context_ documents.
 
         The _expected_ results can be compared using [JSON-LD object comparison](#json-ld-object-comparison) with the processor output. Additionally, if the `ordered` option is not set, result should be expanded and compared with the expanded _expected_ document also using [JSON-LD object comparison](#json-ld-object-comparison).
 
@@ -38,7 +38,7 @@
 
     - if manifest['sequence'].first.is_a?(String) || manifest['sequence'].any? {|te| te['@type'].include?('jld:ExpandTest')}
       :markdown
-        ### [expand](expand-manifest.jsonld) tests have _input_ and _expected_ documents.
+        ### [expand](expand-manifest.html) tests have _input_ and _expected_ documents.
 
         The _expected_ results can be compared using [JSON-LD object comparison](#json-ld-object-comparison) with the processor output.
 
@@ -49,7 +49,7 @@
 
     - if manifest['sequence'].first.is_a?(String) || manifest['sequence'].any? {|te| te['@type'].include?('jld:HtmlTest')}
       :markdown
-        ### [html](html.jsonld) tests have _input_ and _expected_ documents and an optional _context_ document.
+        ### [html](html-manifest.html) tests have _input_ and _expected_ documents and an optional _context_ document.
 
         The _expected_ results can be compared using [JSON-LD object comparison](#json-ld-object-comparison) with the processor output after potentially remapping blank node identifiers (see below). Additionally, if the result is compacted and the `ordered` option is not set, result should be expanded and compared with the expanded _expected_ document also using [JSON-LD object comparison](#json-ld-object-comparison).
 
@@ -57,7 +57,7 @@
 
     - if manifest['sequence'].first.is_a?(String) || manifest['sequence'].any? {|te| te['@type'].include?('jld:FlattenTest')}
       :markdown
-        ### [flatten](flatten-manifest.jsonld) tests have _input_ and _expected_ documents and an optional _context_ document.
+        ### [flatten](flatten-manifest.html) tests have _input_ and _expected_ documents and an optional _context_ document.
 
         The _expected_ results can be compared using [JSON-LD object comparison](#json-ld-object-comparison) with the processor output after potentially remapping blank node identifiers (see below). Additionally, if the result is compacted and the `ordered` option is not set, result should be expanded and compared with the expanded _expected_ document also using [JSON-LD object comparison](#json-ld-object-comparison).
 
@@ -65,7 +65,7 @@
 
     - if manifest['sequence'].first.is_a?(String) || manifest['name'].include?('Remote')
       :markdown
-        ### [remote-doc](remote-doc-manifest.jsonld) tests have _input_ and _expected_ documents.
+        ### [remote-doc](remote-doc-manifest.html) tests have _input_ and _expected_ documents.
 
         The _expected_ results can be compared using [JSON-LD object comparison](#json-ld-object-comparison) with the processor output.
 
@@ -80,13 +80,13 @@
 
     - if manifest['sequence'].first.is_a?(String) || manifest['sequence'].any? {|te| te['@type'].include?('jld:FromRdfTest')}
       :markdown
-        ### [fromRdf](fromRdf-manifest.jsonld) tests have _input_ and _expected_ documents.
+        ### [fromRdf](fromRdf-manifest.html) tests have _input_ and _expected_ documents.
 
         The _expected_ results  can be compared using [JSON-LD object comparison](#json-ld-object-comparison) with the processor output.
 
     - if manifest['sequence'].first.is_a?(String) || manifest['sequence'].any? {|te| te['@type'].include?('jld:ToRdfTest')}
       :markdown
-        ### [toRdf](toRdf-manifest.jsonld) tests have _input_ and _expected_ documents.
+        ### [toRdf](toRdf-manifest.html) tests have _input_ and _expected_ documents.
 
         Some tests require the use of [JSON Canonicalization Scheme](https://tools.ietf.org/html/draft-rundgren-json-canonicalization-scheme-05) to properly generate RDF Literals from JSON literal values. This algorithm is non-normative, but is assumed to be used to properly compare results. These tests are marked using the `useJCS` option.
 


### PR DESCRIPTION
New version of #433.

I intentionally left the links to the JSON-LD manifests in the README, instead of pointing those to their HTML counterpart.