### PR TITLE
Json gold EARL report

### DIFF
--- a/reports/index.html
+++ b/reports/index.html
@@ -4,13 +4,13 @@
 <meta content='text/html;charset=utf-8' http-equiv='Content-Type' />
 <link href='earl.jsonld' rel='alternate' />
 <link href='https://www.w3.org/StyleSheets/TR/base' rel='stylesheet' />
-<link href='ruby-json-ld-earl.ttl' rel='related' />
-<link href='pyld-api-earl.ttl' rel='related' />
-<link href='rdf-parse.ttl' rel='related' />
 <link href='jsonld-gold-earl.ttl' rel='related' />
-<link href='guile-jsonld-earl.ttl' rel='related' />
 <link href='jsonld-streaming-serializer-earl.ttl' rel='related' />
+<link href='pyld-api-earl.ttl' rel='related' />
 <link href='jsonld-streaming-parser-earl.ttl' rel='related' />
+<link href='guile-jsonld-earl.ttl' rel='related' />
+<link href='ruby-json-ld-earl.ttl' rel='related' />
+<link href='rdf-parse.ttl' rel='related' />
 <title>
 JSON-LD 1.1 Processor Conformance
 </title>
@@ -80,8 +80,8 @@ JSON-LD 1.1 Processor Conformance
 EARL results from the JSON-LD 1.1 Test Suite
 </h2>
 <h2 id='w3c-document-28-october-2015'>
-<time class='dt-published' datetime='2020-04-04' property='dc:issued'>
-04 April 2020
+<time class='dt-published' datetime='2020-04-06' property='dc:issued'>
+06 April 2020
 </time>
 </h2>
 <dl>
@@ -11640,12 +11640,18 @@ Percentage passed out of 55 Tests
 Test
 </th>
 <th>
+<a href='#subj_2'>JSON-goLD</a>
+</th>
+<th>
 <a href='#subj_3'>JSON::LD</a>
 </th>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0001'>Test t0001: Library framing example</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11658,10 +11664,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0003'>Test t0003: reframe (null)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11674,10 +11686,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0005'>Test t0005: reframe (explicit)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11690,10 +11708,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0007'>Test t0007: input has multiple types</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11706,6 +11730,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
@@ -11714,10 +11741,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0011'>Test t0011: @embed true/false(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -11730,10 +11763,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0013'>Test t0013: Replace existing embed</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11746,10 +11785,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0015'>Test t0015: Replace deeply-nested embed</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11762,10 +11807,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0017'>Test t0017: Non-flat input</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11778,10 +11829,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0019'>Test t0019: Resources can be re-embedded again in each top-level frame match</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11794,10 +11851,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0021'>Test t0021: Blank nodes in @type(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11810,10 +11873,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0023'>Test t0023: No match on [](new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -11826,10 +11895,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0025'>Test t0025: @requireAll with missing values and @default(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11839,6 +11914,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0026'>Test t0026: explicitly excludes unframed properties (@explicit: true)(new in JSON-LD 1.1)</a>
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -11846,6 +11924,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0027'>Test t0027: non-existent framed properties create null property(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -11855,6 +11936,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0028'>Test t0028: embed matched frames with @reverse(new in JSON-LD 1.1)</a>
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -11862,6 +11946,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0029'>Test t0029: embed matched frames with reversed property(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -11871,6 +11958,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0030'>Test t0030: @embed @always/@never(new in JSON-LD 1.1)</a>
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -11879,6 +11969,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0031'>Test t0031: match none @type match(new in JSON-LD 1.1)</a>
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -11886,6 +11979,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0032'>Test t0032: single @id match(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -11898,10 +11994,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0034'>Test t0034: wildcard and match none(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -11911,6 +12013,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0035'>Test t0035: matches a deep node pattern(new in JSON-LD 1.1)</a>
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -11918,6 +12023,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0036'>Test t0036: matches exact value pattern(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -11927,6 +12035,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0037'>Test t0037: matches wildcard @value in value pattern(new in JSON-LD 1.1)</a>
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -11934,6 +12045,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0038'>Test t0038: matches wildcard @type in value pattern(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -11943,6 +12057,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0039'>Test t0039: matches wildcard @language in value pattern(new in JSON-LD 1.1)</a>
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -11950,6 +12067,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0040'>Test t0040: matches match none @type in value pattern(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -11959,6 +12079,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0041'>Test t0041: matches match none @language in value pattern(new in JSON-LD 1.1)</a>
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -11966,6 +12089,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0042'>Test t0042: matches some @value in value pattern(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -11975,6 +12101,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0043'>Test t0043: matches some @type in value pattern(new in JSON-LD 1.1)</a>
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -11983,6 +12112,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0044'>Test t0044: matches some @language in value pattern(new in JSON-LD 1.1)</a>
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -11990,6 +12122,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0045'>Test t0045: excludes non-matched values in value pattern(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -12002,10 +12137,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0047'>Test t0047: Frame default graph if outer @graph is used(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -12014,6 +12155,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0048'>Test t0048: Merge one graph and preserve another(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -12026,10 +12170,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0050'>Test t0050: Library example with named graphs(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -12038,6 +12188,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0051'>Test t0051: Compacting values of @preserve(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -12050,10 +12203,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0053'>Test t0053: @type must not include a blank node identifier(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12066,10 +12225,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0055'>Test t0055: Framing list with mixed values</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -12082,6 +12247,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
@@ -12090,10 +12258,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0058'>Test t0058: Frame matching with no matching value in list(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -12106,10 +12280,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0060'>Test t0060: @embed: @once only embeds first value with node reference(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -12119,6 +12299,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0061'>Test t0061: Matching embedded nodes with @default(new in JSON-LD 1.1)</a>
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -12126,6 +12309,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0062'>Test t0062: An array with a single value remains an array if container is @set.(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -12135,6 +12321,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0063'>Test t0063: Using @null in @default.(new in JSON-LD 1.1)</a>
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -12142,6 +12331,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0064'>Test t0064: Using @default in @type.(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -12151,6 +12343,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0065'>Test t0065: Match on value(new in JSON-LD 1.1)</a>
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -12158,6 +12353,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0066'>Test t0066: Match on value reference(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -12167,6 +12365,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0067'>Test t0067: Match on list value(new in JSON-LD 1.1)</a>
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -12175,6 +12376,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0068'>Test t0068: Merge @type from different graphs(new in JSON-LD 1.1)</a>
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -12182,6 +12386,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#teo01'>Test teo01: @embed true/false(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -12194,10 +12401,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg002'>Test tg002: Simple embed(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -12207,6 +12420,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg003'>Test tg003: Embed with direct circular reference(new in JSON-LD 1.1)</a>
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -12214,6 +12430,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg004'>Test tg004: Embed with indirect circular reference(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -12226,10 +12445,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg006'>Test tg006: Embed with nested indirect circular reference via set(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -12239,6 +12464,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg007'>Test tg007: Multi-level simple embeds(new in JSON-LD 1.1)</a>
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -12246,6 +12474,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg008'>Test tg008: A tangle of nastiness(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -12255,6 +12486,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg009'>Test tg009: Recursive property embed w/o circular reference(new in JSON-LD 1.1)</a>
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -12262,6 +12496,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg010'>Test tg010: Framing blank node unnamed graphs(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -12271,6 +12508,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tin01'>Test tin01: Basic Included array(new in JSON-LD 1.1)</a>
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -12279,6 +12519,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tin02'>Test tin02: Basic Included object(new in JSON-LD 1.1)</a>
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -12286,6 +12529,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tin03'>Test tin03: json.api example(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -12298,10 +12544,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp021'>Test tp021: Blank nodes in @type (prune bnodes)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12311,6 +12563,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp046'>Test tp046: Merge graphs if no outer @graph is used (prune bnodes)(new in JSON-LD 1.1)</a>
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -12318,6 +12573,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp049'>Test tp049: Merge one graph and deep preserve another (prune bnodes)(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -12327,6 +12585,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp050'>Test tp050: Prune blank nodes with alias of @id(new in JSON-LD 1.1)</a>
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -12334,6 +12595,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tra01'>Test tra01: @requireAll only matches if @type and other properties are present(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -12343,6 +12607,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tra02'>Test tra02: @requireAll only matches if @id and @type match(new in JSON-LD 1.1)</a>
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -12351,6 +12618,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tra03'>Test tra03: @requireAll with type and properties(new in JSON-LD 1.1)</a>
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -12358,6 +12628,9 @@ PASS
 <tr class='summary'>
 <td>
 Percentage passed out of 89 Tests
+</td>
+<td class='passed-some'>
+39.3%
 </td>
 <td class='passed-all'>
 100.0%
@@ -14531,13 +14804,13 @@ PASS
 </tr>
 <tr>
 <td>
-<a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0124'>Test t0124: IRI Resolution (4)(new in JSON-LD 1.1)</a>
+<a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0124'>Test t0124: compact IRI as @vocab(new in JSON-LD 1.1)</a>
 </td>
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
+<td class='UNTESTED'>
+UNTESTED
 </td>
 <td class='PASS'>
 PASS
@@ -17472,13 +17745,13 @@ PASS
 </tr>
 <tr>
 <td>
-<a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0124'>Test t0124: IRI Resolution (4)(new in JSON-LD 1.1)</a>
+<a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0124'>Test t0124: compact IRI as @vocab(new in JSON-LD 1.1)</a>
 </td>
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
+<td class='UNTESTED'>
+UNTESTED
 </td>
 <td class='PASS'>
 PASS
@@ -21286,7 +21559,7 @@ Percentage passed out of 442 Tests
 98.0%
 </td>
 <td class='passed-most'>
-95.5%
+95.0%
 </td>
 <td class='passed-all'>
 100.0%
@@ -22320,7 +22593,7 @@ https://github.com/digitalbazaar/pyld
 <a href='https://github.com/dlongley'>
 <span property='foaf:name'>Dave Longley</span>
 </a>
-<a href-@id='https://github.com/dlongley' href-@type='[&quot;Assertor&quot;, &quot;foaf:Person&quot;]' href-foaf:homepage='https://github.com/dlongley' href-foaf:name='Dave Longley' property='foaf:homepage'>
+<a href-@id='https://github.com/dlongley' href-@type='[&quot;foaf:Person&quot;, &quot;Assertor&quot;]' href-foaf:homepage='https://github.com/dlongley' href-foaf:name='Dave Longley' property='foaf:homepage'>
 https://github.com/dlongley
 </a>
 </div>
@@ -22401,7 +22674,7 @@ Transform RDF to JSON-LD
 <dd>
 <dl>
 <dt>Release</dt>
-<dd property='doap:release'><span property='doap:revision'>unknown</span></dd>
+<dd property='doap:release'><span property='doap:revision'>v0.3.0</span></dd>
 <dt>Programming Language</dt>
 <dd property='doap:programming-language'>Go</dd>
 <dt>Home Page</dt>
@@ -22416,7 +22689,7 @@ https://github.com/piprate/json-gold
 <a href='https://github.com/kazarena'>
 <span property='foaf:name'>Stan Nazarenko</span>
 </a>
-<a href-@id='https://github.com/kazarena' href-@type='[&quot;Assertor&quot;, &quot;foaf:Person&quot;]' href-foaf:homepage='https://github.com/kazarena' href-foaf:name='Stan Nazarenko' property='foaf:homepage'>
+<a href-@id='https://github.com/kazarena' href-@type='[&quot;foaf:Person&quot;, &quot;Assertor&quot;]' href-foaf:homepage='https://github.com/kazarena' href-foaf:name='Stan Nazarenko' property='foaf:homepage'>
 https://github.com/kazarena
 </a>
 </div>
@@ -22453,6 +22726,14 @@ Flattening
 </tr>
 <tr>
 <td>
+Framing
+</td>
+<td class='passed-some'>
+35/89 (39.3%)
+</td>
+</tr>
+<tr>
+<td>
 Remote document
 </td>
 <td class='passed-some'>
@@ -22464,7 +22745,7 @@ Remote document
 Transform JSON-LD to RDF
 </td>
 <td class='passed-most'>
-422/442 (95.5%)
+420/442 (95.0%)
 </td>
 </tr>
 <tr>
@@ -22743,25 +23024,25 @@ Individual test results used to construct this report are available here:
 </p>
 <ul>
 <li>
-<a class='source' href='ruby-json-ld-earl.ttl'>ruby-json-ld-earl.ttl</a>
-</li>
-<li>
-<a class='source' href='pyld-api-earl.ttl'>pyld-api-earl.ttl</a>
-</li>
-<li>
-<a class='source' href='rdf-parse.ttl'>rdf-parse.ttl</a>
-</li>
-<li>
 <a class='source' href='jsonld-gold-earl.ttl'>jsonld-gold-earl.ttl</a>
-</li>
-<li>
-<a class='source' href='guile-jsonld-earl.ttl'>guile-jsonld-earl.ttl</a>
 </li>
 <li>
 <a class='source' href='jsonld-streaming-serializer-earl.ttl'>jsonld-streaming-serializer-earl.ttl</a>
 </li>
 <li>
+<a class='source' href='pyld-api-earl.ttl'>pyld-api-earl.ttl</a>
+</li>
+<li>
 <a class='source' href='jsonld-streaming-parser-earl.ttl'>jsonld-streaming-parser-earl.ttl</a>
+</li>
+<li>
+<a class='source' href='guile-jsonld-earl.ttl'>guile-jsonld-earl.ttl</a>
+</li>
+<li>
+<a class='source' href='ruby-json-ld-earl.ttl'>ruby-json-ld-earl.ttl</a>
+</li>
+<li>
+<a class='source' href='rdf-parse.ttl'>rdf-parse.ttl</a>
 </li>
 </ul>
 </section>

--- a/reports/index.html
+++ b/reports/index.html
@@ -5,11 +5,12 @@
 <link href='earl.jsonld' rel='alternate' />
 <link href='https://www.w3.org/StyleSheets/TR/base' rel='stylesheet' />
 <link href='ruby-json-ld-earl.ttl' rel='related' />
-<link href='jsonld-streaming-parser-earl.ttl' rel='related' />
-<link href='jsonld-streaming-serializer-earl.ttl' rel='related' />
 <link href='pyld-api-earl.ttl' rel='related' />
-<link href='guile-jsonld-earl.ttl' rel='related' />
 <link href='rdf-parse.ttl' rel='related' />
+<link href='jsonld-gold-earl.ttl' rel='related' />
+<link href='guile-jsonld-earl.ttl' rel='related' />
+<link href='jsonld-streaming-serializer-earl.ttl' rel='related' />
+<link href='jsonld-streaming-parser-earl.ttl' rel='related' />
 <title>
 JSON-LD 1.1 Processor Conformance
 </title>
@@ -79,8 +80,8 @@ JSON-LD 1.1 Processor Conformance
 EARL results from the JSON-LD 1.1 Test Suite
 </h2>
 <h2 id='w3c-document-28-october-2015'>
-<time class='dt-published' datetime='2020-04-03' property='dc:issued'>
-03 April 2020
+<time class='dt-published' datetime='2020-04-04' property='dc:issued'>
+04 April 2020
 </time>
 </h2>
 <dl>
@@ -225,19 +226,23 @@ Test Subjects
 </li>
 <li class='tocline'>
 <span class='secno'>A.3</span>
-<a class='tocxref' href='#subj_2'>JSON::LD</a>
+<a class='tocxref' href='#subj_2'>JSON-goLD</a>
 </li>
 <li class='tocline'>
 <span class='secno'>A.4</span>
-<a class='tocxref' href='#subj_3'>jsonld-streaming-parser</a>
+<a class='tocxref' href='#subj_3'>JSON::LD</a>
 </li>
 <li class='tocline'>
 <span class='secno'>A.5</span>
-<a class='tocxref' href='#subj_4'>jsonld-streaming-serializer</a>
+<a class='tocxref' href='#subj_4'>jsonld-streaming-parser</a>
 </li>
 <li class='tocline'>
 <span class='secno'>A.6</span>
-<a class='tocxref' href='#subj_5'>rdf-parse</a>
+<a class='tocxref' href='#subj_5'>jsonld-streaming-serializer</a>
+</li>
+<li class='tocline'>
+<span class='secno'>A.7</span>
+<a class='tocxref' href='#subj_6'>rdf-parse</a>
 </li>
 </ul>
 </li>
@@ -312,12 +317,18 @@ Test
 <a href='#subj_1'>PyLD</a>
 </th>
 <th>
-<a href='#subj_2'>JSON::LD</a>
+<a href='#subj_2'>JSON-goLD</a>
+</th>
+<th>
+<a href='#subj_3'>JSON::LD</a>
 </th>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0001'>Test t0001: drop free-floating nodes</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -342,10 +353,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0003'>Test t0003: drop null and unmapped properties</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -370,10 +387,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0005'>Test t0005: @type and prefix compaction</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -398,10 +421,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0007'>Test t0007: add context</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -426,10 +455,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0009'>Test t0009: compact @id</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -454,10 +489,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0011'>Test t0011: compact date</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -482,10 +523,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0013'>Test t0013: @value with @language</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -510,10 +557,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0015'>Test t0015: best match compaction</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -538,10 +591,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0017'>Test t0017: A term mapping to null removes the mapping</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -566,10 +625,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0019'>Test t0019: Keep duplicate values in @list and @set</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -594,10 +659,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0021'>Test t0021: Compact properties and types using @vocab</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -622,10 +693,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0023'>Test t0023: prefer @vocab over compacted IRIs</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -650,10 +727,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0025'>Test t0025: Language maps</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -678,10 +761,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0027'>Test t0027: @container: @set with multiple values</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -706,10 +795,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0029'>Test t0029: Simple @index map</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -734,10 +829,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0031'>Test t0031: Compact @reverse</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -762,10 +863,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0033'>Test t0033: Compact reverse-map to reverse property</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -790,10 +897,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0035'>Test t0035: Compact @reverse node references using strings</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -818,10 +931,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0037'>Test t0037: Compact keys in @reverse using @vocab</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -846,10 +965,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0039'>Test t0039: @graph is array</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -874,10 +999,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0041'>Test t0041: index rejects term having @list</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -902,10 +1033,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0043'>Test t0043: select term over @vocab</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -930,10 +1067,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0045'>Test t0045: @id value uses relative IRI, not term</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -958,10 +1101,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0047'>Test t0047: Round-trip relative URLs</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -986,10 +1135,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0049'>Test t0049: Round tripping of lists that contain just IRIs</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1014,10 +1169,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0051'>Test t0051: Round tripping @list with scalar</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1042,10 +1203,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0053'>Test t0053: Use @type: @vocab if no @type: @id</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1070,10 +1237,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0055'>Test t0055: Round tripping @type: @vocab</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1098,10 +1271,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0057'>Test t0057: Complex round tripping @type: @vocab and @type: @id</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1126,10 +1305,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0059'>Test t0059: Term with @type: @vocab if no @type: @id</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1154,10 +1339,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0061'>Test t0061: @type: @vocab/@id with values matching either</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1182,10 +1373,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0063'>Test t0063: Compact IRI round-tripping with @type: @vocab</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1210,10 +1407,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0065'>Test t0065: Language-tagged and indexed strings with language-map</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1238,10 +1441,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0067'>Test t0067: Reverse properties with blank nodes</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1266,10 +1475,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0069'>Test t0069: Single value reverse properties with @set</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1294,10 +1509,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0071'>Test t0071: Input has multiple @contexts, output has one</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1322,10 +1543,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0073'>Test t0073: Mapped @id and @type</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1350,10 +1577,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0075'>Test t0075: Compact using relative fragment identifier</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1378,10 +1611,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0077'>Test t0077: Compact a @graph container(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1406,10 +1645,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0079'>Test t0079: Compact a @graph container having @index(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1434,10 +1679,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0081'>Test t0081: Compact a [@graph, @index] container(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1462,10 +1713,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0083'>Test t0083: [@graph, @index] does not compact graph with @id(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1490,10 +1747,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0085'>Test t0085: Compact a named graph with a [@graph, @id] container(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1518,10 +1781,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0087'>Test t0087: Compact a named graph with a [@graph, @id, @set] container(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1546,10 +1815,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0089'>Test t0089: Language map term selection with complications</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1574,10 +1849,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0091'>Test t0091: Compact input with @graph container to output without @graph container with compactArrays unset(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1602,10 +1883,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0093'>Test t0093: Compact input with [@graph, @set] container to output without [@graph, @set] container with compactArrays unset(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1630,10 +1917,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0095'>Test t0095: Relative propererty IRIs with @vocab: &#39;&#39;</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1658,10 +1951,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0097'>Test t0097: Compact [@graph, @set] container (multiple graphs)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1686,10 +1985,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0099'>Test t0099: Compact [@graph, @index, @set] container (multiple indexed objects)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1714,10 +2019,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0101'>Test t0101: Compact [@graph, @id, @set] container (multiple indexed objects)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1742,10 +2053,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0103'>Test t0103: Compact [@graph, @id] container (multiple ids and objects)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1770,10 +2087,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0105'>Test t0105: Compact @type with @container: @set using an alias of @type(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1798,10 +2121,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0107'>Test t0107: Relative propererty IRIs with @vocab: &#39;&#39;</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1826,10 +2155,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0109'>Test t0109: Compact @graph container (multiple objects)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1854,10 +2189,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc001'>Test tc001: adding new term(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1882,10 +2223,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc003'>Test tc003: property and value with different terms mapping to the same expanded property(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1910,10 +2257,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc005'>Test tc005: scoped context layers on intemediate contexts(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1938,10 +2291,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc007'>Test tc007: overriding a term(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1966,10 +2325,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc009'>Test tc009: deep @type-scoped @context does NOT affect nested nodes(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1994,10 +2359,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc011'>Test tc011: applies context for all values(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2022,10 +2393,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc013'>Test tc013: deep property-term scoped @context in @type-scoped @context affects nested nodes(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2050,10 +2427,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc015'>Test tc015: type-scoped base(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2078,10 +2461,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc017'>Test tc017: multiple type-scoped contexts are properly reverted(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2106,10 +2495,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc019'>Test tc019: type-scoped context with multiple property scoped terms(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2134,10 +2529,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc021'>Test tc021: type-scoped value mix(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2162,10 +2563,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc023'>Test tc023: composed type-scoped property-scoped contexts including @type:@vocab(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2190,10 +2597,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc025'>Test tc025: type-scoped + graph container(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2218,10 +2631,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc027'>Test tc027: @propagate: false on property-scoped context(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2246,10 +2665,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi02'>Test tdi02: use alias of @direction(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2274,10 +2699,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi04'>Test tdi04: simple language map with term direction(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2302,10 +2733,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi06'>Test tdi06: simple language map with overriding null direction(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2330,10 +2767,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#te002'>Test te002: Absolute IRI confused with Compact IRI(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2358,10 +2801,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tep05'>Test tep05: processingMode json-ld-1.0 conflicts with @version: 1.1(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2386,10 +2835,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tep07'>Test tep07: @prefix is not allowed in 1.0(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2414,10 +2869,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tep09'>Test tep09: @prefix not allowed on compact IRI term(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2442,10 +2903,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tep11'>Test tep11: @context is not allowed in 1.0(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2470,10 +2937,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tep13'>Test tep13: @container may not be @id in 1.0(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2498,10 +2971,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tep15'>Test tep15: @container may not be @graph in 1.0(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2523,6 +3002,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -2536,6 +3018,9 @@ PASS
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -2551,6 +3036,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -2564,6 +3052,9 @@ PASS
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -2579,6 +3070,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -2586,6 +3080,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs01'>Test tjs01: Compact JSON literal (boolean true)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2610,10 +3107,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs03'>Test tjs03: Compact JSON literal (double)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2638,10 +3141,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs05'>Test tjs05: Compact JSON literal (integer)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2666,10 +3175,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs07'>Test tjs07: Compact JSON literal (array)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2694,10 +3209,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs09'>Test tjs09: Compact already expanded JSON literal with aliased keys(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2722,10 +3243,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs11'>Test tjs11: Compact JSON literal (null)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2750,10 +3277,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tli01'>Test tli01: coerced @list containing an empty list(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2778,10 +3311,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tli03'>Test tli03: coerced @list containing an deep list(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2806,10 +3345,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tli05'>Test tli05: coerced @list containing mixed list values(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2834,10 +3379,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tm002'>Test tm002: Indexes to object already having an @id(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2862,10 +3413,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tm004'>Test tm004: Indexes to object already having an @type(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2890,10 +3447,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tm006'>Test tm006: Indexes using compacted @type(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2918,10 +3481,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tm008'>Test tm008: @index map with @none node definition(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2946,10 +3515,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tm010'>Test tm010: @index map with @none value using alias of @none(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2974,10 +3549,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tm012'>Test tm012: language map with no @language using alias of @none(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3002,10 +3583,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tm014'>Test tm014: id map using @none with alias(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3030,10 +3617,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tm016'>Test tm016: type map using @none with alias(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3058,10 +3651,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tm018'>Test tm018: graph id map using @none(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3086,10 +3685,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tm020'>Test tm020: node reference compacts to string value of type map(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3114,10 +3719,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tm022'>Test tm022: node reference compacts to string value of type map with @type: @vocab(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3142,10 +3753,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tn002'>Test tn002: Indexes to @nest for all properties with @nest(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3170,10 +3787,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tn004'>Test tn004: Arrays of nested values(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3198,10 +3821,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tn006'>Test tn006: Nested @container: @index(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3226,10 +3855,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tn008'>Test tn008: Nested @container: @type(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3254,10 +3889,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tn010'>Test tn010: Multiple nest aliases(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3282,6 +3923,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
@@ -3293,6 +3937,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -3300,6 +3947,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tp002'>Test tp002: Compact IRI does not use expanded term definition in 1.1(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3324,10 +3974,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tp004'>Test tp004: Compact IRIs using simple terms ending with gen-delim(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3352,10 +4008,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tp006'>Test tp006: Compact IRI uses term with definition including @prefix: true(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3380,10 +4042,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tp008'>Test tp008: Compact IRI does not use term with definition including @prefix: false(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3408,10 +4076,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tpi02'>Test tpi02: property-valued index indexes property value, instead of property (multiple values)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3436,10 +4110,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tpi04'>Test tpi04: property-valued index indexes property value, instead of property (multiple nodes)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3464,10 +4144,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tpi06'>Test tpi06: property-valued index indexes using @none if no property value does not compact to string(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3492,10 +4178,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tpr02'>Test tpr02: Check illegal overriding of protected term(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3520,10 +4212,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tpr04'>Test tpr04: Check legal overriding of protected term from property-scoped context(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3548,10 +4246,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tr001'>Test tr001: Expands and compacts to document base by default(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3576,10 +4280,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#ts001'>Test ts001: @context with single array values(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3604,10 +4314,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#ttn01'>Test ttn01: @type: @none does not compact values(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3632,10 +4348,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#ttn03'>Test ttn03: @type: @none uses arrays with @container: @set(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3656,6 +4378,9 @@ Percentage passed out of 238 Tests
 </td>
 <td class='passed-all'>
 100.0%
+</td>
+<td class='passed-most'>
+97.5%
 </td>
 <td class='passed-all'>
 100.0%
@@ -3680,12 +4405,18 @@ Test
 <a href='#subj_1'>PyLD</a>
 </th>
 <th>
-<a href='#subj_2'>JSON::LD</a>
+<a href='#subj_2'>JSON-goLD</a>
+</th>
+<th>
+<a href='#subj_3'>JSON::LD</a>
 </th>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0001'>Test t0001: drop free-floating nodes</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3710,10 +4441,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0003'>Test t0003: drop null and unmapped properties</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3738,10 +4475,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0005'>Test t0005: do not expand aliased @id/@type</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3766,10 +4509,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0007'>Test t0007: date type-coercion</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3794,10 +4543,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0009'>Test t0009: @graph with terms</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3822,10 +4577,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0011'>Test t0011: coerced @id</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3850,10 +4611,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0013'>Test t0013: expand already expanded</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3878,10 +4645,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0015'>Test t0015: collapse set of sets, keep empty lists</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3906,10 +4679,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0017'>Test t0017: @graph and @id aliased</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3934,10 +4713,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0019'>Test t0019: remove @value = null</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3962,10 +4747,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0021'>Test t0021: do not remove @graph at top-level if not only property</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3990,10 +4781,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0023'>Test t0023: Expanding list/set with coercion</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4018,10 +4815,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0025'>Test t0025: Problematic IRI expansion tests</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4046,10 +4849,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0028'>Test t0028: Use @vocab in properties and @type but not in @id</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4074,10 +4883,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0030'>Test t0030: Language maps</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4102,10 +4917,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0032'>Test t0032: Null term and @vocab</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4130,10 +4951,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0034'>Test t0034: Multiple properties expanding to the same IRI</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4158,10 +4985,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0036'>Test t0036: Expanding @index</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4186,10 +5019,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0039'>Test t0039: Using terms in a reverse-maps</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4214,10 +5053,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0041'>Test t0041: @language: null resets the default language</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4242,10 +5087,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0043'>Test t0043: Using reverse properties inside a @reverse-container</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4270,10 +5121,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0045'>Test t0045: Top-level value objects</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4298,10 +5155,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0047'>Test t0047: Free-floating values in sets and free-floating lists</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4326,10 +5189,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0049'>Test t0049: String values of reverse properties</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4354,10 +5223,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0051'>Test t0051: Expansion of keyword aliases in term definitions</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4382,10 +5257,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0053'>Test t0053: Expand absolute IRI with @type: @vocab</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4410,10 +5291,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0055'>Test t0055: Expand @vocab-relative term with @type: @vocab</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4438,10 +5325,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0057'>Test t0057: Expand relative IRI with @type: @vocab</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4466,10 +5359,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0059'>Test t0059: Reset @vocab by setting it to null</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4494,10 +5393,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0061'>Test t0061: Coercing native types to arbitrary datatypes</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4522,10 +5427,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0063'>Test t0063: Reverse property and index container</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4550,10 +5461,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0065'>Test t0065: Drop unmapped keys in reverse map</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4578,10 +5495,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0067'>Test t0067: prefix://suffix not a compact IRI</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4606,10 +5529,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0069'>Test t0069: Compact IRI as term with type mapping</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4634,10 +5563,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0072'>Test t0072: Redefine term using @vocab, not itself</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4662,10 +5597,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0074'>Test t0074: @id not first property</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4690,10 +5631,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0076'>Test t0076: base option overrides document location</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4718,10 +5665,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0078'>Test t0078: multiple reverse properties</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4746,10 +5699,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0080'>Test t0080: expand [@graph, @set] container(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4774,10 +5733,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0082'>Test t0082: expand [@graph, @index] container(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4802,10 +5767,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0084'>Test t0084: Do not expand [@graph, @index] container if value is a graph(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4830,10 +5801,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0086'>Test t0086: expand [@graph, @id, @set] container(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4858,10 +5835,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0088'>Test t0088: Do not expand native values to IRIs</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4886,10 +5869,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0090'>Test t0090: relative @base overrides base option and document location</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4914,10 +5903,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0092'>Test t0092: Various relative IRIs as properties with with @vocab: &#39;&#39;(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4942,10 +5937,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0094'>Test t0094: expand [@graph, @set] container (multiple objects)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4970,10 +5971,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0096'>Test t0096: expand [@graph, @index] container (multiple indexed objects)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4998,10 +6005,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0098'>Test t0098: Do not expand [@graph, @index] container if value is a graph (multiple objects)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5026,10 +6039,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0100'>Test t0100: expand [@graph, @id, @set] container (multiple objects)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5054,10 +6073,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0102'>Test t0102: Expand @graph container if value is a graph (multiple objects)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5082,10 +6107,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0104'>Test t0104: Creates an @graph container if value is a graph (mixed graph and object)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5110,10 +6141,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0106'>Test t0106: Do not expand [@graph, @id] container if value is a graph (mixed graph and object)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5138,10 +6175,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0108'>Test t0108: expand [@graph, @id] container (multiple ids and objects)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5166,10 +6209,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0110'>Test t0110: Various relative IRIs as properties with with relative @vocab(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5194,10 +6243,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0112'>Test t0112: Various relative IRIs as properties with with relative @vocab relative to another relative vocabulary base(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5222,10 +6277,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0114'>Test t0114: Expansion allows multiple properties expanding to @type(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5250,10 +6311,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0118'>Test t0118: Expanding a value staring with a colon does not treat that value as an IRI(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5278,10 +6345,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0120'>Test t0120: Ignore some values of @id with @, allow others.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5306,6 +6379,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
@@ -5316,6 +6392,9 @@ PASS
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -5331,6 +6410,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -5338,6 +6420,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0124'>Test t0124: compact IRI as @vocab(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5362,10 +6447,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0126'>Test t0126: A scoped context may include itself recursively (direct)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5390,10 +6481,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0128'>Test t0128: Two scoped context may include a shared context(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5418,10 +6515,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0130'>Test t0130: Base without trailing slash, with path</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5446,10 +6549,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc002'>Test tc002: overriding a term(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5474,10 +6583,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc004'>Test tc004: deep @context affects nested nodes(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5502,10 +6617,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc006'>Test tc006: adding new term(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5530,10 +6651,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc008'>Test tc008: alias of @type(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5558,10 +6685,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc010'>Test tc010: scoped context layers on intemediate contexts(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5586,10 +6719,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc012'>Test tc012: deep property-term scoped @context in @type-scoped @context affects nested nodes(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5614,10 +6753,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc014'>Test tc014: type-scoped context nullification(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5642,10 +6787,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc016'>Test tc016: type-scoped vocab(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5670,10 +6821,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc018'>Test tc018: multiple type-scoped types resolved against previous context(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5698,10 +6855,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc020'>Test tc020: type-scoped value(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5726,10 +6889,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc022'>Test tc022: type-scoped property-scoped contexts including @type:@vocab(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5754,10 +6923,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc024'>Test tc024: type-scoped + property-scoped + values evaluates against previous context(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5782,10 +6957,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc026'>Test tc026: @propagate: true on type-scoped context(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5810,10 +6991,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc028'>Test tc028: @propagate: false on embedded context(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5838,10 +7025,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc030'>Test tc030: @propagate must be boolean valued(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5863,6 +7056,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='UNTESTED'>
+UNTESTED
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -5876,6 +7072,9 @@ PASS
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -5891,6 +7090,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -5898,6 +7100,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc034'>Test tc034: Remote scoped context.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5922,10 +7127,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi01'>Test tdi01: Expand string using default and term directions(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5950,10 +7161,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi03'>Test tdi03: expand list values with @direction(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5978,10 +7195,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi05'>Test tdi05: simple language mapwith overriding term direction(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6006,10 +7229,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi07'>Test tdi07: simple language map with mismatching term direction(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6034,10 +7263,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi09'>Test tdi09: @direction is incompatible with @type(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6062,6 +7297,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
@@ -6073,6 +7311,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -6080,6 +7321,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tem01'>Test tem01: Invalid container mapping(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6104,10 +7348,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ten02'>Test ten02: @nest MUST NOT have a boolen value(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6132,10 +7382,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ten04'>Test ten04: @nest MUST NOT have a value object value(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6160,10 +7416,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ten06'>Test ten06: does not allow @nest with @reverse(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6188,10 +7450,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tep03'>Test tep03: @version must be 1.1(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6216,10 +7484,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter04'>Test ter04: Error dereferencing a remote context</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6244,10 +7518,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter06'>Test ter06: Invalid local context</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6272,10 +7552,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter08'>Test ter08: Invalid vocab mapping</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6300,10 +7586,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter10'>Test ter10: Cyclic IRI mapping</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6328,10 +7620,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter12'>Test ter12: Invalid type mapping (not a string)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6356,10 +7654,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter14'>Test ter14: Invalid reverse property (contains @id)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6384,10 +7688,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter17'>Test ter17: Invalid reverse property (invalid @container)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6412,10 +7722,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter19'>Test ter19: Invalid keyword alias (@context)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6440,10 +7756,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter21'>Test ter21: Invalid container mapping(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6468,10 +7790,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter23'>Test ter23: Invalid IRI mapping (relative IRI in @type)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6496,10 +7824,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter26'>Test ter26: Colliding keywords</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6524,10 +7858,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter28'>Test ter28: Invalid type value</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6552,10 +7892,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter30'>Test ter30: Invalid language-tagged string</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6580,10 +7926,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter33'>Test ter33: Invalid @reverse value</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6608,10 +7960,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter35'>Test ter35: Invalid language map value</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6636,10 +7994,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter37'>Test ter37: Invalid value object (unexpected keyword)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6664,10 +8028,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter39'>Test ter39: Invalid language-tagged value</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6692,10 +8062,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter41'>Test ter41: Invalid set or list object</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6720,10 +8096,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter43'>Test ter43: Term definition with @id: @type(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6748,10 +8130,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter48'>Test ter48: Invalid term as relative IRI(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6776,10 +8164,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter50'>Test ter50: Invalid reverse id</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6804,6 +8198,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
@@ -6814,6 +8211,9 @@ PASS
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -6832,10 +8232,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tes01'>Test tes01: Using an array value for @context is illegal in JSON-LD 1.0(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6860,10 +8266,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tin01'>Test tin01: Basic Included array(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6888,10 +8300,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tin03'>Test tin03: Multiple properties mapping to @included are folded together(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6916,10 +8334,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tin05'>Test tin05: Property value with @included(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6944,10 +8368,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tin07'>Test tin07: Error if @included value is a string(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6972,10 +8402,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tin09'>Test tin09: Error if @included value is a list object(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7000,10 +8436,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs02'>Test tjs02: Expand JSON literal (boolean false)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7028,10 +8470,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs04'>Test tjs04: Expand JSON literal (double-zero)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7056,10 +8504,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs06'>Test tjs06: Expand JSON literal (object)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7084,10 +8538,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs08'>Test tjs08: Expand JSON literal with array canonicalization(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7112,10 +8572,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs10'>Test tjs10: Expand JSON literal with structural canonicalization(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7140,10 +8606,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs12'>Test tjs12: Expand JSON literal with value canonicalization(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7168,10 +8640,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs14'>Test tjs14: Expand JSON literal without expanding contents(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7196,10 +8674,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs16'>Test tjs16: Expand JSON literal aleady in expanded form with aliased keys(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7224,10 +8708,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs18'>Test tjs18: Expand JSON literal (null)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7252,10 +8742,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs20'>Test tjs20: Expand JSON literal with aliased @value(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7280,10 +8776,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs22'>Test tjs22: Expand JSON literal (null) aleady in expanded form.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7308,10 +8810,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tl001'>Test tl001: Language map with null value(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7336,10 +8844,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tli02'>Test tli02: @list containing empty @list(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7364,10 +8878,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tli04'>Test tli04: @list containing empty @list (with coercion)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7392,10 +8912,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tli06'>Test tli06: coerced @list containing an empty array(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7420,10 +8946,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tli08'>Test tli08: coerced @list containing deep empty arrays(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7448,10 +8980,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tli10'>Test tli10: coerced @list containing mixed list values(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7476,10 +9014,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tm002'>Test tm002: Retains @id in object already having an @id(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7504,10 +9048,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tm004'>Test tm004: Prepends @type in object already having an @type(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7532,10 +9082,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tm006'>Test tm006: Adds vocabulary expanded @type to object(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7560,10 +9116,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tm008'>Test tm008: When type is in a type map(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7588,10 +9150,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tm010'>Test tm010: language map with alias of @none(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7616,10 +9184,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tm012'>Test tm012: type map with alias of @none(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7644,10 +9218,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tm014'>Test tm014: graph index map with alias @none(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7672,10 +9252,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tm016'>Test tm016: graph id index map with aliased @none(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7700,10 +9286,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tm018'>Test tm018: string value of type map expands to node reference with @type: @id(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7728,10 +9320,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tm020'>Test tm020: string value of type map must not be a literal(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7756,10 +9354,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tn002'>Test tn002: Expands input using aliased @nest(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7784,10 +9388,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tn004'>Test tn004: Appends nested values from all @nest aliases(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7812,10 +9422,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tn006'>Test tn006: Arrays of nested values(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7840,10 +9456,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tn008'>Test tn008: Multiple keys may mapping to @type when nesting(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7868,10 +9490,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tp002'>Test tp002: @version setting [1.0, 1.1, 1.0](new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7896,10 +9524,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tp004'>Test tp004: @version setting [1.1, 1.0, 1.1](new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7924,10 +9558,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi02'>Test tpi02: error if @container does not include @index for property-valued index(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7952,10 +9592,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi04'>Test tpi04: error if @index is not a string for property-valued index(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7980,10 +9626,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi06'>Test tpi06: property-valued index expands to property value, instead of @index (value)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8008,10 +9660,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi08'>Test tpi08: property-valued index expands to property value, instead of @index (node)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8036,10 +9694,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi10'>Test tpi10: property-valued index does not output property for @none(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8064,10 +9728,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr01'>Test tpr01: Protect a term(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8092,10 +9762,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr03'>Test tpr03: Protect all terms in context(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8120,10 +9796,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr05'>Test tpr05: Clear active context with protected terms from an embedded context(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8148,10 +9830,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr08'>Test tpr08: Term with protected scoped context.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8176,10 +9864,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr10'>Test tpr10: Simple protected and unprotected terms.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8204,10 +9898,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr12'>Test tpr12: Scoped context fail to override protected term.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8232,10 +9932,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr14'>Test tpr14: Clear protection with null context.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8260,10 +9966,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr16'>Test tpr16: Override protected terms after null.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8288,10 +10000,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr18'>Test tpr18: Fail to override protected terms with type+null+ctx.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8316,10 +10034,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr20'>Test tpr20: Fail with mix of protected and unprotected terms with type+null+ctx.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8344,10 +10068,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr22'>Test tpr22: Check legal overriding of type-scoped protected term from nested node.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8372,10 +10102,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr24'>Test tpr24: Allows redefinition of protected prefix term with same definition.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8400,10 +10136,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr26'>Test tpr26: Fails on redefinition of terms with scoped contexts using different definitions.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8428,6 +10170,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
@@ -8439,6 +10184,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -8446,6 +10194,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr29'>Test tpr29: Does not expand a Compact IRI using a non-prefix term.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8470,10 +10221,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr31'>Test tpr31: Protected keyword aliases cannot be overridden.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8498,10 +10255,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr33'>Test tpr33: Fails if trying to declare a keyword alias as prefix.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8526,10 +10289,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr35'>Test tpr35: Ignores a non-keyword term starting with &#39;@&#39; (with @vocab)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8554,10 +10323,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr37'>Test tpr37: Ignores a term mapping to a value in the form of a keyword (with @vocab).(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8579,6 +10354,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -8593,6 +10371,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -8600,6 +10381,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr40'>Test tpr40: Protected terms and property-scoped contexts(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8624,10 +10408,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tso02'>Test tso02: @import must be a string(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8652,10 +10442,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tso05'>Test tso05: @propagate: true on type-scoped context with @import(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8680,10 +10476,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tso07'>Test tso07: Protect all terms in sourced context(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8708,10 +10510,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tso09'>Test tso09: Override @vocab defined in sourced context(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8736,10 +10544,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tso11'>Test tso11: Override protected terms in sourced context(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8764,10 +10578,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tso13'>Test tso13: @import can only reference a single context(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8792,10 +10612,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ttn02'>Test ttn02: @type: @none expands strings as value objects(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8816,6 +10642,9 @@ Percentage passed out of 366 Tests
 </td>
 <td class='passed-all'>
 100.0%
+</td>
+<td class='passed-most'>
+97.3%
 </td>
 <td class='passed-all'>
 100.0%
@@ -8840,12 +10669,18 @@ Test
 <a href='#subj_1'>PyLD</a>
 </th>
 <th>
-<a href='#subj_2'>JSON::LD</a>
+<a href='#subj_2'>JSON-goLD</a>
+</th>
+<th>
+<a href='#subj_3'>JSON::LD</a>
 </th>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0001'>Test t0001: drop free-floating nodes</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8870,10 +10705,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0003'>Test t0003: drop null and unmapped properties</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8898,10 +10739,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0005'>Test t0005: do not expand aliased @id/@type</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8926,10 +10773,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0007'>Test t0007: date type-coercion</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8954,10 +10807,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0009'>Test t0009: @graph with terms</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8982,10 +10841,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0011'>Test t0011: coerced @id</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9010,10 +10875,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0013'>Test t0013: flatten already expanded</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9038,10 +10909,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0016'>Test t0016: context reset</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9066,10 +10943,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0018'>Test t0018: override default @language</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9094,10 +10977,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0020'>Test t0020: do not remove @graph if not at top-level</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9122,10 +11011,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0022'>Test t0022: flatten value with default language</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9150,10 +11045,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0024'>Test t0024: Multiple contexts</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9178,10 +11079,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0027'>Test t0027: Duplicate values in @list and @set</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9206,10 +11113,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0030'>Test t0030: Language maps</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9234,10 +11147,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0032'>Test t0032: Null term and @vocab</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9262,10 +11181,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0034'>Test t0034: Multiple properties expanding to the same IRI</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9290,10 +11215,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0036'>Test t0036: Flattening @index</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9318,10 +11249,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0039'>Test t0039: Using terms in a reverse-maps</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9346,10 +11283,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0041'>Test t0041: Free-floating sets and lists</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9374,10 +11317,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0043'>Test t0043: Sample test manifest extract</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9402,10 +11351,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0045'>Test t0045: Blank nodes with reverse properties</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9430,10 +11385,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0047'>Test t0047: Flatten using relative fragment identifier properly joins to base</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9458,10 +11419,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0049'>Test t0049: context with JavaScript Object property names</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9486,10 +11453,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#tin01'>Test tin01: Basic Included array(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9514,10 +11487,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#tin03'>Test tin03: Multiple properties mapping to @included are folded together(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9542,10 +11521,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#tin05'>Test tin05: Property value with @included(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9570,10 +11555,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#tli01'>Test tli01: @list containing an deep list(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9598,10 +11589,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#tli03'>Test tli03: @list containing mixed list values(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9626,6 +11623,9 @@ Percentage passed out of 55 Tests
 <td class='passed-all'>
 100.0%
 </td>
+<td class='passed-all'>
+100.0%
+</td>
 </tr>
 </table>
 </section>
@@ -9640,7 +11640,7 @@ Percentage passed out of 55 Tests
 Test
 </th>
 <th>
-<a href='#subj_2'>JSON::LD</a>
+<a href='#subj_3'>JSON::LD</a>
 </th>
 </tr>
 <tr>
@@ -10382,10 +12382,13 @@ Test
 <a href='#subj_1'>PyLD</a>
 </th>
 <th>
-<a href='#subj_2'>JSON::LD</a>
+<a href='#subj_2'>JSON-goLD</a>
 </th>
 <th>
-<a href='#subj_5'>rdf-parse</a>
+<a href='#subj_3'>JSON::LD</a>
+</th>
+<th>
+<a href='#subj_6'>rdf-parse</a>
 </th>
 </tr>
 <tr>
@@ -10394,6 +12397,9 @@ Test
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='FAIL'>
 FAIL
@@ -10415,6 +12421,9 @@ PASS
 <td class='FAIL'>
 FAIL
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -10428,6 +12437,9 @@ UNTESTED
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='FAIL'>
 FAIL
@@ -10449,6 +12461,9 @@ PASS
 <td class='FAIL'>
 FAIL
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -10462,6 +12477,9 @@ UNTESTED
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='FAIL'>
 FAIL
@@ -10483,6 +12501,9 @@ PASS
 <td class='FAIL'>
 FAIL
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -10500,6 +12521,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -10513,6 +12537,9 @@ UNTESTED
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='FAIL'>
 FAIL
@@ -10534,6 +12561,9 @@ UNTESTED
 <td class='FAIL'>
 FAIL
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -10550,6 +12580,9 @@ PASS
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -10568,6 +12601,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -10585,6 +12621,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -10598,6 +12637,9 @@ UNTESTED
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='FAIL'>
 FAIL
@@ -10619,6 +12661,9 @@ UNTESTED
 <td class='FAIL'>
 FAIL
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -10632,6 +12677,9 @@ UNTESTED
 </td>
 <td class='UNTESTED'>
 UNTESTED
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='FAIL'>
 FAIL
@@ -10653,6 +12701,9 @@ CANTTELL
 <td class='FAIL'>
 FAIL
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -10666,6 +12717,9 @@ UNTESTED
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='FAIL'>
 FAIL
@@ -10687,6 +12741,9 @@ PASS
 <td class='FAIL'>
 FAIL
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -10697,6 +12754,9 @@ UNTESTED
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/html-manifest#te020'>Test te020: Expands embedded JSON-LD script element relative to HTML base(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='FAIL'>
 FAIL
@@ -10721,6 +12781,9 @@ FAIL
 <td class='FAIL'>
 FAIL
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -10734,6 +12797,9 @@ UNTESTED
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='FAIL'>
 FAIL
@@ -10755,6 +12821,9 @@ PASS
 <td class='FAIL'>
 FAIL
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -10768,6 +12837,9 @@ UNTESTED
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='FAIL'>
 FAIL
@@ -10789,6 +12861,9 @@ PASS
 <td class='FAIL'>
 FAIL
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -10806,6 +12881,9 @@ PASS
 <td class='FAIL'>
 FAIL
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -10816,6 +12894,9 @@ UNTESTED
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/html-manifest#tf001'>Test tf001: Flattens embedded JSON-LD script element(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='FAIL'>
 FAIL
@@ -10840,6 +12921,9 @@ FAIL
 <td class='FAIL'>
 FAIL
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -10857,6 +12941,9 @@ PASS
 <td class='FAIL'>
 FAIL
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -10867,6 +12954,9 @@ UNTESTED
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/html-manifest#tf004'>Test tf004: Flattens all script elements by default(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='FAIL'>
 FAIL
@@ -10891,6 +12981,9 @@ INAPPLICABLE
 <td class='FAIL'>
 FAIL
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -10904,6 +12997,9 @@ PASS
 </td>
 <td class='INAPPLICABLE'>
 INAPPLICABLE
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='FAIL'>
 FAIL
@@ -10925,6 +13021,9 @@ INAPPLICABLE
 <td class='FAIL'>
 FAIL
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -10938,6 +13037,9 @@ PASS
 </td>
 <td class='INAPPLICABLE'>
 INAPPLICABLE
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='FAIL'>
 FAIL
@@ -10959,6 +13061,9 @@ INAPPLICABLE
 <td class='FAIL'>
 FAIL
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -10972,6 +13077,9 @@ PASS
 </td>
 <td class='INAPPLICABLE'>
 INAPPLICABLE
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='FAIL'>
 FAIL
@@ -10993,6 +13101,9 @@ INAPPLICABLE
 <td class='FAIL'>
 FAIL
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -11006,6 +13117,9 @@ PASS
 </td>
 <td class='INAPPLICABLE'>
 INAPPLICABLE
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='FAIL'>
 FAIL
@@ -11027,6 +13141,9 @@ INAPPLICABLE
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -11043,6 +13160,9 @@ INAPPLICABLE
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -11061,6 +13181,9 @@ INAPPLICABLE
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -11074,6 +13197,9 @@ PASS
 </td>
 <td class='INAPPLICABLE'>
 INAPPLICABLE
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='FAIL'>
 FAIL
@@ -11095,6 +13221,9 @@ INAPPLICABLE
 <td class='FAIL'>
 FAIL
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -11108,6 +13237,9 @@ PASS
 </td>
 <td class='INAPPLICABLE'>
 INAPPLICABLE
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='FAIL'>
 FAIL
@@ -11129,6 +13261,9 @@ INAPPLICABLE
 <td class='FAIL'>
 FAIL
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -11142,6 +13277,9 @@ PASS
 </td>
 <td class='INAPPLICABLE'>
 INAPPLICABLE
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='FAIL'>
 FAIL
@@ -11163,6 +13301,9 @@ INAPPLICABLE
 <td class='FAIL'>
 FAIL
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -11176,6 +13317,9 @@ PASS
 </td>
 <td class='INAPPLICABLE'>
 INAPPLICABLE
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='FAIL'>
 FAIL
@@ -11197,6 +13341,9 @@ INAPPLICABLE
 <td class='FAIL'>
 FAIL
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -11210,6 +13357,9 @@ PASS
 </td>
 <td class='INAPPLICABLE'>
 INAPPLICABLE
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='FAIL'>
 FAIL
@@ -11230,6 +13380,9 @@ Percentage passed out of 49 Tests
 </td>
 <td class='passed-some'>
 14.3%
+</td>
+<td class='passed-some'>
+0.0%
 </td>
 <td class='passed-all'>
 100.0%
@@ -11257,12 +13410,18 @@ Test
 <a href='#subj_1'>PyLD</a>
 </th>
 <th>
-<a href='#subj_2'>JSON::LD</a>
+<a href='#subj_2'>JSON-goLD</a>
+</th>
+<th>
+<a href='#subj_3'>JSON::LD</a>
 </th>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0001'>Test t0001: load JSON-LD document</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11287,10 +13446,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0003'>Test t0003: load JSON document with extension-type</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11315,6 +13480,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
@@ -11325,6 +13493,9 @@ PASS
 </td>
 <td class='FAIL'>
 FAIL
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11343,6 +13514,9 @@ FAIL
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
@@ -11357,10 +13531,16 @@ FAIL
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0008'>Test t0008: Non-existant file (404)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11385,6 +13565,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
@@ -11395,6 +13578,9 @@ PASS
 </td>
 <td class='FAIL'>
 FAIL
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11413,6 +13599,9 @@ FAIL
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
@@ -11427,6 +13616,9 @@ FAIL
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
@@ -11434,6 +13626,9 @@ PASS
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='FAIL'>
 FAIL
@@ -11452,6 +13647,9 @@ PASS
 <td class='FAIL'>
 FAIL
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -11459,6 +13657,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#tla02'>Test tla02: Does not redirect if type is application/ld+json</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11483,10 +13684,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#tla04'>Test tla04: Does not redirect if type is application/json</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11508,6 +13715,9 @@ PASS
 <td class='FAIL'>
 FAIL
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -11521,6 +13731,9 @@ Percentage passed out of 18 Tests
 </td>
 <td class='passed-some'>
 50.0%
+</td>
+<td class='passed-some'>
+83.3%
 </td>
 <td class='passed-all'>
 100.0%
@@ -11542,15 +13755,21 @@ Test
 <a href='#subj_1'>PyLD</a>
 </th>
 <th>
-<a href='#subj_2'>JSON::LD</a>
+<a href='#subj_2'>JSON-goLD</a>
 </th>
 <th>
-<a href='#subj_3'>jsonld-streaming-parser</a>
+<a href='#subj_3'>JSON::LD</a>
+</th>
+<th>
+<a href='#subj_4'>jsonld-streaming-parser</a>
 </th>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0001'>Test t0001: Plain literal with URIs</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11575,10 +13794,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0003'>Test t0003: Default subject is BNode</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11603,10 +13828,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0005'>Test t0005: Extended character set literal</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11631,10 +13862,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0007'>Test t0007: Tests &#39;a&#39; generates rdf:type and object is implicit IRI</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11659,10 +13896,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0009'>Test t0009: Test using an empty suffix</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11687,10 +13930,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0011'>Test t0011: Test object processing defines object with implicit BNode</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11715,10 +13964,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0013'>Test t0013: Creation of an empty list</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11743,10 +13998,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0015'>Test t0015: Creation of a list with multiple elements</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11771,10 +14032,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0017'>Test t0017: Relative IRI expands relative resource location</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11799,10 +14066,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0019'>Test t0019: Test type coercion to anyURI</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11827,10 +14100,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0022'>Test t0022: Test coercion of double value</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11855,10 +14134,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0024'>Test t0024: Test coercion of boolean value</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11883,10 +14168,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0026'>Test t0026: Test creation of multiple types</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11911,10 +14202,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0028'>Test t0028: Simple named graph</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11939,10 +14236,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0030'>Test t0030: top-level graph with string subject reference</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11967,10 +14270,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0032'>Test t0032: @context reordering</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11995,10 +14304,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0034'>Test t0034: context properties reordering</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12023,10 +14338,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0036'>Test t0036: Use nodeMapGeneration bnode labels</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12051,10 +14372,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0114'>Test t0114: Dataset with a IRI named graph</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12079,10 +14406,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0116'>Test t0116: Dataset from node with embedded named graph</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12107,10 +14440,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0119'>Test t0119: Blank nodes with reverse properties</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12129,6 +14468,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='UNTESTED'>
+UNTESTED
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -12142,6 +14484,9 @@ PASS
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='UNTESTED'>
+UNTESTED
 </td>
 <td class='PASS'>
 PASS
@@ -12157,6 +14502,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='UNTESTED'>
+UNTESTED
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -12170,6 +14518,9 @@ PASS
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='UNTESTED'>
+UNTESTED
 </td>
 <td class='PASS'>
 PASS
@@ -12191,10 +14542,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
-<a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0125'>Test t0125: IRI Resolution (5)(new in JSON-LD 1.1)</a>
+<a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0125'>Test t0125: term as @vocab(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12213,6 +14570,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='UNTESTED'>
+UNTESTED
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -12226,6 +14586,9 @@ PASS
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='UNTESTED'>
+UNTESTED
 </td>
 <td class='PASS'>
 PASS
@@ -12241,6 +14604,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='UNTESTED'>
+UNTESTED
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -12254,6 +14620,9 @@ PASS
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='UNTESTED'>
+UNTESTED
 </td>
 <td class='PASS'>
 PASS
@@ -12269,6 +14638,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='UNTESTED'>
+UNTESTED
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -12282,6 +14654,9 @@ PASS
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='UNTESTED'>
+UNTESTED
 </td>
 <td class='PASS'>
 PASS
@@ -12297,6 +14672,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='UNTESTED'>
+UNTESTED
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -12307,6 +14685,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc001'>Test tc001: adding new term(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12331,10 +14712,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc003'>Test tc003: property and value with different terms mapping to the same expanded property(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12359,10 +14746,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc005'>Test tc005: scoped context layers on intemediate contexts(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12387,10 +14780,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc007'>Test tc007: overriding a term(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12415,10 +14814,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc009'>Test tc009: deep @type-scoped @context does NOT affect nested nodes(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12443,10 +14848,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc011'>Test tc011: orders @type terms when applying scoped contexts(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12471,10 +14882,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc013'>Test tc013: type maps use scoped context from type index and not scoped context from containing(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12499,10 +14916,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc015'>Test tc015: type-scoped base(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12527,10 +14950,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc017'>Test tc017: multiple type-scoped contexts are properly reverted(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12555,10 +14984,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc019'>Test tc019: type-scoped context with multiple property scoped terms(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12583,10 +15018,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc021'>Test tc021: type-scoped value mix(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12611,10 +15052,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc023'>Test tc023: composed type-scoped property-scoped contexts including @type:@vocab(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12639,10 +15086,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc025'>Test tc025: type-scoped + graph container(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12667,10 +15120,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc027'>Test tc027: @propagate: false on property-scoped context(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12695,10 +15154,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc029'>Test tc029: @propagate is invalid in 1.0(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12723,6 +15188,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
@@ -12730,6 +15198,9 @@ PASS
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='UNTESTED'>
+UNTESTED
 </td>
 <td class='PASS'>
 PASS
@@ -12745,6 +15216,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -12759,6 +15233,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -12769,6 +15246,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc034'>Test tc034: Remote scoped context.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12793,10 +15273,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi01'>Test tdi01: Expand string using default and term directions(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12821,10 +15307,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi03'>Test tdi03: expand list values with @direction(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12849,10 +15341,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi05'>Test tdi05: simple language mapwith overriding term direction(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12877,10 +15375,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi07'>Test tdi07: simple language map with mismatching term direction(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12905,10 +15409,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi09'>Test tdi09: rdfDirection: i18n-datatype with direction and no language(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12933,6 +15443,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
@@ -12940,6 +15453,9 @@ PASS
 </td>
 <td class='FAIL'>
 FAIL
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12961,10 +15477,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te001'>Test te001: drop free-floating nodes</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12989,10 +15511,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te003'>Test te003: drop null and unmapped properties</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13017,10 +15545,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te005'>Test te005: do not expand aliased @id/@type</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13045,10 +15579,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te007'>Test te007: date type-coercion</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13073,10 +15613,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te009'>Test te009: @graph with terms</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13101,10 +15647,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te011'>Test te011: coerced @id</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13129,10 +15681,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te013'>Test te013: expand already expanded</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13157,10 +15715,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te016'>Test te016: context reset</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13185,10 +15749,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te018'>Test te018: override default @language</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13213,10 +15783,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te020'>Test te020: do not remove @graph if not at top-level</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13241,10 +15817,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te022'>Test te022: expand value with default language</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13269,10 +15851,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te024'>Test te024: Multiple contexts</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13297,10 +15885,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te027'>Test te027: Keep duplicate values in @list and @set</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13325,10 +15919,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te029'>Test te029: Relative IRIs</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13353,10 +15953,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te031'>Test te031: type-coercion of native types</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13381,10 +15987,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te033'>Test te033: Using @vocab with with type-coercion</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13409,10 +16021,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te035'>Test te035: Language maps with @vocab, default language, and colliding property</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13437,10 +16055,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te037'>Test te037: Expanding @reverse</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13465,10 +16089,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te040'>Test te040: language and index expansion on non-objects</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13493,10 +16123,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te042'>Test te042: Expanding reverse properties</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13521,10 +16157,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te044'>Test te044: Ensure index maps use language mapping</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13549,10 +16191,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te046'>Test te046: Free-floating nodes are removed</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13577,10 +16225,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te048'>Test te048: Terms are ignored in @id</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13605,10 +16259,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te050'>Test te050: Term definitions with prefix separate from prefix definitions</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13633,10 +16293,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te052'>Test te052: @vocab-relative IRIs in term definitions</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13661,10 +16327,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te054'>Test te054: Expand term with @type: @vocab</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13689,10 +16361,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te056'>Test te056: Use terms with @type: @vocab but not with @type: @id</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13717,10 +16395,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te058'>Test te058: Expand compact IRI with @type: @vocab</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13745,10 +16429,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te060'>Test te060: Overwrite document base with @base and reset it again</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13773,10 +16463,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te062'>Test te062: Various relative IRIs with with @base</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13801,10 +16497,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te064'>Test te064: Expand reverse property whose values are unlabeled blank nodes</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13829,10 +16531,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te066'>Test te066: Use @vocab to expand keys in reverse-maps</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13857,10 +16565,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te068'>Test te068: _::sufffix not a compact IRI</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13885,10 +16599,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te070'>Test te070: Redefine compact IRI with itself</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13913,10 +16633,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te073'>Test te073: @context not first property</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13941,6 +16667,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
@@ -13955,10 +16684,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te076'>Test te076: base option overrides document location</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13983,10 +16718,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te078'>Test te078: multiple reverse properties</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14011,10 +16752,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te080'>Test te080: expand [@graph, @set] container(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14039,10 +16786,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te082'>Test te082: expand [@graph, @index] container(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14067,10 +16820,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te084'>Test te084: Do not expand [@graph, @index] container if value is a graph(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14095,10 +16854,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te086'>Test te086: expand [@graph, @id, @set] container(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14123,10 +16888,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te088'>Test te088: Do not expand native values to IRIs</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14151,10 +16922,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te090'>Test te090: relative @base overrides base option and document location</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14179,10 +16956,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te092'>Test te092: Various relative IRIs as properties with with @vocab: &#39;&#39;(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14207,10 +16990,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te094'>Test te094: expand [@graph, @set] container (multiple objects)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14235,10 +17024,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te096'>Test te096: expand [@graph, @index] container (multiple indexed objects)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14263,10 +17058,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te098'>Test te098: Do not expand [@graph, @index] container if value is a graph (multiple objects)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14291,10 +17092,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te100'>Test te100: expand [@graph, @id, @set] container (multiple objects)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14319,10 +17126,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te102'>Test te102: Expand @graph container if value is a graph (multiple objects)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14347,10 +17160,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te104'>Test te104: Creates an @graph container if value is a graph (mixed graph and object)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14375,10 +17194,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te106'>Test te106: Do not expand [@graph, @id] container if value is a graph (mixed graph and object)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14403,10 +17228,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te108'>Test te108: expand [@graph, @id] container (multiple ids and objects)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14431,10 +17262,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te110'>Test te110: Various relative IRIs as properties with with relative @vocab(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14459,6 +17296,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
@@ -14473,10 +17313,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te113'>Test te113: context with JavaScript Object property names</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14501,10 +17347,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te117'>Test te117: A term starting with a colon can expand to a different IRI(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14529,10 +17381,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te119'>Test te119: Ignore some terms with @, allow others.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14557,10 +17415,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te121'>Test te121: Ignore some values of @reverse with @, allow others.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14585,6 +17449,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
@@ -14592,6 +17459,9 @@ PASS
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -14613,10 +17483,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
-<a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0125'>Test t0125: IRI Resolution (5)(new in JSON-LD 1.1)</a>
+<a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0125'>Test t0125: term as @vocab(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14641,10 +17517,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te127'>Test te127: A scoped context may include itself recursively (indirect)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14669,10 +17551,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te129'>Test te129: Base without trailing slash, without path(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14697,10 +17585,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tec01'>Test tec01: Invalid keyword in term definition(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14719,6 +17613,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -14729,6 +17626,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tem01'>Test tem01: Invalid container mapping(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14753,10 +17653,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ten02'>Test ten02: @nest MUST NOT have a boolen value(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14781,10 +17687,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ten04'>Test ten04: @nest MUST NOT have a value object value(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14809,10 +17721,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ten06'>Test ten06: does not allow @nest with @reverse(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14837,10 +17755,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tep03'>Test tep03: @version must be 1.1(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14865,10 +17789,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter04'>Test ter04: Error dereferencing a remote context</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14893,10 +17823,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter06'>Test ter06: Invalid local context</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14921,10 +17857,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter08'>Test ter08: Invalid vocab mapping</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14949,10 +17891,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter10'>Test ter10: Cyclic IRI mapping</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14977,10 +17925,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter12'>Test ter12: Invalid type mapping (not a string)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15005,10 +17959,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter14'>Test ter14: Invalid reverse property (contains @id)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15033,10 +17993,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter17'>Test ter17: Invalid reverse property (invalid @container)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15061,10 +18027,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter19'>Test ter19: Invalid keyword alias (@context)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15089,10 +18061,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter21'>Test ter21: Invalid container mapping(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15117,10 +18095,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter23'>Test ter23: Invalid IRI mapping (relative IRI in @type)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15145,10 +18129,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter26'>Test ter26: Colliding keywords</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15173,10 +18163,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter28'>Test ter28: Invalid type value</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15201,10 +18197,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter30'>Test ter30: Invalid language-tagged string</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15229,10 +18231,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter33'>Test ter33: Invalid @reverse value</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15257,10 +18265,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter35'>Test ter35: Invalid language map value</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15285,10 +18299,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter37'>Test ter37: Invalid value object (unexpected keyword)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15313,10 +18333,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter39'>Test ter39: Invalid language-tagged value</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15341,10 +18367,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter41'>Test ter41: Invalid set or list object</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15369,10 +18401,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter43'>Test ter43: Term definition with @id: @type(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15397,10 +18435,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter48'>Test ter48: Invalid term as relative IRI(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15425,10 +18469,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter50'>Test ter50: Invalid reverse id</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15453,6 +18503,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
@@ -15460,6 +18513,9 @@ PASS
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -15471,6 +18527,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter53'>Test ter53: Invalid prefix value</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15495,10 +18554,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin02'>Test tin02: Basic Included object(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15523,10 +18588,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin04'>Test tin04: Included containing @included(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15551,10 +18622,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin06'>Test tin06: json.api example(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15579,10 +18656,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin08'>Test tin08: Error if @included value is a value object(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15607,10 +18690,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs01'>Test tjs01: Transform JSON literal (boolean true)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15635,10 +18724,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs03'>Test tjs03: Transform JSON literal (double)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15663,10 +18758,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs05'>Test tjs05: Transform JSON literal (integer)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15691,10 +18792,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs07'>Test tjs07: Transform JSON literal (array)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15719,10 +18826,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs09'>Test tjs09: Transform JSON literal with string canonicalization(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15747,10 +18860,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs11'>Test tjs11: Transform JSON literal with unicode canonicalization(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15775,10 +18894,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs13'>Test tjs13: Transform JSON literal with wierd canonicalization(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15803,10 +18928,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs15'>Test tjs15: Transform JSON literal aleady in expanded form(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15831,10 +18962,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs17'>Test tjs17: Transform JSON literal (string)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15859,10 +18996,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs19'>Test tjs19: Transform JSON literal with aliased @type(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15887,10 +19030,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs21'>Test tjs21: Transform JSON literal with @context(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15915,10 +19064,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs23'>Test tjs23: Transform JSON literal (empty array).(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15943,10 +19098,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli02'>Test tli02: @list containing empty @list(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15971,10 +19132,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli04'>Test tli04: @list containing empty @list (with coercion)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15999,10 +19166,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli06'>Test tli06: coerced @list containing an empty array(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16027,10 +19200,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli08'>Test tli08: coerced @list containing deep empty arrays(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16055,10 +19234,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli10'>Test tli10: coerced @list containing mixed list values(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16083,10 +19268,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm002'>Test tm002: Retains @id in object already having an @id(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16111,10 +19302,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm004'>Test tm004: Prepends @type in object already having an @type(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16139,10 +19336,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm006'>Test tm006: Adds vocabulary expanded @type to object(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16167,10 +19370,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm008'>Test tm008: When type is in a type map(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16195,10 +19404,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm010'>Test tm010: language map with alias of @none(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16223,10 +19438,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm012'>Test tm012: type map with alias of @none(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16251,10 +19472,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm014'>Test tm014: graph index map with alias @none(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16279,10 +19506,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm016'>Test tm016: graph id index map with aliased @none(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16307,10 +19540,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm018'>Test tm018: string value of type map expands to node reference with @type: @id(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16335,10 +19574,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm020'>Test tm020: string value of type map must not be a literal(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16363,10 +19608,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn002'>Test tn002: Expands input using aliased @nest(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16391,10 +19642,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn004'>Test tn004: Appends nested values from all @nest aliases in term order(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16419,10 +19676,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn006'>Test tn006: Arrays of nested values(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16447,10 +19710,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn008'>Test tn008: Multiple keys may mapping to @type when nesting(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16475,10 +19744,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt02'>Test tnt02: literal_with_UTF8_boundaries</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16503,10 +19778,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt04'>Test tnt04: literal_all_punctuation</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16531,10 +19812,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt06'>Test tnt06: literal_with_2_squotes</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16559,10 +19846,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt08'>Test tnt08: literal_with_2_dquotes</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16587,10 +19880,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt10'>Test tnt10: literal_with_CHARACTER_TABULATION</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16615,10 +19914,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt12'>Test tnt12: literal_with_LINE_FEED</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16643,10 +19948,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt14'>Test tnt14: literal_with_FORM_FEED</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16671,10 +19982,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt16'>Test tnt16: literal_with_numeric_escape4</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16699,10 +20016,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tp002'>Test tp002: @version setting [1.0, 1.1, 1.0](new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16727,10 +20050,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tp004'>Test tp004: @version setting [1.1, 1.0, 1.1](new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16755,10 +20084,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi02'>Test tpi02: error if @container does not include @index for property-valued index(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16783,10 +20118,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi04'>Test tpi04: error if @index is not a string for property-valued index(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16811,10 +20152,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi06'>Test tpi06: property-valued index expands to property value, instead of @index (value)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16839,10 +20186,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi08'>Test tpi08: property-valued index expands to property value, instead of @index (node)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16867,10 +20220,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi10'>Test tpi10: property-valued index does not output property for @none(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16895,10 +20254,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr01'>Test tpr01: Protect a term(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16923,10 +20288,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr03'>Test tpr03: Protect all terms in context(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16951,10 +20322,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr05'>Test tpr05: Clear active context with protected terms from an embedded context(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16979,10 +20356,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr08'>Test tpr08: Term with protected scoped context.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17007,10 +20390,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr10'>Test tpr10: Simple protected and unprotected terms.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17035,10 +20424,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr12'>Test tpr12: Scoped context fail to override protected term.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17063,10 +20458,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr14'>Test tpr14: Clear protection with null context.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17091,10 +20492,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr16'>Test tpr16: Override protected terms after null.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17119,10 +20526,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr18'>Test tpr18: Fail to override protected terms with type+null+ctx.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17147,10 +20560,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr20'>Test tpr20: Fail with mix of protected and unprotected terms with type+null+ctx.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17175,10 +20594,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr22'>Test tpr22: Check legal overriding of type-scoped protected term from nested node.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17203,10 +20628,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr24'>Test tpr24: Allows redefinition of protected prefix term with same definition.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17231,10 +20662,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr26'>Test tpr26: Fails on redefinition of terms with scoped contexts using different definitions.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17259,6 +20696,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
@@ -17266,6 +20706,9 @@ PASS
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -17277,6 +20720,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr29'>Test tpr29: Does not expand a Compact IRI using a non-prefix term.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17301,10 +20747,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr31'>Test tpr31: Protected keyword aliases cannot be overridden.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17329,10 +20781,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr33'>Test tpr33: Fails if trying to declare a keyword alias as prefix.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17357,10 +20815,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr35'>Test tpr35: Ignores a non-keyword term starting with &#39;@&#39; (with @vocab)(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17385,10 +20849,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr37'>Test tpr37: Ignores a term mapping to a value in the form of a keyword (with @vocab).(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17407,6 +20877,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -17421,6 +20894,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -17431,6 +20907,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr40'>Test tpr40: Protected terms and property-scoped contexts(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17455,10 +20934,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso01'>Test tso01: @import is invalid in 1.0.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17483,10 +20968,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso03'>Test tso03: @import overflow(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17511,10 +21002,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso06'>Test tso06: @propagate: false on property-scoped context with @import(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17539,10 +21036,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso08'>Test tso08: Override term defined in sourced context(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17567,10 +21070,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso10'>Test tso10: Protect terms in sourced context(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17595,10 +21104,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso12'>Test tso12: @import may not be used in an imported context.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17623,10 +21138,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ttn01'>Test ttn01: @type: @none is illegal in 1.0.(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17651,10 +21172,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf01'>Test twf01: Triples including invalid subject IRIs are rejected(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17679,10 +21206,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf03'>Test twf03: Triples including invalid object IRIs are rejected(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17707,6 +21240,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
@@ -17714,6 +21250,9 @@ PASS
 </td>
 <td class='FAIL'>
 FAIL
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17735,6 +21274,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='summary'>
 <td>
@@ -17742,6 +21284,9 @@ Percentage passed out of 442 Tests
 </td>
 <td class='passed-most'>
 98.0%
+</td>
+<td class='passed-most'>
+95.5%
 </td>
 <td class='passed-all'>
 100.0%
@@ -17766,15 +21311,21 @@ Test
 <a href='#subj_1'>PyLD</a>
 </th>
 <th>
-<a href='#subj_2'>JSON::LD</a>
+<a href='#subj_2'>JSON-goLD</a>
 </th>
 <th>
-<a href='#subj_4'>jsonld-streaming-serializer</a>
+<a href='#subj_3'>JSON::LD</a>
+</th>
+<th>
+<a href='#subj_5'>jsonld-streaming-serializer</a>
 </th>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0001'>Test t0001: Object Lists</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17799,10 +21350,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0003'>Test t0003: BNodes and references</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17824,6 +21381,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -17838,6 +21398,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -17845,6 +21408,9 @@ FAIL
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0006'>Test t0006: Two graphs having same subject but different values</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17869,10 +21435,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0009'>Test t0009: List conversion with IRI nodes</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17897,10 +21469,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0011'>Test t0011: List pattern with extra properties</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17925,10 +21503,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0013'>Test t0013: List pattern with multiple values of rdf:first</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17943,6 +21527,9 @@ FAIL
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0014'>Test t0014: List pattern with multiple values of rdf:rest</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17967,10 +21554,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0016'>Test t0016: List pattern with type rdf:List</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17985,6 +21578,9 @@ FAIL
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0017'>Test t0017: Remove duplicate triples</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18009,10 +21605,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0019'>Test t0019: use rdf:type flag set to false</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18037,10 +21639,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0021'>Test t0021: list with node shared across graphs (same triple in different graphs)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18055,6 +21663,9 @@ FAIL
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0022'>Test t0022: list from duplicate triples</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18079,10 +21690,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0024'>Test t0024: multiple languages for same subject+property+value</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18107,10 +21724,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0026'>Test t0026: triple with rdf:first property and rdf:nil value</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18135,10 +21758,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi02'>Test tdi02: rdfDirection: null with i18n literal with direction and language(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18163,10 +21792,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi04'>Test tdi04: rdfDirection: null with compound literal with direction and language(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18185,6 +21820,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -18199,6 +21837,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -18209,6 +21850,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi07'>Test tdi07: rdfDirection: i18n-datatype with compound literal with direction and no language(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18233,10 +21877,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi09'>Test tdi09: rdfDirection: compound-literal with i18n literal with direction and no language(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18261,10 +21911,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi11'>Test tdi11: rdfDirection: compound-literal with compound literal with direction and no language(new in JSON-LD 1.1)</a>
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='FAIL'>
 FAIL
@@ -18283,6 +21939,9 @@ FAIL
 <td class='FAIL'>
 FAIL
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -18296,6 +21955,9 @@ FAIL
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -18311,6 +21973,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -18324,6 +21989,9 @@ PASS
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -18339,6 +22007,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -18352,6 +22023,9 @@ PASS
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -18367,6 +22041,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -18380,6 +22057,9 @@ PASS
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -18395,6 +22075,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -18408,6 +22091,9 @@ PASS
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
@@ -18423,6 +22109,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -18437,6 +22126,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='FAIL'>
+FAIL
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -18447,6 +22139,9 @@ PASS
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tli01'>Test tli01: @list containing empty @list(new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18468,6 +22163,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -18475,6 +22173,9 @@ FAIL
 <tr>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tli03'>Test tli03: t0008 as interpreted for 1.1. (new in JSON-LD 1.1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18492,6 +22193,9 @@ Percentage passed out of 51 Tests
 </td>
 <td class='passed-most'>
 96.1%
+</td>
+<td class='passed-some'>
+70.6%
 </td>
 <td class='passed-all'>
 100.0%
@@ -18616,7 +22320,7 @@ https://github.com/digitalbazaar/pyld
 <a href='https://github.com/dlongley'>
 <span property='foaf:name'>Dave Longley</span>
 </a>
-<a href-@id='https://github.com/dlongley' href-@type='[&quot;foaf:Person&quot;, &quot;Assertor&quot;]' href-foaf:homepage='https://github.com/dlongley' href-foaf:name='Dave Longley' property='foaf:homepage'>
+<a href-@id='https://github.com/dlongley' href-@type='[&quot;Assertor&quot;, &quot;foaf:Person&quot;]' href-foaf:homepage='https://github.com/dlongley' href-foaf:name='Dave Longley' property='foaf:homepage'>
 https://github.com/dlongley
 </a>
 </div>
@@ -18690,6 +22394,94 @@ Transform RDF to JSON-LD
 </dd>
 <dt id='subj_2'>
 <span class='secno'>A.3</span>
+<a href='https://github.com/piprate/json-gold'>
+<span about='https://github.com/piprate/json-gold' property='doap:name'>JSON-goLD</span>
+</a>
+</dt>
+<dd>
+<dl>
+<dt>Release</dt>
+<dd property='doap:release'><span property='doap:revision'>unknown</span></dd>
+<dt>Programming Language</dt>
+<dd property='doap:programming-language'>Go</dd>
+<dt>Home Page</dt>
+<dd>
+<a href='https://github.com/piprate/json-gold' property='doap:homepage'>
+https://github.com/piprate/json-gold
+</a>
+</dd>
+<dt>Developer</dt>
+<dd rel='doap:developer'>
+<div>
+<a href='https://github.com/kazarena'>
+<span property='foaf:name'>Stan Nazarenko</span>
+</a>
+<a href-@id='https://github.com/kazarena' href-@type='[&quot;Assertor&quot;, &quot;foaf:Person&quot;]' href-foaf:homepage='https://github.com/kazarena' href-foaf:name='Stan Nazarenko' property='foaf:homepage'>
+https://github.com/kazarena
+</a>
+</div>
+</dd>
+<dt>
+Test Suite Compliance
+</dt>
+<dd>
+<table class='report'>
+<tbody>
+<tr>
+<td>
+Compaction
+</td>
+<td class='passed-most'>
+232/238 (97.5%)
+</td>
+</tr>
+<tr>
+<td>
+Expansion
+</td>
+<td class='passed-most'>
+356/366 (97.3%)
+</td>
+</tr>
+<tr>
+<td>
+Flattening
+</td>
+<td class='passed-all'>
+55/55 (100.0%)
+</td>
+</tr>
+<tr>
+<td>
+Remote document
+</td>
+<td class='passed-some'>
+15/18 (83.3%)
+</td>
+</tr>
+<tr>
+<td>
+Transform JSON-LD to RDF
+</td>
+<td class='passed-most'>
+422/442 (95.5%)
+</td>
+</tr>
+<tr>
+<td>
+Transform RDF to JSON-LD
+</td>
+<td class='passed-some'>
+36/51 (70.6%)
+</td>
+</tr>
+</tbody>
+</table>
+</dd>
+</dl>
+</dd>
+<dt id='subj_3'>
+<span class='secno'>A.4</span>
 <a href='https://rubygems.org/gems/json-ld'>
 <span about='https://rubygems.org/gems/json-ld' property='doap:name'>JSON::LD</span>
 </a>
@@ -18789,8 +22581,8 @@ Transform RDF to JSON-LD
 </dd>
 </dl>
 </dd>
-<dt id='subj_3'>
-<span class='secno'>A.4</span>
+<dt id='subj_4'>
+<span class='secno'>A.5</span>
 <a href='https://www.npmjs.com/package/jsonld-streaming-parser/'>
 <span about='https://www.npmjs.com/package/jsonld-streaming-parser/' property='doap:name'>jsonld-streaming-parser</span>
 </a>
@@ -18839,8 +22631,8 @@ Transform JSON-LD to RDF
 </dd>
 </dl>
 </dd>
-<dt id='subj_4'>
-<span class='secno'>A.5</span>
+<dt id='subj_5'>
+<span class='secno'>A.6</span>
 <a href='https://www.npmjs.com/package/jsonld-streaming-serializer/'>
 <span about='https://www.npmjs.com/package/jsonld-streaming-serializer/' property='doap:name'>jsonld-streaming-serializer</span>
 </a>
@@ -18889,8 +22681,8 @@ Transform RDF to JSON-LD
 </dd>
 </dl>
 </dd>
-<dt id='subj_5'>
-<span class='secno'>A.6</span>
+<dt id='subj_6'>
+<span class='secno'>A.7</span>
 <a href='https://www.npmjs.com/package/rdf-parse/'>
 <span about='https://www.npmjs.com/package/rdf-parse/' property='doap:name'>rdf-parse</span>
 </a>
@@ -18954,23 +22746,26 @@ Individual test results used to construct this report are available here:
 <a class='source' href='ruby-json-ld-earl.ttl'>ruby-json-ld-earl.ttl</a>
 </li>
 <li>
-<a class='source' href='jsonld-streaming-parser-earl.ttl'>jsonld-streaming-parser-earl.ttl</a>
-</li>
-<li>
-<a class='source' href='jsonld-streaming-serializer-earl.ttl'>jsonld-streaming-serializer-earl.ttl</a>
-</li>
-<li>
 <a class='source' href='pyld-api-earl.ttl'>pyld-api-earl.ttl</a>
+</li>
+<li>
+<a class='source' href='rdf-parse.ttl'>rdf-parse.ttl</a>
+</li>
+<li>
+<a class='source' href='jsonld-gold-earl.ttl'>jsonld-gold-earl.ttl</a>
 </li>
 <li>
 <a class='source' href='guile-jsonld-earl.ttl'>guile-jsonld-earl.ttl</a>
 </li>
 <li>
-<a class='source' href='rdf-parse.ttl'>rdf-parse.ttl</a>
+<a class='source' href='jsonld-streaming-serializer-earl.ttl'>jsonld-streaming-serializer-earl.ttl</a>
+</li>
+<li>
+<a class='source' href='jsonld-streaming-parser-earl.ttl'>jsonld-streaming-parser-earl.ttl</a>
 </li>
 </ul>
 </section>
-<section class='appendix' id='report-generation-software' property='earl:generatedBy' resource='http://rubygems.org/gems/earl-report' typeof='Software doap:Project'>
+<section class='appendix' id='report-generation-software' property='earl:generatedBy' resource='http://rubygems.org/gems/earl-report' typeof='doap:Project Software'>
 <h2>
 <span class='secno'>D.</span>
 Report Generation Software

--- a/reports/jsonld-gold-earl.ttl
+++ b/reports/jsonld-gold-earl.ttl
@@ -4,21 +4,27 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://github.com/piprate/json-gold> a doap:Project,
-    <http://www.w3.org/ns/earl#TestSubject>,
+<https://github.com/piprate/json-gold/tree/v0.3.0> a doap:Version;
+  doap:created "2020-04-06"^^xsd:date;
+  doap:name "json-gold-v0.3.0";
+  doap:revision "v0.3.0" .
+
+<https://github.com/piprate/json-gold> a <http://www.w3.org/ns/earl#TestSubject>,
+    doap:Project,
     <http://www.w3.org/ns/earl#Software>;
   dc:title "JSON-goLD";
   dc:creator <https://github.com/kazarena>;
-  dc:date "2020-04-04"^^xsd:date;
+  dc:date "2020-04-06"^^xsd:date;
   doap:description "A JSON-LD processor for Go";
   doap:developer <https://github.com/kazarena>;
   doap:homepage <https://github.com/piprate/json-gold>;
   doap:license <https://github.com/piprate/json-gold/blob/master/LICENSE>;
   doap:name "JSON-goLD";
-  doap:programming-language "Go" .
+  doap:programming-language "Go";
+  doap:release <https://github.com/piprate/json-gold/tree/v0.3.0> .
 
-<https://github.com/kazarena> a foaf:Person,
-    <http://www.w3.org/ns/earl#Assertor>;
+<https://github.com/kazarena> a <http://www.w3.org/ns/earl#Assertor>,
+    foaf:Person;
   foaf:homepage <https://github.com/kazarena>;
   foaf:name "Stan Nazarenko" .
 
@@ -28,7 +34,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.488006"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.676634"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -41,7 +47,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.492095"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.680952"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -54,7 +60,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.527195"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.71681"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -67,7 +73,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.845948"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.965305"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -80,7 +86,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.846447"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.965758"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -93,7 +99,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.846981"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.966226"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -106,7 +112,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.847443"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.966654"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -119,7 +125,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.847897"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.967113"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -132,7 +138,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.848354"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.967562"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -145,7 +151,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.848847"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.968006"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -158,7 +164,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.849337"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.968462"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -171,7 +177,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.84983"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.968944"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -184,7 +190,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.850292"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.969446"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -197,7 +203,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.52786"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.717474"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -210,7 +216,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.850748"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.969938"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -223,7 +229,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.851203"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.970423"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -236,7 +242,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.852209"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.970947"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -249,7 +255,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.852688"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.971437"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -262,7 +268,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.853139"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.972025"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -275,7 +281,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.85358"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.972678"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -288,7 +294,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.854048"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.974107"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -301,7 +307,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.854538"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.974707"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -314,7 +320,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.855072"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.975156"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -327,7 +333,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.856365"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.97561"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -340,7 +346,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.528465"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.718062"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -353,7 +359,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.856843"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.976007"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -366,7 +372,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.857381"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.976512"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -379,7 +385,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.85865"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.976946"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -392,7 +398,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.859159"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.977466"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -405,7 +411,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.859615"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.977915"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -418,7 +424,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.860077"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.978333"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -431,7 +437,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.860547"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.978834"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -444,7 +450,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.860755"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.979059"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -457,7 +463,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.861179"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.979501"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -470,7 +476,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.861631"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.979975"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -483,7 +489,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.529409"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.718694"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -496,7 +502,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.863141"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.980417"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -509,7 +515,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.863633"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.980943"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -522,7 +528,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.864127"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.98143"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -535,7 +541,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.864612"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.981875"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -548,7 +554,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.865071"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.982395"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -561,7 +567,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.865516"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.982856"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -574,7 +580,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.865911"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.983261"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -587,7 +593,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.866397"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.983723"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -600,7 +606,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.866863"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.984221"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -613,7 +619,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.867281"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.984691"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -626,7 +632,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.530084"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.719349"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -639,7 +645,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.867579"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.984987"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -652,7 +658,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.867836"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.98523"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -665,7 +671,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.868112"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.985581"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -678,7 +684,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.868416"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.98589"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -691,7 +697,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.868711"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.986226"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -704,7 +710,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.869211"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.986906"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -717,7 +723,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.869982"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.987757"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -730,7 +736,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.870981"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.989011"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -743,7 +749,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.871817"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.989505"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -756,7 +762,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.872149"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.990058"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -769,7 +775,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.530732"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.720013"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -782,7 +788,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.872942"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.990444"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -795,7 +801,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.873238"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.99071"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -808,7 +814,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.873594"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.991129"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -821,7 +827,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.873933"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.991678"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -834,7 +840,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.874192"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.992229"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -847,7 +853,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.874394"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.992513"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -860,7 +866,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.874671"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.992842"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -873,7 +879,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.874971"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.99322"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -886,7 +892,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.875315"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.993461"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -899,7 +905,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.87567"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.993818"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -912,7 +918,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.531703"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.721023"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -925,7 +931,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.875917"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.994063"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -938,7 +944,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.876218"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.994345"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -951,7 +957,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.876557"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.994783"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -964,7 +970,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.876901"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.99517"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -977,7 +983,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.877252"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.99558"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -990,7 +996,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.877646"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.99597"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1003,7 +1009,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.877884"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.996265"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1016,7 +1022,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.878132"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.996517"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1029,7 +1035,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.87851"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.996918"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1042,7 +1048,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.878772"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.997202"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1055,7 +1061,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.532381"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.721662"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1068,7 +1074,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.879014"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.997483"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1081,7 +1087,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.879381"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.99782"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1094,7 +1100,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.879796"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.998135"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1107,7 +1113,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.880252"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.998533"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1120,7 +1126,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.881049"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.999412"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1133,7 +1139,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.881596"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.999873"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1146,7 +1152,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.882119"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.000405"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1159,7 +1165,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.882126"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.000412"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1172,7 +1178,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.882585"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.000928"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1185,7 +1191,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.883415"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.001423"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1198,7 +1204,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.533051"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.722358"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1211,7 +1217,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.883746"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.001772"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1224,7 +1230,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.884109"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.002119"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1237,7 +1243,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.884366"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.002394"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1250,7 +1256,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.884664"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.002711"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1263,7 +1269,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.885015"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.002983"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1276,7 +1282,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.885283"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.003337"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1289,7 +1295,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.885562"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.003647"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1302,7 +1308,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.88557"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.003654"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1315,7 +1321,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.885573"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.003657"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1328,7 +1334,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.885958"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.004038"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1341,7 +1347,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.533759"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.723074"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1354,7 +1360,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.886131"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.004227"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1367,7 +1373,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.886309"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.004446"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1380,7 +1386,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.886661"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.004805"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1393,7 +1399,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.887607"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.005749"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1406,7 +1412,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.888936"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.006621"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1419,7 +1425,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.889922"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.007161"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1432,7 +1438,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.891259"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.007863"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1445,7 +1451,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.891976"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.008482"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1458,7 +1464,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.892526"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.009042"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1471,7 +1477,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.893111"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.009655"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1484,7 +1490,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.493023"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.681866"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1497,7 +1503,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.534523"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.723857"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1510,7 +1516,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.893491"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.010082"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1523,7 +1529,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.893985"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.010581"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1536,7 +1542,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.894295"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.010884"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1549,7 +1555,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.894844"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.011514"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1562,7 +1568,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.897893"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.014225"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1575,7 +1581,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.898634"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.014895"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1588,7 +1594,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.899061"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.015316"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1601,7 +1607,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.899727"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.015958"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1614,7 +1620,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.90028"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.016608"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1627,7 +1633,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.900781"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.017077"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1640,7 +1646,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.535192"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.724857"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1653,7 +1659,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.901324"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.017624"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1666,7 +1672,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.90227"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.018292"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1679,7 +1685,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.903163"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.018991"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1692,7 +1698,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.904613"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.019539"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1705,7 +1711,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.905593"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.020127"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1718,7 +1724,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.90618"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.020751"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1731,7 +1737,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.906679"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.021209"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1744,7 +1750,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.907283"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.021807"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1757,7 +1763,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.907939"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.022457"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1770,7 +1776,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.908664"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.023196"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1783,7 +1789,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.535899"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.725704"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1796,7 +1802,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.909237"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.023836"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1809,7 +1815,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.909932"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.024333"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1822,7 +1828,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.910655"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.025092"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1835,7 +1841,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.911391"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.02592"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1848,7 +1854,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.911815"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.026446"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1861,7 +1867,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.912589"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.027193"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1874,7 +1880,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.91313"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.027816"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1887,7 +1893,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.913617"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.028251"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1900,7 +1906,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.914136"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.028798"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1913,7 +1919,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.914633"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.02931"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1926,7 +1932,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.536605"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.726442"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1939,7 +1945,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.915115"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.029812"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1952,7 +1958,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.915716"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.030362"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1965,7 +1971,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.916164"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.030789"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1978,7 +1984,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.916664"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.031264"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -1991,7 +1997,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.917179"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.031774"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2004,7 +2010,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.917772"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.032316"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2017,7 +2023,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.91982"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.033567"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2030,7 +2036,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.920828"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.034252"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2043,7 +2049,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.921497"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.035784"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2056,7 +2062,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.922061"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.03635"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2069,7 +2075,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.537263"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.727234"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2082,7 +2088,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.922643"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.036906"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2095,7 +2101,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.923083"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.037368"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2108,7 +2114,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.923593"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.037888"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2121,7 +2127,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.924238"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.038534"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2134,7 +2140,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.92472"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.039116"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2147,7 +2153,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.925154"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.039601"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2160,7 +2166,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.925608"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.040084"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2173,7 +2179,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.926056"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.040542"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2186,7 +2192,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.926574"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.041006"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2199,7 +2205,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.926869"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.041452"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2212,7 +2218,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.538583"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.728433"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2225,7 +2231,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.927153"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.041756"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2238,7 +2244,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.927434"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.042128"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2251,7 +2257,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.927922"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.042615"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2264,7 +2270,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.928374"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.043029"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2277,7 +2283,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.928803"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.043507"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2290,7 +2296,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.929618"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.044439"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2303,7 +2309,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.930057"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.04489"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2316,7 +2322,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.930517"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.045343"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2329,7 +2335,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.931025"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.045884"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2342,7 +2348,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.932429"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.046958"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2355,7 +2361,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.539294"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.729132"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2368,7 +2374,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.932762"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.04739"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2381,7 +2387,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.933214"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.047744"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2394,7 +2400,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.935145"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.048139"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2407,7 +2413,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.936103"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.048594"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2420,7 +2426,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.936623"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.049065"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2433,7 +2439,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.937214"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.049628"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2446,7 +2452,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.937581"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.050023"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2459,7 +2465,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.937962"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.050339"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2472,7 +2478,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.938331"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.050742"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2485,7 +2491,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.938694"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.051082"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2498,7 +2504,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.540309"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.729877"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2511,7 +2517,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.939043"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.051485"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2524,7 +2530,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.939407"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.051854"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2537,7 +2543,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.939732"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.052183"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2550,7 +2556,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.940133"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.052553"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2563,7 +2569,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.940489"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.052878"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2576,7 +2582,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.940876"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.053281"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2589,7 +2595,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.941224"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.053638"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2602,7 +2608,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.941614"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.054048"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2615,7 +2621,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.941982"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.054377"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2628,7 +2634,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.942341"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.054738"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2641,7 +2647,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.541077"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.730602"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2654,7 +2660,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.942641"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.055003"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2667,7 +2673,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.942952"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.055372"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2680,7 +2686,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.943245"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.055715"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2693,7 +2699,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.943536"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.056101"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2706,7 +2712,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.943916"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.056393"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2719,7 +2725,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.944069"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.056672"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2732,7 +2738,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.944242"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.056878"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2745,7 +2751,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.944417"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.057059"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2758,7 +2764,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.944424"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.057066"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2771,7 +2777,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.944427"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.057074"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2784,7 +2790,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.541742"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.731261"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2797,7 +2803,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.944716"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.0574"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2810,7 +2816,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.945028"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.057795"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2823,7 +2829,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.945346"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.058079"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2836,7 +2842,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.945632"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.058399"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2849,7 +2855,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.945639"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.058404"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2862,7 +2868,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.945642"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.058407"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2875,7 +2881,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.945645"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.058411"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2888,7 +2894,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.94565"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.058418"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2901,7 +2907,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.945653"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.058421"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2914,7 +2920,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.945656"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.058425"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2927,7 +2933,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.493741"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.682604"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2940,7 +2946,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.542399"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.732003"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2953,7 +2959,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.945659"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.058427"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2966,7 +2972,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.945663"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.058432"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2979,7 +2985,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.945665"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.058435"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -2992,7 +2998,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.945669"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.058439"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3005,7 +3011,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.945672"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.058442"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3018,7 +3024,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.945675"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.058445"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3031,7 +3037,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.945678"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.058448"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3044,7 +3050,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.946071"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.058762"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3057,7 +3063,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.946486"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.059168"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3070,7 +3076,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.946611"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.059309"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3083,7 +3089,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.542972"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.732581"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3096,7 +3102,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.949945"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.061928"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3109,7 +3115,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.95086"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.062455"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3122,7 +3128,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.95211"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.062932"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3135,7 +3141,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.952242"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.063077"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3148,7 +3154,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.952511"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.063391"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3161,7 +3167,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.952747"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.06372"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3174,7 +3180,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.952974"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.063996"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3187,7 +3193,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.953073"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.064102"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3200,7 +3206,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.953569"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.064595"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3213,7 +3219,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.954239"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.065585"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3226,7 +3232,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.543652"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.733221"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3239,7 +3245,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.954898"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.067049"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3252,7 +3258,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.955137"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.067357"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3265,7 +3271,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.955144"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.067366"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3278,7 +3284,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.955147"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.067371"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3291,7 +3297,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.957314"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.069077"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3304,7 +3310,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.95773"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.06962"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3317,7 +3323,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.958165"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.070093"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3330,7 +3336,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.958175"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.070102"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3343,7 +3349,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.963346"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.074481"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3356,7 +3362,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.964043"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.075132"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3369,7 +3375,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.54428"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.733873"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3382,7 +3388,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.964969"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.075669"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3395,7 +3401,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.965726"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.076172"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3408,7 +3414,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.966578"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.076681"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3421,7 +3427,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.967134"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.077678"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3434,7 +3440,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.967932"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.078143"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3447,7 +3453,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.968656"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.078683"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3460,7 +3466,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.9692"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.079207"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3473,7 +3479,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.969803"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.079815"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3486,7 +3492,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.970298"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.080388"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3499,7 +3505,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.97084"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.081004"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3512,7 +3518,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.544912"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.734545"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3525,7 +3531,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.97134"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.082311"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3538,7 +3544,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.972305"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.082817"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3551,7 +3557,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.972956"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.08344"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3564,7 +3570,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.97349"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.083941"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3577,7 +3583,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.973934"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.084389"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3590,7 +3596,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.974374"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.084827"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3603,7 +3609,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.974908"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.085431"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3616,7 +3622,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.975439"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.086021"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3629,7 +3635,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.97587"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.086485"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3642,7 +3648,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.976299"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.086982"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3655,7 +3661,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.546615"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.735075"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3668,7 +3674,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.976765"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.087516"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3681,7 +3687,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.977302"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.088107"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3694,7 +3700,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.977789"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.088606"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3707,7 +3713,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.97876"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.089654"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3720,7 +3726,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.97968"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.090582"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3733,7 +3739,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.98067"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.091458"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3746,7 +3752,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.982434"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.09241"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3759,7 +3765,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.983818"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.093139"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3772,7 +3778,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.984522"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.093916"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3785,7 +3791,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.985231"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.094667"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3798,7 +3804,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.548016"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.735805"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3811,7 +3817,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.98594"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.09597"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3824,7 +3830,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.986576"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.096963"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3837,7 +3843,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.98717"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.097664"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3850,7 +3856,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.987629"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.098445"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3863,7 +3869,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.98807"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.098987"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3876,7 +3882,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.9886"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.099585"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3889,7 +3895,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.989032"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.100101"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3902,7 +3908,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.989503"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.100687"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3915,7 +3921,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.990017"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.10128"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3928,7 +3934,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.990023"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.101286"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3941,7 +3947,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.549043"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.736474"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3954,7 +3960,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.990026"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.101288"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3967,7 +3973,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.990029"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.101292"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3980,7 +3986,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.990032"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.101295"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -3993,7 +3999,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.990035"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.101298"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4006,7 +4012,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.990038"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.101301"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4019,7 +4025,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.990041"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.101305"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4032,7 +4038,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.990044"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.101308"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4045,7 +4051,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.990046"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.101311"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4058,7 +4064,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.990048"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.101314"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4071,7 +4077,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.990052"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.101317"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4084,7 +4090,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.549871"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.737121"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4097,7 +4103,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.990054"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.10132"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4110,7 +4116,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.990057"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.101324"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4123,7 +4129,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.990537"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.101839"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4136,7 +4142,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.991044"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.102418"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4149,7 +4155,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.99157"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.10298"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4162,7 +4168,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.992069"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.10352"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4175,7 +4181,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.992696"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.104213"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4188,7 +4194,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.993194"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.104716"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4201,7 +4207,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.993663"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.105359"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4214,7 +4220,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.994068"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.105796"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4227,7 +4233,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.551023"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.738089"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4240,7 +4246,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.995087"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.106194"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4253,7 +4259,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.995603"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.106741"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4266,7 +4272,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.996146"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.107223"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4279,7 +4285,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.996583"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.107645"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4292,7 +4298,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.997199"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.108285"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4305,7 +4311,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.997609"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.108681"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4318,7 +4324,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.998221"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.109278"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4331,7 +4337,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.998718"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.109788"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4344,7 +4350,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.999191"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.110322"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4357,7 +4363,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.999693"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.110823"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4370,7 +4376,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.494417"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.683302"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4383,7 +4389,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.551618"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.739343"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4396,7 +4402,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.000434"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.111562"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4409,7 +4415,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.000922"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.11209"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4422,7 +4428,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.001574"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.113547"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4435,7 +4441,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.002131"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.11458"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4448,7 +4454,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.002658"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.115203"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4461,7 +4467,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.003336"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.115956"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4474,7 +4480,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.003922"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.116626"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4487,7 +4493,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.004435"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.117212"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4500,7 +4506,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.004938"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.117794"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4513,7 +4519,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.005859"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.118305"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4526,7 +4532,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.5522"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.740066"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4539,7 +4545,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.006145"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.118534"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4552,7 +4558,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.006315"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.118726"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4565,7 +4571,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.006322"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.118731"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4578,7 +4584,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.006326"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.118735"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4591,7 +4597,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.006329"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.118739"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4604,7 +4610,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.007262"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.119686"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4617,7 +4623,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.007796"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.120321"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4630,7 +4636,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.008374"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.120965"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4643,7 +4649,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.009178"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.121912"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4656,7 +4662,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.009777"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.1226"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4669,7 +4675,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.552842"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.740738"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4682,7 +4688,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.010233"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.123169"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4695,7 +4701,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.010661"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.123635"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4708,7 +4714,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.011091"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.124084"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4721,7 +4727,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.01152"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.12455"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4734,7 +4740,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.011697"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.124755"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4747,7 +4753,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.012626"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.125081"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4760,7 +4766,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.01307"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.125465"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4773,7 +4779,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.013569"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.125906"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4786,7 +4792,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.014814"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.126386"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4799,7 +4805,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.015153"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.126645"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4812,7 +4818,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.553454"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.741392"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4825,7 +4831,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.016064"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.12772"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4838,7 +4844,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.016378"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.128174"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4851,7 +4857,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.017348"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.129333"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4864,7 +4870,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.018214"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.130304"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4877,7 +4883,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.018802"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.130899"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4890,7 +4896,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.01927"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.13144"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4903,7 +4909,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.019744"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.131928"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4916,7 +4922,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.020683"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.133406"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4929,7 +4935,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.021202"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.133954"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4942,7 +4948,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.021748"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.134478"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4955,7 +4961,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.554066"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.742025"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4968,7 +4974,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.022678"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.135323"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4981,7 +4987,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.023485"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.135893"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -4994,7 +5000,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.024136"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.136627"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5007,7 +5013,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.024869"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.137481"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5020,7 +5026,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.0258"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.138449"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5033,7 +5039,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.026554"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.139231"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5046,7 +5052,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.026836"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.139489"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5059,7 +5065,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.027811"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.140565"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5072,7 +5078,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.029572"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.141709"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5085,7 +5091,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.030022"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.142065"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5098,7 +5104,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.554654"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.742692"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5111,7 +5117,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.03104"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.143131"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5124,7 +5130,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.031656"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.143752"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5137,7 +5143,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.032202"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.144376"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5150,7 +5156,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.033097"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.145147"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5163,7 +5169,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.034258"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.14583"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5176,7 +5182,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.036213"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.147671"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5189,7 +5195,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.036878"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.148337"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5202,7 +5208,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.03754"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.149076"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5215,7 +5221,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.03802"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.149586"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5228,7 +5234,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.038538"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.15022"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5241,7 +5247,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.55526"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.743326"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5254,7 +5260,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.039098"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.150805"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5267,7 +5273,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.039786"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.151479"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5280,7 +5286,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.041312"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.153704"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5293,7 +5299,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.042656"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.154435"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5306,7 +5312,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.043859"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.155131"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5319,7 +5325,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.045912"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.155906"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5332,7 +5338,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.047497"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.156516"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5345,7 +5351,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.048147"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.157054"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5358,7 +5364,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.048782"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.157673"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5371,7 +5377,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.049363"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.158174"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5384,7 +5390,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.555767"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.743945"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5397,7 +5403,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.049627"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.158405"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5410,7 +5416,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.049885"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.158737"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5423,7 +5429,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.050317"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.159152"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5436,7 +5442,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.051012"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.159821"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5449,7 +5455,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.051534"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.160484"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5462,7 +5468,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.051911"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.160939"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5475,7 +5481,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.052292"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.161457"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5488,7 +5494,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.052733"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.161898"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5501,7 +5507,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.053022"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.162203"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5514,7 +5520,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.05339"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.162593"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5527,7 +5533,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.556446"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.744618"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5540,7 +5546,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.053703"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.162941"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5553,7 +5559,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.054322"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.163571"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5566,7 +5572,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.055228"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.163998"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5579,7 +5585,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.055621"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.164404"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5592,7 +5598,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.056261"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.164975"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5605,7 +5611,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.056907"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.16569"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5618,7 +5624,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.057291"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.166143"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5631,7 +5637,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.059074"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.167981"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5644,7 +5650,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.059714"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.169063"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5657,7 +5663,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.060232"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.169675"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5670,7 +5676,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.557108"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.745294"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5683,7 +5689,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.060719"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.170252"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5696,7 +5702,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.061345"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.170941"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5709,7 +5715,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.061751"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.17149"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5722,7 +5728,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.062083"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.171794"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5735,7 +5741,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.062513"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.172296"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5748,7 +5754,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.062942"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.172787"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5761,7 +5767,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.063439"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.173161"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5774,7 +5780,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.064689"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.173808"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5787,7 +5793,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.065299"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.174431"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5800,7 +5806,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.066041"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.174826"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5813,7 +5819,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.495086"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.683985"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5826,7 +5832,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.557741"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.745925"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5839,7 +5845,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.066436"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.175189"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5852,7 +5858,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.067274"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.175999"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5865,7 +5871,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.068296"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.177033"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5878,7 +5884,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.06867"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.177391"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5891,7 +5897,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.06904"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.1778"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5904,7 +5910,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.069462"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.178206"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5917,7 +5923,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.069803"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.178561"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5930,7 +5936,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.070255"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.178966"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5943,7 +5949,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.070652"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.179418"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5956,7 +5962,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.07108"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.17977"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5969,7 +5975,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.558396"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.746666"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5982,7 +5988,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.071556"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.180215"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -5995,7 +6001,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.071944"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.180629"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6008,7 +6014,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.072706"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.181455"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6021,7 +6027,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.073048"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.181888"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6034,7 +6040,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.073441"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.182287"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6047,7 +6053,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.073818"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.182652"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6060,7 +6066,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.074863"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.183748"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6073,7 +6079,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.075451"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.184181"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6086,7 +6092,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.075885"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.184618"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6099,7 +6105,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.076815"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.185639"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6112,7 +6118,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.559123"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.747381"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6125,7 +6131,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.07723"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.186158"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6138,7 +6144,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.077623"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.186596"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6151,7 +6157,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.078049"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.187075"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6164,7 +6170,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.078503"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.187648"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6177,7 +6183,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.078969"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.188208"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6190,7 +6196,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.079503"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.188806"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6203,7 +6209,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.079921"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.189218"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6216,7 +6222,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.08037"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.189693"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6229,7 +6235,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.080902"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.190201"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6242,7 +6248,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.081487"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.190755"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6255,7 +6261,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.559801"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.748069"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6268,7 +6274,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.082063"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.191316"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6281,7 +6287,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.082635"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.191874"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6294,7 +6300,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.083264"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.192535"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6307,7 +6313,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.083611"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.192938"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6320,7 +6326,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.085136"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.193948"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6333,7 +6339,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.086158"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.194962"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6346,7 +6352,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.087048"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.195924"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6359,7 +6365,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.08785"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.196392"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6372,7 +6378,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.088218"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.196809"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6385,7 +6391,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.088598"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.197174"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6398,7 +6404,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.560474"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.74876"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6411,7 +6417,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.089167"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.197774"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6424,7 +6430,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.089877"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.198303"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6437,7 +6443,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.091009"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.198978"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6450,7 +6456,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.092247"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.199542"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6463,7 +6469,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.093116"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.200136"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6476,7 +6482,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.093125"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.200143"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6489,7 +6495,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.093709"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.20065"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6502,7 +6508,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.094172"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.201159"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6515,7 +6521,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.095235"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.202248"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6528,7 +6534,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.09672"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.203708"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6541,7 +6547,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.561644"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.749376"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6554,7 +6560,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.098965"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.206089"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6567,7 +6573,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.099526"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.206578"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6580,7 +6586,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.100029"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.207023"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6593,7 +6599,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.100334"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.207239"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6606,7 +6612,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.100342"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.207247"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6619,7 +6625,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.100565"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.207433"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6632,7 +6638,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.100767"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.207651"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6645,7 +6651,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.100948"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.207898"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6658,7 +6664,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.101135"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.208098"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6671,7 +6677,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.101327"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.20829"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6684,7 +6690,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.562334"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.750078"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6697,7 +6703,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.101524"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.208564"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6710,7 +6716,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.101696"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.208785"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6723,7 +6729,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.101885"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.208978"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6736,7 +6742,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.102032"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.20921"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6749,7 +6755,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.102223"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.209394"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6762,7 +6768,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.102445"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.209584"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6775,7 +6781,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.102757"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.209896"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6788,7 +6794,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.102954"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.210098"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6801,7 +6807,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.103167"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.210321"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6814,7 +6820,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.103427"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.210532"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6827,7 +6833,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.562964"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.750758"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6840,7 +6846,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.103709"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.210783"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6853,7 +6859,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.10392"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.211071"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6866,7 +6872,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.104124"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.211331"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6879,7 +6885,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.104385"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.21163"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6892,7 +6898,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.104687"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.211953"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6905,7 +6911,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.106127"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.212205"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6918,7 +6924,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.107321"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.212523"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6931,7 +6937,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.107711"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.212788"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6944,7 +6950,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.107971"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.213042"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6957,7 +6963,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.109522"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.213297"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6970,7 +6976,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.563617"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.751353"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6983,7 +6989,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.109865"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.213518"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -6996,7 +7002,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.110124"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.213751"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7009,7 +7015,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.110355"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.213926"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7022,7 +7028,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.110566"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.214143"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7035,7 +7041,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.110778"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.214342"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7048,7 +7054,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.111062"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.214649"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7061,7 +7067,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.111313"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.214927"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7074,7 +7080,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.111568"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.215186"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7087,7 +7093,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.11184"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.215454"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7100,7 +7106,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.112089"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.215728"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7113,7 +7119,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.564294"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.751974"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7126,7 +7132,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.112332"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.216006"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7139,7 +7145,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.112784"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.216233"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7152,7 +7158,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.113422"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.216539"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7165,7 +7171,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.113815"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.216843"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7178,7 +7184,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.114129"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.217123"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7191,7 +7197,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.114385"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.217348"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7204,7 +7210,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.114658"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.217657"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7217,7 +7223,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.114859"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.217857"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7230,7 +7236,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.115053"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.218047"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7243,7 +7249,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.115234"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.218216"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7256,7 +7262,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.489081"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.677862"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7269,7 +7275,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.495839"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.684725"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7282,7 +7288,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.564899"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.752658"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7295,7 +7301,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.115412"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.218429"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7308,7 +7314,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.115684"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.218652"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7321,7 +7327,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.115945"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.218881"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7334,7 +7340,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.116217"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.219093"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7347,7 +7353,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.11642"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.219293"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7360,7 +7366,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.11669"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.219569"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7373,7 +7379,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.116928"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.2198"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7386,7 +7392,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.116934"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.219808"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7399,7 +7405,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.117115"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.220044"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7412,7 +7418,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.117628"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.220636"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7425,7 +7431,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.56557"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.753355"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7438,7 +7444,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.118139"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.222545"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7451,7 +7457,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.118681"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.22316"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7464,7 +7470,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.119236"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.223791"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7477,7 +7483,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.11975"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.224355"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7490,7 +7496,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.121803"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.226103"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7503,7 +7509,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.122067"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.226376"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7516,7 +7522,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.122433"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.226668"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7529,7 +7535,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.122747"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.226948"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7542,7 +7548,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.123196"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.227425"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7555,7 +7561,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.123681"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.227961"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7568,7 +7574,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.566219"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.753999"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7581,7 +7587,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.124194"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.228473"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7594,7 +7600,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.124665"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.228931"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7607,7 +7613,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.125146"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.22947"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7620,7 +7626,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.125651"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.229976"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7633,7 +7639,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.126215"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.230459"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7646,7 +7652,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.126675"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.230897"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7659,7 +7665,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.127074"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.231355"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7672,7 +7678,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.127589"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.231925"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7685,7 +7691,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.128077"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.232454"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7698,7 +7704,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.128552"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.233014"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7711,7 +7717,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.566854"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.754798"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7724,7 +7730,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.129052"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.23354"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7737,7 +7743,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.129589"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.234083"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7750,7 +7756,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.129934"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.234909"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7763,7 +7769,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.130357"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.235383"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7776,7 +7782,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.13123"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.235808"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7789,7 +7795,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.131587"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.236167"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7802,7 +7808,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.131996"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.236568"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7815,7 +7821,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.132324"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.236988"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7828,7 +7834,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.132647"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.237325"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7841,7 +7847,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.133024"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.237729"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7854,7 +7860,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.567396"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.755939"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7867,7 +7873,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.133357"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.238347"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7880,7 +7886,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.13393"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.238973"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7893,7 +7899,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.134463"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.239491"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7906,7 +7912,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.134952"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.240039"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7919,7 +7925,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.135391"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.240487"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7932,7 +7938,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.135802"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.241016"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7945,7 +7951,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.136216"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.241444"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7958,7 +7964,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.136699"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.241963"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7971,7 +7977,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.137715"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.242376"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7984,7 +7990,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.138313"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.242937"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -7997,7 +8003,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.567955"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.757433"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8010,7 +8016,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.13879"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.243436"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8023,7 +8029,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.139243"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.243931"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8036,7 +8042,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.139683"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.244494"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8049,7 +8055,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.140076"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.244921"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8062,7 +8068,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.140535"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.245437"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8075,7 +8081,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.140898"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.245889"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8088,7 +8094,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.141243"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.246254"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8101,7 +8107,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.142214"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.246697"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8114,7 +8120,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.142644"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.247139"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8127,7 +8133,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.143154"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.247735"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8140,7 +8146,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.568576"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.758097"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8153,7 +8159,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.14367"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.248315"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8166,7 +8172,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.14407"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.248695"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8179,7 +8185,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.144472"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.24919"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8192,7 +8198,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.144839"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.249615"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8205,7 +8211,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.145204"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.249975"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8218,7 +8224,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.145543"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.250369"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8231,7 +8237,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.145911"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.250752"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8244,7 +8250,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.146448"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.251135"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8257,7 +8263,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.146982"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.251611"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8270,7 +8276,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.147427"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.252011"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8283,7 +8289,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.569239"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.758772"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8296,7 +8302,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.147701"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.252232"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8309,7 +8315,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.148071"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.252615"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8322,7 +8328,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.148496"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.253047"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8335,7 +8341,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.148968"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.25349"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8348,7 +8354,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.149407"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.253897"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8361,7 +8367,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.149833"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.254359"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8374,7 +8380,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.150272"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.254857"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8387,7 +8393,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.150954"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.255418"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8400,7 +8406,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.152761"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.256094"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8413,7 +8419,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.153654"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.256759"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8426,7 +8432,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.570038"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.759468"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8439,7 +8445,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.154348"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.257132"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8452,7 +8458,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.155107"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.257474"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8465,7 +8471,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.156003"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.257815"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8478,7 +8484,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.156404"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.258102"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8491,7 +8497,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.156754"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.258422"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8504,7 +8510,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.157115"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.258789"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8517,7 +8523,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.157509"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.259152"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8530,7 +8536,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.157905"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.259505"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8543,7 +8549,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.158303"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.259861"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8556,7 +8562,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.158709"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.260193"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8569,7 +8575,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.570535"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.75995"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8582,7 +8588,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.159095"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.260552"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8595,7 +8601,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.159447"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.260887"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8608,7 +8614,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.159792"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.261253"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8621,7 +8627,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.160109"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.261605"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8634,7 +8640,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.160411"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.261988"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8647,7 +8653,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.160911"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.262501"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8660,7 +8666,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.161388"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.26304"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8673,7 +8679,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.16194"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.263612"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8686,7 +8692,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.16234"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.264026"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8699,7 +8705,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.162522"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.264223"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8712,7 +8718,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.496447"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.685348"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8725,7 +8731,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.57127"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.76058"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8738,7 +8744,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.162731"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.264395"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8751,7 +8757,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.162939"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.26459"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8764,7 +8770,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.163149"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.264775"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8777,7 +8783,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.163871"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.264986"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8790,7 +8796,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.164541"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.265789"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8803,7 +8809,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.16527"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.26654"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8816,7 +8822,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.165967"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.267209"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8829,7 +8835,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.166854"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.26803"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8842,7 +8848,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.168144"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.268675"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8855,7 +8861,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.168592"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.269072"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8868,7 +8874,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.572246"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.76124"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8881,7 +8887,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.168807"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.269331"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8894,7 +8900,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.169288"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.269909"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8907,7 +8913,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.169548"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.270195"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8920,7 +8926,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.169773"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.270499"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8933,7 +8939,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.17001"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.270726"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8946,7 +8952,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.170322"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.271157"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8959,7 +8965,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.170646"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.271623"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8972,7 +8978,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.170882"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.271894"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8985,7 +8991,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.171291"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.272325"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -8998,7 +9004,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.171522"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.272619"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9011,7 +9017,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.572964"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.761856"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9024,7 +9030,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.17179"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.272878"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9037,7 +9043,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.17216"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.273315"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9050,7 +9056,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.172557"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.273756"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9063,7 +9069,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.172951"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.274117"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9076,7 +9082,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.173504"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.27461"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9089,7 +9095,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.173746"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.274884"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9102,7 +9108,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.173936"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.275139"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9115,7 +9121,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.174849"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.275764"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9128,7 +9134,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.1751"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.275997"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9141,7 +9147,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.17536"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.276256"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9154,7 +9160,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.573627"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.762508"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9167,7 +9173,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.175829"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.276727"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9180,7 +9186,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.17619"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.277118"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9193,7 +9199,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.176545"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.277515"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9206,7 +9212,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.177297"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.279028"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9219,7 +9225,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.177621"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.279425"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9232,7 +9238,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.177987"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.279859"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9245,7 +9251,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.177995"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.279867"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9258,7 +9264,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.178356"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.280278"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9271,7 +9277,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.178741"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.280767"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9284,7 +9290,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.17898"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.281041"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9297,7 +9303,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.57432"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.763222"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9310,7 +9316,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.179242"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.281304"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9323,7 +9329,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.179422"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.281498"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9336,7 +9342,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.179917"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.282131"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9349,7 +9355,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.180367"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.282712"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9362,7 +9368,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.18083"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.283334"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9375,7 +9381,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.181297"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.284076"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9388,7 +9394,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.181304"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.284083"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9401,7 +9407,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.181307"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.284086"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9414,7 +9420,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.181805"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.284864"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9427,7 +9433,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.182381"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.285527"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9440,7 +9446,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.574992"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.763852"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9453,7 +9459,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.182764"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.285803"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9466,7 +9472,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.18317"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.286076"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9479,7 +9485,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.185221"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.286516"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9492,7 +9498,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.187335"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.287253"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9505,7 +9511,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.188269"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.288032"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9518,7 +9524,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.188796"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.288618"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9531,7 +9537,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.189559"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.289319"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9544,7 +9550,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.190276"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.289924"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9557,7 +9563,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.190779"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.290362"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9570,7 +9576,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.191333"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.29091"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9583,7 +9589,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.575764"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.764532"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9596,7 +9602,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.191733"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.291266"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9609,7 +9615,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.192144"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.291675"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9622,7 +9628,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.192373"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.29195"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9635,7 +9641,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.193028"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.292659"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9648,7 +9654,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.193392"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.292993"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9661,7 +9667,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.193719"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.293299"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9674,7 +9680,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.19409"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.293745"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9687,7 +9693,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.194588"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.294218"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9700,7 +9706,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.194933"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.294574"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9713,7 +9719,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.195825"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.294966"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9726,7 +9732,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.578729"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.765218"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9739,7 +9745,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196465"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295589"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9752,7 +9758,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196469"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295593"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9765,7 +9771,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196472"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295596"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9778,7 +9784,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196474"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295599"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9791,7 +9797,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196477"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295601"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9804,7 +9810,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196481"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295605"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9817,7 +9823,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196485"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295608"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9830,7 +9836,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196488"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.29561"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9843,7 +9849,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196491"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295614"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9856,7 +9862,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196494"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295616"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9869,7 +9875,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.579902"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.766317"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9882,7 +9888,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196496"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.29562"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9895,7 +9901,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196509"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295623"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9908,7 +9914,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196513"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295626"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9921,7 +9927,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196516"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295628"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9934,7 +9940,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.19652"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295632"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9947,7 +9953,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196522"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295634"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9960,7 +9966,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196526"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295637"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9973,7 +9979,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196529"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.29564"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9986,7 +9992,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196537"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295643"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -9999,7 +10005,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196541"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295646"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10012,7 +10018,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.580596"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.767004"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10025,7 +10031,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196544"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295648"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10038,7 +10044,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196547"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295651"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10051,7 +10057,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196549"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295654"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10064,7 +10070,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196552"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295657"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10077,7 +10083,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196556"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.29566"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10090,7 +10096,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196558"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295662"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10103,7 +10109,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196561"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295665"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10116,7 +10122,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196564"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295668"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10129,7 +10135,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196569"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295671"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10142,7 +10148,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196572"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295674"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10155,7 +10161,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.497061"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.685985"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10168,7 +10174,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.581366"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.767748"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10181,7 +10187,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196575"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295677"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10194,7 +10200,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196577"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.29568"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10207,7 +10213,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.19658"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295683"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10220,7 +10226,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196584"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295685"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10233,7 +10239,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196588"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295688"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10246,7 +10252,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196592"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295717"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10259,7 +10265,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196626"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.29572"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10272,7 +10278,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.19663"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295723"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10285,7 +10291,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196633"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295726"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10298,7 +10304,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196636"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295729"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10311,7 +10317,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.582068"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.7685"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10324,7 +10330,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196639"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295732"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10337,7 +10343,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196642"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295735"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10350,7 +10356,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196645"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295739"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10363,7 +10369,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196649"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295742"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10376,7 +10382,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196652"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295745"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10389,7 +10395,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196655"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295749"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10402,7 +10408,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196658"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.29576"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10415,7 +10421,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196661"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.295767"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10428,7 +10434,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.196664"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.29577"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10441,11 +10447,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.202048"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.299358"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0001>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0001>
   ] .
 
  [
@@ -10454,7 +10460,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.583332"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.769152"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10467,11 +10473,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.203266"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.300826"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0002>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0002>
   ] .
 
  [
@@ -10480,11 +10486,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.204733"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.301733"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0003>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0003>
   ] .
 
  [
@@ -10493,11 +10499,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.206181"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.302954"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0004>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0004>
   ] .
 
  [
@@ -10506,11 +10512,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.206939"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.303925"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0005>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0005>
   ] .
 
  [
@@ -10519,11 +10525,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.207844"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.304845"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0006>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0006>
   ] .
 
  [
@@ -10532,11 +10538,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.208608"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.305831"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0007>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0007>
   ] .
 
  [
@@ -10545,11 +10551,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.209384"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.306941"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0008>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0008>
   ] .
 
  [
@@ -10558,11 +10564,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.209997"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.3079"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0009>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0009>
   ] .
 
  [
@@ -10571,11 +10577,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.210005"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.30791"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0010>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0011>
   ] .
 
  [
@@ -10584,11 +10590,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.210507"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.308853"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0011>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0012>
   ] .
 
  [
@@ -10597,7 +10603,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.58404"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.769852"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10610,11 +10616,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.211063"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.309556"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0012>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0013>
   ] .
 
  [
@@ -10623,11 +10629,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.211528"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.310329"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0013>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0014>
   ] .
 
  [
@@ -10636,11 +10642,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.212039"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.314296"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0014>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0015>
   ] .
 
  [
@@ -10649,11 +10655,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.215479"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.316132"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0015>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0016>
   ] .
 
  [
@@ -10662,11 +10668,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.216309"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.317556"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0016>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0017>
   ] .
 
  [
@@ -10675,11 +10681,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.216993"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.318562"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0017>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0018>
   ] .
 
  [
@@ -10688,11 +10694,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.217599"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.319581"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0018>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0019>
   ] .
 
  [
@@ -10701,11 +10707,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.218202"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.320908"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0019>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0020>
   ] .
 
  [
@@ -10714,11 +10720,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.219156"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.322117"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0020>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0021>
   ] .
 
  [
@@ -10727,11 +10733,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.22004"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.322944"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0021>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0022>
   ] .
 
  [
@@ -10740,7 +10746,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.584659"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.770498"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10753,11 +10759,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.220559"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.322952"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0022>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0023>
   ] .
 
  [
@@ -10766,11 +10772,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.221024"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.32375"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0023>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0024>
   ] .
 
  [
@@ -10779,11 +10785,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.221537"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.324548"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0024>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0025>
   ] .
 
  [
@@ -10792,11 +10798,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.222059"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.324556"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0025>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0026>
   ] .
 
  [
@@ -10805,11 +10811,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.222501"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.324559"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0026>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0027>
   ] .
 
  [
@@ -10818,11 +10824,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.222986"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.324575"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0027>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0028>
   ] .
 
  [
@@ -10831,11 +10837,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.223683"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.324578"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0028>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0029>
   ] .
 
  [
@@ -10844,11 +10850,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.224476"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.324581"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0029>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0030>
   ] .
 
  [
@@ -10857,11 +10863,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.224988"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.324584"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0030>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0031>
   ] .
 
  [
@@ -10870,11 +10876,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.225474"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.324587"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0031>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0032>
   ] .
 
  [
@@ -10883,7 +10889,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.585083"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.771012"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -10896,11 +10902,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.225913"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.325367"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0032>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0033>
   ] .
 
  [
@@ -10909,11 +10915,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.22641"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.325374"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0033>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0034>
   ] .
 
  [
@@ -10922,11 +10928,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.226869"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.325377"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0034>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0035>
   ] .
 
  [
@@ -10935,11 +10941,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.227345"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.325385"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0035>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0036>
   ] .
 
  [
@@ -10948,11 +10954,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.228249"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.325388"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0036>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0037>
   ] .
 
  [
@@ -10961,11 +10967,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.22876"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.325392"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0037>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0038>
   ] .
 
  [
@@ -10974,11 +10980,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.229219"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.325394"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0038>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0039>
   ] .
 
  [
@@ -10987,11 +10993,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.229647"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.325398"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0039>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0040>
   ] .
 
  [
@@ -11000,11 +11006,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.230237"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.325401"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0040>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0041>
   ] .
 
  [
@@ -11013,11 +11019,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.230804"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.325405"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0041>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0042>
   ] .
 
  [
@@ -11026,7 +11032,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.585566"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.771554"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -11039,11 +11045,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.231317"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.325409"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0042>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0043>
   ] .
 
  [
@@ -11052,11 +11058,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.231793"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.325412"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0043>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0044>
   ] .
 
  [
@@ -11065,11 +11071,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.23224"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.325416"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0044>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0045>
   ] .
 
  [
@@ -11078,11 +11084,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.232782"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.326071"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0045>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0046>
   ] .
 
  [
@@ -11091,11 +11097,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.233261"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.326077"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0046>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0047>
   ] .
 
  [
@@ -11104,11 +11110,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.233695"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.32608"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0047>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0048>
   ] .
 
  [
@@ -11117,11 +11123,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.234219"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.326829"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0048>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0049>
   ] .
 
  [
@@ -11130,11 +11136,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.234765"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.326836"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0049>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0050>
   ] .
 
  [
@@ -11143,11 +11149,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.235546"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.326839"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0050>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0051>
   ] .
 
  [
@@ -11156,11 +11162,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.236298"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.327337"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0051>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0052>
   ] .
 
  [
@@ -11169,7 +11175,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.586065"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.771983"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -11182,11 +11188,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.23663"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.327858"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0052>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0053>
   ] .
 
  [
@@ -11195,11 +11201,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.236964"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.328347"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0053>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0054>
   ] .
 
  [
@@ -11208,63 +11214,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.237264"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0054>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.237766"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0055>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.238469"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0056>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.239631"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0057>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.239638"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.328354"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0058>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0055>
   ] .
 
  [
@@ -11273,11 +11227,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.240202"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.329739"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0059>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0056>
   ] .
 
  [
@@ -11286,11 +11240,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.240865"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.33083"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tg001>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0057>
   ] .
 
  [
@@ -11299,11 +11253,24 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.241532"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.330837"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0058>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.331564"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tg002>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0059>
   ] .
 
  [
@@ -11312,7 +11279,46 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.586694"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.331571"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0060>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.331575"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0061>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.331583"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0062>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:22.772591"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -11325,102 +11331,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.242235"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tg003>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.242915"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tg004>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.244199"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tg005>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.245056"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tg006>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.246243"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tg007>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.24754"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tg008>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.248211"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tg009>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.248218"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.331587"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tp010>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0063>
   ] .
 
  [
@@ -11429,11 +11344,89 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.249123"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.33164"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0064>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.331644"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0065>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.331647"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0066>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.33165"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0067>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.331653"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0068>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.331657"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#teo01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.332512"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tp020>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg001>
   ] .
 
  [
@@ -11442,11 +11435,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.249885"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.332519"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tp021>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg002>
   ] .
 
  [
@@ -11455,7 +11448,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.587172"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.332522"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:22.773104"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -11468,11 +11474,24 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.250716"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.332525"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.333565"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tp046>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg005>
   ] .
 
  [
@@ -11481,11 +11500,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.251393"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.333572"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tp049>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg006>
   ] .
 
  [
@@ -11494,11 +11513,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.25195"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.333575"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
-    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tp050>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg007>
   ] .
 
  [
@@ -11507,10 +11526,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.252546"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.333583"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg008>
   ] .
 
  [
@@ -11519,10 +11539,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.252906"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.333587"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg009>
   ] .
 
  [
@@ -11531,10 +11552,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.253185"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.33359"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg010>
   ] .
 
  [
@@ -11543,10 +11565,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.253533"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.333593"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tin01>
   ] .
 
  [
@@ -11555,10 +11578,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.253806"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.333597"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tin02>
   ] .
 
  [
@@ -11567,10 +11591,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.25408"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+      dc:date "2020-04-06T17:15:23.3336"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tin03>
   ] .
 
  [
@@ -11579,19 +11604,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.254327"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.497778"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.686757"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -11604,7 +11617,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.587746"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.773687"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -11617,7 +11630,111 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.254627"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.334526"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.335371"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.335378"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp046>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.335381"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp049>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.335384"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp050>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.335388"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tra01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.335391"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tra02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.335393"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tra03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.335942"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -11629,7 +11746,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.254938"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.336286"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -11641,103 +11758,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.255186"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.255459"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.255733"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.255988"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.256247"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.256294"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.256548"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.256794"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.588179"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.774161"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -11750,7 +11771,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.257066"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.336566"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -11762,7 +11783,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.257307"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.336904"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -11774,7 +11795,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.257616"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.337168"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -11786,7 +11807,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.257916"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.337433"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -11798,7 +11819,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.258237"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.337705"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -11810,7 +11831,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.258529"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.338006"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -11822,7 +11843,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.258873"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.338366"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -11834,7 +11855,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.259228"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.338625"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -11846,7 +11867,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.259614"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.338913"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -11858,7 +11879,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.259973"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.339202"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -11870,7 +11891,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.58874"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.774798"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -11883,7 +11904,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.260353"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.339563"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -11895,7 +11916,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.260777"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.339859"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -11907,7 +11928,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.261276"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.339917"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -11919,7 +11940,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.261737"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.340192"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -11931,7 +11952,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.262125"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.340336"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -11943,7 +11964,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.262807"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.340495"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -11955,7 +11976,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.264081"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.340751"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -11967,7 +11988,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.264329"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.341059"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -11979,7 +12000,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.264495"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.341393"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -11991,7 +12012,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.26466"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.341774"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12003,7 +12024,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.589399"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.77546"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -12016,7 +12037,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.264845"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.342143"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12028,7 +12049,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.264998"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.342491"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12040,7 +12061,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.265186"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.343133"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12052,7 +12073,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.26538"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.343615"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12064,7 +12085,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.26566"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.343984"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12076,7 +12097,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.265824"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.344391"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12088,7 +12109,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.272629"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.344751"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12100,7 +12121,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.279357"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.345075"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12112,7 +12133,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.286282"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.345368"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12124,7 +12145,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.286631"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.345778"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12136,7 +12157,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.589947"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.776038"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -12149,7 +12170,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.287066"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.346142"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12161,7 +12182,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.287132"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.349265"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12173,7 +12194,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.287456"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.349619"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12185,7 +12206,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.287753"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.349958"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12197,7 +12218,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.288069"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.350164"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12209,7 +12230,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.288383"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.350418"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12221,7 +12242,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.288815"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.350588"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12233,7 +12254,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.289059"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.350814"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12245,7 +12266,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.289305"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.350994"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12257,7 +12278,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.289552"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.351171"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12269,7 +12290,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.590331"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.776522"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -12282,7 +12303,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.289718"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.35136"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12294,7 +12315,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.289891"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.358139"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12306,7 +12327,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.290392"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.364643"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12318,7 +12339,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.290582"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.37073"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12330,7 +12351,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.290741"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.371299"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12342,7 +12363,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.29094"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.371667"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12354,7 +12375,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.291162"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.371726"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12366,7 +12387,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.291419"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.372091"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12378,7 +12399,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.291623"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.372327"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12390,7 +12411,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.291857"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.372533"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12402,7 +12423,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.590802"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.776956"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -12415,7 +12436,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.292196"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.372855"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12427,7 +12448,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.292386"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.373296"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12439,7 +12460,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.292572"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.373544"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12451,7 +12472,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.292806"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.37377"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12463,7 +12484,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.293045"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.37408"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12475,7 +12496,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.293259"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.374254"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12487,7 +12508,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.293318"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.374401"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12499,7 +12520,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.293511"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.374904"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12511,7 +12532,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.293682"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.375064"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12523,7 +12544,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.293862"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.375225"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12535,7 +12556,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.591191"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.777337"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -12548,7 +12569,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.294038"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.375425"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12560,7 +12581,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.294232"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.375669"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12572,7 +12593,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.294441"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.375857"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12584,7 +12605,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.294731"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.376015"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12596,7 +12617,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.294972"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.37623"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12608,7 +12629,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.295254"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.376452"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12620,7 +12641,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.295855"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.376623"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12632,7 +12653,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.296394"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.376828"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12644,7 +12665,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.296719"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.377063"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12656,7 +12677,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.297059"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.377306"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12668,7 +12689,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.591561"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.777734"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -12681,7 +12702,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.297381"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.377611"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12693,7 +12714,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.297623"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.377661"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12705,7 +12726,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.297875"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.377828"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12717,7 +12738,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.298098"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.378009"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12729,7 +12750,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.29837"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.378278"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12741,7 +12762,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.298581"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.378553"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12753,7 +12774,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.298831"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.378764"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12765,7 +12786,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.299065"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.37903"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12777,7 +12798,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.299298"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.379253"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12789,7 +12810,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.299533"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.379862"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12801,7 +12822,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.592053"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.778239"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -12814,7 +12835,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.299774"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.380163"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12826,7 +12847,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.300016"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.380435"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12838,7 +12859,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.300244"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.380738"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12850,7 +12871,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.300521"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.381052"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12862,7 +12883,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.300684"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.381368"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12874,7 +12895,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.308087"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.38165"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12886,7 +12907,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.315576"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.381841"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12898,7 +12919,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.322801"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.382036"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12910,7 +12931,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.323185"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.382194"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12922,7 +12943,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.323604"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.38237"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12934,7 +12955,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.498617"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.687635"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -12947,7 +12968,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.592568"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.778793"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -12960,7 +12981,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.323662"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.382563"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12972,7 +12993,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.32396"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.382797"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12984,7 +13005,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.324235"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.383022"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -12996,7 +13017,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.324492"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.383217"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -13008,7 +13029,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.324815"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.383433"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -13020,7 +13041,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.325233"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.383647"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -13032,7 +13053,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.325467"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.383897"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -13044,7 +13065,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.325707"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.384183"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -13056,7 +13077,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.326054"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.384398"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -13068,7 +13089,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.326415"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.384563"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -13080,7 +13101,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.593086"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.779261"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13093,7 +13114,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.326908"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.391696"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -13105,7 +13126,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.32717"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.399149"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -13117,7 +13138,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.327361"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.406583"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -13129,7 +13150,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:37.327563"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.406993"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
@@ -13141,7 +13162,79 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.594891"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.407424"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.407489"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.40785"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.408935"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.409156"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.409598"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:22.779917"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13154,7 +13247,115 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.596197"^^xsd:date;
+      dc:date "2020-04-06T17:15:23.410061"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.410388"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.410691"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.411144"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.411657"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.412235"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.41259"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.412867"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:23.413087"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-06T17:15:22.780661"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13167,7 +13368,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.596679"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.781177"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13180,7 +13381,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.597124"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.781669"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13193,7 +13394,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.597512"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.782023"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13206,7 +13407,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.597934"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.782426"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13219,7 +13420,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.59835"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.782784"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13232,7 +13433,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.59881"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.7832"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13245,7 +13446,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.499395"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.688333"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13258,7 +13459,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.599301"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.783642"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13271,7 +13472,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.599679"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.784002"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13284,7 +13485,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.600068"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.784454"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13297,7 +13498,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.600481"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.784843"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13310,7 +13511,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.600942"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.785298"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13323,7 +13524,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.601397"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.785884"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13336,7 +13537,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.601818"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.787182"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13349,7 +13550,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.601826"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.787189"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13362,7 +13563,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.601829"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.787192"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13375,7 +13576,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.601836"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.787195"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13388,7 +13589,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.500073"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.689026"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13401,7 +13602,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.601839"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.787199"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13414,7 +13615,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.601843"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.787207"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13427,7 +13628,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.602517"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.78804"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13440,7 +13641,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.603127"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.788681"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13453,7 +13654,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.603685"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.789301"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13466,7 +13667,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.604278"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.789922"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13479,7 +13680,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.605201"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.790565"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13492,7 +13693,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.60582"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.791234"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13505,7 +13706,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.606211"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.791632"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13518,7 +13719,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.606658"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.792014"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13531,7 +13732,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.501185"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.690144"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13544,7 +13745,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.60711"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.792435"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13557,7 +13758,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.607576"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.79281"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13570,7 +13771,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.60798"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.793227"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13583,7 +13784,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.609238"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.794526"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13596,7 +13797,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.610481"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.795232"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13609,7 +13810,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.611184"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.795899"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13622,7 +13823,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.611854"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.796551"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13635,7 +13836,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.612515"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.797181"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13648,7 +13849,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.613132"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.797807"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13661,7 +13862,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.613799"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.798471"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13674,7 +13875,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.501874"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.690861"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13687,7 +13888,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.614437"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.799185"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13700,7 +13901,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.615052"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.799882"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13713,7 +13914,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.616176"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.800539"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13726,7 +13927,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.616823"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.801428"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13739,7 +13940,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.617469"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.802072"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13752,7 +13953,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.618138"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.802707"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13765,7 +13966,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.618783"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.803462"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13778,7 +13979,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.619407"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.804083"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13791,7 +13992,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.620033"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.804733"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13804,7 +14005,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.620747"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.805366"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13817,7 +14018,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.502533"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.691646"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13830,7 +14031,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.621436"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.806051"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13843,7 +14044,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.622139"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.806685"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13856,7 +14057,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.624071"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.807301"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13869,7 +14070,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.62568"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.807963"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13882,7 +14083,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.627125"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.808651"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13895,7 +14096,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.627767"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.809307"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13908,7 +14109,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.628346"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.810009"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13921,7 +14122,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.628954"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.810613"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13934,7 +14135,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.629566"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.811199"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13947,7 +14148,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.630172"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.811803"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13960,7 +14161,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.489811"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.678636"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13973,7 +14174,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.503274"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.693387"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13986,7 +14187,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.630839"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.812462"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -13999,7 +14200,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.631429"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.813039"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14012,7 +14213,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.632067"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.813567"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14025,7 +14226,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.632698"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.81419"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14038,7 +14239,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.633317"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.814733"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14051,7 +14252,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.633984"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.815286"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14064,7 +14265,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.634599"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.815905"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14077,7 +14278,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.635217"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.817703"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14090,7 +14291,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.635873"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.818484"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14103,7 +14304,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.636569"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.819273"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14116,7 +14317,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.504055"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.694153"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14129,7 +14330,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.637179"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.820027"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14142,7 +14343,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.639172"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.820681"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14155,7 +14356,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.63918"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.820689"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14168,7 +14369,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.640179"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.821377"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14181,7 +14382,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.640902"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.821951"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14194,7 +14395,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.642364"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.822634"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14207,7 +14408,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.643014"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.823293"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14220,7 +14421,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.643702"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.823981"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14233,7 +14434,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.644363"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.824587"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14246,7 +14447,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.645171"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.8253"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14259,7 +14460,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.504777"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.694876"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14272,7 +14473,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.645665"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.825833"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14285,7 +14486,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.646137"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.826389"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14298,7 +14499,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.646624"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.826979"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14311,7 +14512,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.647331"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.827575"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14324,7 +14525,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.647924"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.828032"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14337,7 +14538,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.648429"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.828978"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14350,7 +14551,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.649219"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.829288"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14363,7 +14564,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.64974"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.82971"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14376,7 +14577,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.650223"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.830187"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14389,7 +14590,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.650878"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.830929"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14402,7 +14603,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.505866"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.695922"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14415,7 +14616,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.651597"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.831622"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14428,7 +14629,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.652235"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.832529"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14441,7 +14642,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.652993"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.833235"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14454,7 +14655,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.655626"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.834195"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14467,7 +14668,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.656912"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.835015"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14480,7 +14681,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.65775"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.835856"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14493,7 +14694,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.658683"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.836575"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14506,7 +14707,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.661243"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.837227"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14519,7 +14720,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.682014"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.840978"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14532,7 +14733,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.684376"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.841538"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14545,7 +14746,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.50695"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.696625"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14558,7 +14759,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.691993"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.842004"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14571,7 +14772,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.701624"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.842599"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14584,7 +14785,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.710203"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.8432"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14597,7 +14798,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.712018"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.843684"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14610,7 +14811,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.712807"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.84423"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14623,7 +14824,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.713306"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.844713"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14636,7 +14837,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.713931"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.845397"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14649,7 +14850,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.714453"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.845839"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14662,7 +14863,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.71493"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.846384"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14675,7 +14876,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.71596"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.846925"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14688,7 +14889,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.507687"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.697801"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14701,7 +14902,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.717197"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.847476"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14714,7 +14915,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.7184"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.850121"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14727,7 +14928,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.719655"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.850725"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14740,7 +14941,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.720205"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.851452"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14753,7 +14954,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.72091"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.852185"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14766,7 +14967,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.721441"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.852769"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14779,7 +14980,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.721852"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.853172"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14792,7 +14993,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.722504"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.853838"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14805,7 +15006,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.72322"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.854605"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14818,7 +15019,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.723719"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.855005"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14831,7 +15032,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.508414"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.698589"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14844,7 +15045,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.724421"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.855763"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14857,7 +15058,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.724927"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.856373"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14870,7 +15071,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.725538"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.85694"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14883,7 +15084,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.726122"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.857439"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14896,7 +15097,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.726658"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.857928"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14909,7 +15110,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.727317"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.858529"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14922,7 +15123,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.727748"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.859014"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14935,7 +15136,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.728259"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.8596"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14948,7 +15149,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.728724"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.860044"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14961,7 +15162,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.729231"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.860545"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14974,7 +15175,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.509127"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.699301"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -14987,7 +15188,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.729715"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.861078"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15000,7 +15201,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.730185"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.861591"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15013,7 +15214,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.73096"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.862337"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15026,7 +15227,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.731615"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.863068"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15039,7 +15240,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.732107"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.864364"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15052,7 +15253,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.732643"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.864891"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15065,7 +15266,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.734265"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.865515"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15078,7 +15279,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.734916"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.866114"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15091,7 +15292,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.735378"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.866618"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15104,7 +15305,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.735885"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.867134"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15117,7 +15318,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.509813"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.700061"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15130,7 +15331,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.736319"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.867647"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15143,7 +15344,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.736717"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.86805"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15156,7 +15357,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.737162"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.868534"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15169,7 +15370,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.737698"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.869096"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15182,7 +15383,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.738136"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.869621"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15195,7 +15396,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.738616"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.870093"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15208,7 +15409,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.739367"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.870601"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15221,7 +15422,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.739898"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.871063"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15234,7 +15435,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.740394"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.871491"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15247,7 +15448,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.740859"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.871984"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15260,7 +15461,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.510893"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.701708"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15273,7 +15474,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.741331"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.872406"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15286,7 +15487,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.741941"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.873403"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15299,7 +15500,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.742403"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.873987"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15312,7 +15513,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.742902"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.874453"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15325,7 +15526,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.743355"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.87496"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15338,7 +15539,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.743932"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.8755"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15351,7 +15552,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.744416"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.87598"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15364,7 +15565,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.745069"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.876649"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15377,7 +15578,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.745625"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.877275"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15390,7 +15591,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.746095"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.877796"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15403,7 +15604,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.490614"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.679478"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15416,7 +15617,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.511588"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.702467"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15429,7 +15630,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.746687"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.87832"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15442,7 +15643,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.749423"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.878905"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15455,7 +15656,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.750368"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.879539"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15468,7 +15669,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.750841"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.880259"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15481,7 +15682,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.751314"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.880719"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15494,7 +15695,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.751804"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.881251"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15507,7 +15708,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.752297"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.881798"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15520,7 +15721,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.752872"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.88225"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15533,7 +15734,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.753364"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.882822"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15546,7 +15747,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.753803"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.883235"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15559,7 +15760,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.512265"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.703153"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15572,7 +15773,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.75423"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.883696"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15585,7 +15786,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.754993"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.884451"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15598,7 +15799,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.755576"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.88516"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15611,7 +15812,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.756024"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.885697"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15624,7 +15825,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.756539"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.886359"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15637,7 +15838,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.757029"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.886804"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15650,7 +15851,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.757484"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.887307"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15663,7 +15864,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.757955"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.887763"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15676,7 +15877,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.758425"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.888218"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15689,7 +15890,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.758924"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.888678"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15702,7 +15903,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.512983"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.70386"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15715,7 +15916,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.759381"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.889159"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15728,7 +15929,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.759857"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.889688"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15741,7 +15942,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.760386"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.890155"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15754,7 +15955,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.760776"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.890597"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15767,7 +15968,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.761232"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.891041"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15780,7 +15981,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.761795"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.891479"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15793,7 +15994,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.762578"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.89202"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15806,7 +16007,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.763389"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.892544"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15819,7 +16020,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.764424"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.893026"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15832,7 +16033,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.765414"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.893503"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15845,7 +16046,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.5137"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.704706"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15858,7 +16059,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.767"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.893969"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15871,7 +16072,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.7675"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.894536"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15884,7 +16085,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.767989"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.895917"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15897,7 +16098,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.768432"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.896446"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15910,7 +16111,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.768915"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.896937"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15923,7 +16124,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.769376"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.897379"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15936,7 +16137,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.769832"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.897837"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15949,7 +16150,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.770296"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.898276"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15962,7 +16163,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.771273"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.898779"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15975,7 +16176,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.771766"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.899298"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -15988,7 +16189,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.515038"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.705439"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16001,7 +16202,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.772226"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.899767"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16014,7 +16215,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.772695"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.90029"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16027,7 +16228,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.773154"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.900793"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16040,7 +16241,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.773602"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.901271"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16053,7 +16254,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.774118"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.902242"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16066,7 +16267,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.774617"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.902814"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16079,7 +16280,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.775175"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.903324"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16092,7 +16293,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.775693"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.903803"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16105,7 +16306,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.776791"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.904251"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16118,7 +16319,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.777194"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.904688"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16131,7 +16332,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.515862"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.706137"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16144,7 +16345,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.777565"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.90519"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16157,7 +16358,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.778007"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.905778"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16170,7 +16371,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.778499"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.906208"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16183,7 +16384,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.778866"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.906625"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16196,7 +16397,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.778874"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.906633"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16209,7 +16410,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.778877"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.906636"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16222,7 +16423,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.780028"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.907091"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16235,7 +16436,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.780836"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.907513"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16248,7 +16449,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.78208"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.908565"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16261,7 +16462,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.783884"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.910211"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16274,7 +16475,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.516728"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.706944"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16287,7 +16488,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.785625"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.912276"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16300,7 +16501,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.786067"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.912695"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16313,7 +16514,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.787032"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.913099"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16326,7 +16527,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.787498"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.913601"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16339,7 +16540,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.787973"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.91406"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16352,7 +16553,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.78848"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.914555"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16365,7 +16566,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.788951"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.915072"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16378,7 +16579,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.789471"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.915551"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16391,7 +16592,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.789908"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.916059"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16404,7 +16605,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.790399"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.916602"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16417,7 +16618,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.518438"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.708285"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16430,7 +16631,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.790837"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.9171"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16443,7 +16644,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.791277"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.917587"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16456,7 +16657,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.791755"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.918069"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16469,7 +16670,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.792277"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.918493"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16482,7 +16683,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.792774"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.919028"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16495,7 +16696,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.793901"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.919613"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16508,7 +16709,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.794611"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.920076"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16521,7 +16722,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.796088"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.92064"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16534,7 +16735,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.797053"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.921088"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16547,7 +16748,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.797834"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.921502"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16560,7 +16761,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.519071"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.708936"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16573,7 +16774,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.798203"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.921853"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16586,7 +16787,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.798676"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.922357"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16599,7 +16800,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.799016"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.922723"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16612,7 +16813,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.799503"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.92327"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16625,7 +16826,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.800043"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.923641"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16638,7 +16839,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.800696"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.924085"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16651,7 +16852,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.801121"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.924628"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16664,7 +16865,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.801573"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.925011"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16677,7 +16878,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.801916"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.925434"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16690,7 +16891,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.802205"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.925848"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16703,7 +16904,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.519679"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.709459"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16716,7 +16917,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.802567"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.926152"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16729,7 +16930,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.802748"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.926351"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16742,7 +16943,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.802928"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.926554"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16755,7 +16956,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.802934"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.92656"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16768,7 +16969,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.802938"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.926569"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16781,7 +16982,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.802943"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.926573"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16794,7 +16995,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.803694"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.927367"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16807,7 +17008,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.804124"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.928"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16820,7 +17021,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.8046"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.928789"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16833,7 +17034,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.805169"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.929386"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16846,7 +17047,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.491353"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.680162"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16859,7 +17060,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.520278"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.710081"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16872,7 +17073,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.805595"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.9299"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16885,7 +17086,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.806043"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.930414"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16898,7 +17099,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.806529"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.930911"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16911,7 +17112,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.80699"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.93143"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16924,7 +17125,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.807475"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.932187"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16937,7 +17138,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.807712"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.932451"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16950,7 +17151,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.807947"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.932723"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16963,7 +17164,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.808233"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.933025"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16976,7 +17177,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.808247"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.933032"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -16989,7 +17190,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.809025"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.933296"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17002,7 +17203,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.520992"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.710717"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17015,7 +17216,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.809443"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.933617"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17028,7 +17229,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.810337"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.933901"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17041,7 +17242,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.811235"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.934205"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17054,7 +17255,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.811692"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.934511"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17067,7 +17268,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.81295"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.934847"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17080,7 +17281,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.813236"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.935119"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17093,7 +17294,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.813514"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.935393"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17106,7 +17307,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.813811"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.935649"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17119,7 +17320,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.814136"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.935919"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17132,7 +17333,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.814443"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.936159"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17145,7 +17346,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.521672"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.711302"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17158,7 +17359,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.814852"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.936512"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17171,7 +17372,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.815124"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.93675"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17184,7 +17385,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.815403"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.936982"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17197,7 +17398,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.81567"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.937255"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17210,7 +17411,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.815995"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.937511"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17223,7 +17424,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.816306"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.938019"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17236,7 +17437,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.816579"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.938228"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17249,7 +17450,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.816775"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.938433"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17262,7 +17463,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.816977"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.938645"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17275,7 +17476,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.81719"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.938885"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17288,7 +17489,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.522464"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.712107"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17301,7 +17502,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.817445"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.939183"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17314,7 +17515,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.81771"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.939435"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17327,7 +17528,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.817986"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.939738"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17340,7 +17541,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.818252"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.940007"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17353,7 +17554,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.818506"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.940244"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17366,7 +17567,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.818801"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.940591"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17379,7 +17580,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.819593"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.941445"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17392,7 +17593,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.819914"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.941876"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17405,7 +17606,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.820181"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.942097"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17418,7 +17619,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.820447"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.942336"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17431,7 +17632,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.523181"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.712867"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17444,7 +17645,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.820678"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.942617"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17457,7 +17658,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.820908"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.942851"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17470,7 +17671,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.821134"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.94312"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17483,7 +17684,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.821394"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.943392"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17496,7 +17697,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.821671"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.943683"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17509,7 +17710,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.821951"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.943914"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17522,7 +17723,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.822249"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.944224"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17535,7 +17736,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.822563"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.944519"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17548,7 +17749,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.822854"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.9448"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17561,7 +17762,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.823117"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.945027"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17574,7 +17775,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.523816"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.713453"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17587,7 +17788,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.823377"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.945269"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17600,7 +17801,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.823674"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.945517"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17613,7 +17814,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.823942"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.945737"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17626,7 +17827,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.82422"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.945968"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17639,7 +17840,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.82451"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.946226"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17652,7 +17853,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.825198"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.946513"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17665,7 +17866,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.825647"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.946808"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17678,7 +17879,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.826757"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.94713"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17691,7 +17892,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.827052"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.947447"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17704,7 +17905,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.827332"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.94768"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17717,7 +17918,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.52443"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.714136"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17730,7 +17931,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.827602"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.947919"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17743,7 +17944,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.827609"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.947927"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17756,7 +17957,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.828067"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.948196"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17769,7 +17970,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.82856"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.94851"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17782,7 +17983,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.828858"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.94882"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17795,7 +17996,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.829277"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.949242"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17808,7 +18009,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.830328"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.949715"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17821,7 +18022,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.83081"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.950131"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17834,7 +18035,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.831276"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.950595"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17847,7 +18048,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.831703"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.951067"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17860,7 +18061,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.525128"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.714819"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17873,7 +18074,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.832525"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.951868"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17886,7 +18087,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.83281"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.952147"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17899,7 +18100,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.833048"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.952402"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17912,7 +18113,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.833288"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.952691"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17925,7 +18126,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.833741"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.953296"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17938,7 +18139,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.834487"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.953775"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17951,7 +18152,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.834947"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.954197"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17964,7 +18165,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.835393"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.95468"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17977,7 +18178,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.835842"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.95517"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -17990,7 +18191,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.836136"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.955616"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -18003,7 +18204,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.525902"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.71551"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -18016,7 +18217,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.836465"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.955979"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -18029,7 +18230,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.836746"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.956394"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -18042,7 +18243,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.837073"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.956763"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -18055,7 +18256,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.837386"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.957177"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -18068,7 +18269,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.837825"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.957633"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -18081,7 +18282,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.838246"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.958261"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -18094,7 +18295,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.838723"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.959232"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -18107,7 +18308,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.839138"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.959792"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -18120,7 +18321,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.839487"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.960185"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -18133,7 +18334,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.840234"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.960615"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -18146,7 +18347,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.526639"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.71623"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -18159,7 +18360,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.841066"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.961111"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -18172,7 +18373,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.842478"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.961702"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -18185,7 +18386,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.84287"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.962159"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -18198,7 +18399,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.843248"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.962515"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -18211,7 +18412,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.843513"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.962798"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -18224,7 +18425,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.843762"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.963141"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -18237,7 +18438,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.844012"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.963451"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -18250,7 +18451,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.844574"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.963965"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -18263,7 +18464,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.845039"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.964397"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
@@ -18276,7 +18477,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-04T02:12:36.845484"^^xsd:date;
+      dc:date "2020-04-06T17:15:22.964836"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;

--- a/reports/jsonld-gold-earl.ttl
+++ b/reports/jsonld-gold-earl.ttl
@@ -1,0 +1,18284 @@
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://github.com/piprate/json-gold> a doap:Project,
+    <http://www.w3.org/ns/earl#TestSubject>,
+    <http://www.w3.org/ns/earl#Software>;
+  dc:title "JSON-goLD";
+  dc:creator <https://github.com/kazarena>;
+  dc:date "2020-04-04"^^xsd:date;
+  doap:description "A JSON-LD processor for Go";
+  doap:developer <https://github.com/kazarena>;
+  doap:homepage <https://github.com/piprate/json-gold>;
+  doap:license <https://github.com/piprate/json-gold/blob/master/LICENSE>;
+  doap:name "JSON-goLD";
+  doap:programming-language "Go" .
+
+<https://github.com/kazarena> a foaf:Person,
+    <http://www.w3.org/ns/earl#Assertor>;
+  foaf:homepage <https://github.com/kazarena>;
+  foaf:name "Stan Nazarenko" .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.488006"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.492095"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.527195"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0051>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.845948"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tli03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.846447"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tli04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.846981"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tli05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.847443"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tli06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.847897"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tli07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.848354"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tli08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.848847"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tli09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.849337"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tli10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.84983"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.850292"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.52786"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0052>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.850748"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.851203"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.852209"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.852688"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.853139"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.85358"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.854048"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.854538"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.855072"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.856365"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.528465"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0053>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.856843"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.857381"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm014>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.85865"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.859159"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.859615"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.860077"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.860547"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.860755"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.861179"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tn001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.861631"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tn002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.529409"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0054>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.863141"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tn003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.863633"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tn004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.864127"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tn005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.864612"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tn006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.865071"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tn007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.865516"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tn008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.865911"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tp001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.866397"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tp002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.866863"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tp003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.867281"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tp004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.530084"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0055>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.867579"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.867836"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.868112"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.868416"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.868711"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.869211"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.869982"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.870981"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.871817"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.872149"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.530732"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0056>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.872942"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.873238"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.873594"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.873933"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.874192"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.874394"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.874671"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.874971"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.875315"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.87567"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.531703"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0057>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.875917"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.876218"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr12>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.876557"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr13>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.876901"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr14>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.877252"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr15>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.877646"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr16>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.877884"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr17>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.878132"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr18>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.87851"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr19>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.878772"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr20>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.532381"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0058>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.879014"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr21>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.879381"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr22>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.879796"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr23>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.880252"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr24>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.881049"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr25>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.881596"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr26>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.882119"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr27>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.882126"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr28>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.882585"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr29>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.883415"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr30>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.533051"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0059>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.883746"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr31>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.884109"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr32>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.884366"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr33>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.884664"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr34>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.885015"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr35>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.885283"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr36>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.885562"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr37>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.88557"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr38>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.885573"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr39>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.885958"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr40>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.533759"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0060>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.886131"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tso01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.886309"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tso02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.886661"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tso03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.887607"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tso05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.888936"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tso06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.889922"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tso07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.891259"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tso08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.891976"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tso09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.892526"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tso10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.893111"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tso11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.493023"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.534523"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0061>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.893491"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tso12>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.893985"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tso13>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.894295"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ttn01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.894844"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ttn02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.897893"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.898634"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.899061"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.899727"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.90028"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.900781"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.535192"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0062>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.901324"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.90227"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.903163"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.904613"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.905593"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.90618"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.906679"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.907283"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.907939"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.908664"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.535899"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0063>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.909237"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.909932"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.910655"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.911391"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.911815"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.912589"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0023>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.91313"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0024>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.913617"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0025>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.914136"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0027>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.914633"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0028>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.536605"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0064>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.915115"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0030>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.915716"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0031>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.916164"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0032>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.916664"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0033>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.917179"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0034>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.917772"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0035>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.91982"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0036>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.920828"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0037>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.921497"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0039>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.922061"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0040>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.537263"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0065>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.922643"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0041>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.923083"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0042>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.923593"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0043>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.924238"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0044>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.92472"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0045>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.925154"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0046>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.925608"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0047>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.926056"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0048>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.926574"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0049>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.926869"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#te001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.538583"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0066>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.927153"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#tin01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.927434"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#tin02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.927922"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#tin03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.928374"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#tin04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.928803"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#tin05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.929618"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#tin06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.930057"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#tli01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.930517"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#tli02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.931025"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#tli03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.932429"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.539294"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0067>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.932762"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.933214"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.935145"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.936103"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.936623"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.937214"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.937581"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.937962"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.938331"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.938694"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.540309"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0068>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.939043"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.939407"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0014>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.939732"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.940133"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.940489"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.940876"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.941224"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.941614"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.941982"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.942341"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.541077"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0069>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.942641"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0023>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.942952"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0024>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.943245"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0025>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.943536"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0026>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.943916"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.944069"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.944242"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.944417"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.944424"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.944427"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.541742"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0070>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.944716"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.945028"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.945346"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.945632"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.945639"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.945642"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi12>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.945645"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.94565"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.945653"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.945656"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.493741"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.542399"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0071>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.945659"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.945663"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.945665"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.945669"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.945672"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.945675"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.945678"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.946071"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tli01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.946486"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tli02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.946611"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tli03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.542972"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0072>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.949945"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.95086"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.95211"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.952242"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.952511"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.952747"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.952974"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.953073"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.953569"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.954239"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.543652"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0073>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.954898"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.955137"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.955144"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.955147"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#tla01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.957314"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#tla02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.95773"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#tla03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.958165"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#tla04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.958175"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#tla05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.963346"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.964043"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.54428"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0074>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.964969"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.965726"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.966578"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.967134"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.967932"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.968656"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.9692"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.969803"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.970298"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.97084"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.544912"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0075>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.97134"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.972305"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0014>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.972956"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.97349"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.973934"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.974374"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.974908"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.975439"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.97587"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.976299"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0023>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.546615"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0076>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.976765"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0024>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.977302"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0025>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.977789"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0026>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.97876"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0027>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.97968"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0028>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.98067"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0029>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.982434"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0030>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.983818"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0031>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.984522"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0032>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.985231"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0033>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.548016"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0077>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.98594"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0034>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.986576"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0035>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.98717"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0036>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.987629"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0113>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.98807"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0114>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.9886"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0115>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.989032"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0116>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.989503"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0117>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.990017"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0119>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.990023"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0120>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.549043"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0078>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.990026"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0121>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.990029"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0122>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.990032"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0123>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.990035"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0124>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.990038"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0125>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.990041"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0126>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.990044"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0127>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.990046"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0128>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.990048"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0129>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.990052"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0130>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.549871"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0079>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.990054"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0131>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.990057"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0132>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.990537"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.991044"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.99157"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.992069"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.992696"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.993194"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.993663"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.994068"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.551023"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0080>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.995087"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.995603"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.996146"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.996583"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.997199"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.997609"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc014>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.998221"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.998718"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.999191"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.999693"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.494417"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.551618"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0081>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.000434"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.000922"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.001574"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.002131"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.002658"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc023>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.003336"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc024>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.003922"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc025>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.004435"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc026>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.004938"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc027>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.005859"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc028>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.5522"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0082>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.006145"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc029>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.006315"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc030>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.006322"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc031>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.006326"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc032>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.006329"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc033>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.007262"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc034>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.007796"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc035>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.008374"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.009178"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.009777"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.552842"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0083>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.010233"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.010661"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.011091"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.01152"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.011697"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.012626"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.01307"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.013569"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.014814"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi12>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.015153"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.553454"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0084>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.016064"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.016378"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.017348"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.018214"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.018802"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.01927"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.019744"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.020683"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.021202"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.021748"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.554066"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0085>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.022678"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.023485"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.024136"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.024869"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.0258"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.026554"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.026836"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.027811"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.029572"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.030022"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.554654"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0086>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.03104"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te023>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.031656"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te024>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.032202"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te025>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.033097"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te027>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.034258"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te028>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.036213"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te029>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.036878"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te030>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.03754"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te031>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.03802"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te032>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.038538"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te033>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.55526"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0087>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.039098"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te034>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.039786"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te035>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.041312"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te036>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.042656"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te037>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.043859"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te039>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.045912"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te040>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.047497"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te041>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.048147"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te042>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.048782"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te043>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.049363"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te044>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.555767"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0088>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.049627"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te045>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.049885"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te046>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.050317"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te047>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.051012"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te048>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.051534"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te049>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.051911"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te050>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.052292"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te051>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.052733"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te052>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.053022"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te053>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.05339"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te054>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.556446"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0089>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.053703"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te055>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.054322"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te056>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.055228"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te057>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.055621"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te058>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.056261"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te059>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.056907"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te060>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.057291"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te061>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.059074"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te062>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.059714"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te063>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.060232"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te064>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.557108"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0090>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.060719"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te065>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.061345"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te066>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.061751"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te067>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.062083"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te068>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.062513"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te069>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.062942"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te070>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.063439"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te072>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.064689"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te073>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.065299"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te074>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.066041"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te075>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.495086"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.557741"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0091>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.066436"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te076>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.067274"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te077>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.068296"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te078>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.06867"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te079>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.06904"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te080>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.069462"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te081>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.069803"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te082>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.070255"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te083>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.070652"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te084>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.07108"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te085>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.558396"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0092>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.071556"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te086>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.071944"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te087>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.072706"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te088>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.073048"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te089>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.073441"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te090>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.073818"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te091>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.074863"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te092>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.075451"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te093>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.075885"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te094>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.076815"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te095>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.559123"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0093>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.07723"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te096>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.077623"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te097>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.078049"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te098>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.078503"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te099>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.078969"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te100>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.079503"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te101>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.079921"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te102>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.08037"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te103>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.080902"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te104>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.081487"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te105>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.559801"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0094>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.082063"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te106>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.082635"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te107>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.083264"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te108>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.083611"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te109>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.085136"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te110>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.086158"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te111>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.087048"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te112>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.08785"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te113>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.088218"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te114>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.088598"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te117>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.560474"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0095>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.089167"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te118>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.089877"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te119>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.091009"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te120>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.092247"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te121>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.093116"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te122>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.093125"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te123>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.093709"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0124>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.094172"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0125>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.095235"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te126>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.09672"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te127>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.561644"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0096>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.098965"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te128>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.099526"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te129>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.100029"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te130>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.100334"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tec01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.100342"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tec02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.100565"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tem01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.100767"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ten01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.100948"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ten02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.101135"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ten03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.101327"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ten04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.562334"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0097>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.101524"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ten05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.101696"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ten06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.101885"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tep02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.102032"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tep03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.102223"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.102445"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.102757"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.102954"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.103167"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.103427"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.562964"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0098>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.103709"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.10392"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.104124"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.104385"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter12>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.104687"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter13>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.106127"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter14>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.107321"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter15>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.107711"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter17>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.107971"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter18>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.109522"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter19>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.563617"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0099>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.109865"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter20>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.110124"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter21>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.110355"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter22>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.110566"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter23>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.110778"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter25>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.111062"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter26>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.111313"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter27>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.111568"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter28>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.11184"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter29>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.112089"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter30>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.564294"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0100>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.112332"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter31>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.112784"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter33>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.113422"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter34>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.113815"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter35>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.114129"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter36>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.114385"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter37>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.114658"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter38>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.114859"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter39>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.115053"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter40>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.115234"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter41>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.489081"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.495839"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.564899"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0101>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.115412"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter42>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.115684"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter43>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.115945"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter44>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.116217"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter48>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.11642"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter49>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.11669"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter50>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.116928"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter51>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.116934"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter52>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.117115"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter53>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.117628"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.56557"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0102>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.118139"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.118681"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.119236"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.11975"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.121803"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.122067"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.122433"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.122747"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.123196"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.123681"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.566219"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0103>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.124194"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.124665"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.125146"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.125651"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.126215"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.126675"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.127074"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.127589"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.128077"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.128552"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs12>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.566854"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0104>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.129052"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs13>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.129589"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs14>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.129934"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs15>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.130357"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs16>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.13123"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs17>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.131587"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs18>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.131996"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs19>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.132324"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs20>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.132647"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs21>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.133024"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs22>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.567396"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0105>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.133357"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs23>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.13393"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.134463"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.134952"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.135391"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.135802"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.136216"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.136699"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.137715"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.138313"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.567955"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0106>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.13879"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.139243"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.139683"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.140076"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.140535"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.140898"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.141243"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.142214"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.142644"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.143154"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.568576"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0107>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.14367"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.14407"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.144472"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.144839"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.145204"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm014>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.145543"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.145911"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.146448"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.146982"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.147427"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.569239"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0108>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.147701"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.148071"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.148496"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.148968"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.149407"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.149833"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.150272"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.150954"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.152761"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.153654"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.570038"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0109>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.154348"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.155107"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.156003"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.156404"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.156754"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.157115"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.157509"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.157905"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.158303"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.158709"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.570535"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0110>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.159095"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt12>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.159447"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt13>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.159792"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt14>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.160109"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt15>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.160411"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt16>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.160911"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tp001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.161388"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tp002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.16194"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tp003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.16234"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tp004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.162522"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.496447"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.57127"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.162731"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.162939"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.163149"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.163871"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.164541"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.16527"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.165967"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.166854"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.168144"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.168592"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.572246"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.168807"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.169288"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.169548"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.169773"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.17001"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.170322"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.170646"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.170882"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.171291"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.171522"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.572964"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.17179"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr12>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.17216"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr13>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.172557"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr14>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.172951"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr15>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.173504"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr16>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.173746"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr17>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.173936"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr18>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.174849"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr19>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.1751"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr20>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.17536"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr21>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.573627"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.175829"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr22>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.17619"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr23>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.176545"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr24>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.177297"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr25>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.177621"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr26>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.177987"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr27>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.177995"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr28>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.178356"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr29>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.178741"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr30>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.17898"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr31>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.57432"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.179242"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr32>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.179422"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr33>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.179917"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr34>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.180367"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr35>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.18083"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr36>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.181297"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr37>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.181304"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr38>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.181307"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr39>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.181805"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr40>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.182381"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#trt01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.574992"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.182764"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.18317"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.185221"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.187335"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.188269"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.188796"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.189559"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.190276"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.190779"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.191333"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.575764"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.191733"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso12>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.192144"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso13>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.192373"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ttn01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.193028"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ttn02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.193392"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.193719"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.19409"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.194588"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.194933"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.195825"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.578729"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196465"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196469"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tex01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196472"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196474"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196477"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196481"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196485"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196488"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196491"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196494"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.579902"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196496"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196509"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196513"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te014>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196516"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.19652"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196522"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196526"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196529"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196537"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196541"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.580596"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196544"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196547"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tc001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196549"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tc002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196552"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tc003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196556"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tc004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196558"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tf001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196561"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tf002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196564"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tf003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196569"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tf004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196572"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.497061"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.581366"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196575"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196577"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.19658"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196584"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196588"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196592"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196626"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.19663"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196633"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196636"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.582068"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196639"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr014>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196642"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196645"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196649"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196652"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196655"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196658"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196661"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.196664"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.202048"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.583332"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.203266"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.204733"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.206181"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.206939"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.207844"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.208608"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.209384"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.209997"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.210005"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.210507"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.58404"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc014>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.211063"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.211528"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.212039"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0014>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.215479"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.216309"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.216993"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.217599"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.218202"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.219156"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.22004"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.584659"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.220559"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.221024"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0023>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.221537"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0024>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.222059"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0025>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.222501"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0026>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.222986"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0027>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.223683"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0028>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.224476"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0029>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.224988"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0030>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.225474"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0031>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.585083"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.225913"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0032>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.22641"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0033>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.226869"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0034>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.227345"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0035>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.228249"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0036>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.22876"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0037>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.229219"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0038>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.229647"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0039>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.230237"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0040>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.230804"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0041>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.585566"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.231317"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0042>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.231793"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0043>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.23224"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0044>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.232782"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0045>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.233261"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0046>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.233695"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0047>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.234219"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0048>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.234765"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0049>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.235546"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0050>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.236298"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0051>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.586065"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.23663"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0052>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.236964"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0053>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.237264"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0054>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.237766"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0055>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.238469"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0056>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.239631"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0057>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.239638"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0058>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.240202"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#t0059>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.240865"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tg001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.241532"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tg002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.586694"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.242235"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tg003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.242915"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tg004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.244199"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tg005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.245056"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tg006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.246243"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tg007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.24754"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tg008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.248211"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tg009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.248218"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tp010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.249123"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tp020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.249885"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tp021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.587172"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.250716"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tp046>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.251393"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tp049>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.25195"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://json-ld.org/test-suite/tests/frame-manifest#tp050>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.252546"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.252906"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.253185"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.253533"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.253806"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.25408"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.254327"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.497778"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0014>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.587746"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.254627"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.254938"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.255186"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.255459"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.255733"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.255988"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.256247"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.256294"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.256548"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.256794"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.588179"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.257066"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.257307"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.257616"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.257916"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.258237"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.258529"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.258873"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.259228"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.259614"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.259973"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.58874"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc023>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.260353"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.260777"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.261276"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.261737"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.262125"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.262807"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.264081"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.264329"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.264495"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.26466"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.589399"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc024>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.264845"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.264998"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.265186"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.26538"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.26566"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.265824"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.272629"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.279357"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.286282"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.286631"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.589947"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc025>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.287066"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.287132"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.287456"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.287753"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.288069"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.288383"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.288815"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.289059"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.289305"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.289552"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.590331"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc026>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.289718"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.289891"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.290392"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.290582"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.290741"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.29094"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.291162"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.291419"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.291623"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.291857"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.590802"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc027>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.292196"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.292386"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.292572"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.292806"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.293045"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.293259"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.293318"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.293511"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.293682"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.293862"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.591191"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.294038"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.294232"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.294441"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.294731"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.294972"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.295254"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.295855"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.296394"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.296719"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.297059"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.591561"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.297381"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.297623"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.297875"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.298098"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.29837"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.298581"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.298831"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.299065"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.299298"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.299533"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.592053"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.299774"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.300016"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.300244"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.300521"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.300684"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.308087"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.315576"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.322801"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.323185"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.323604"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.498617"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.592568"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.323662"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.32396"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.324235"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.324492"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.324815"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.325233"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.325467"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.325707"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.326054"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.326415"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.593086"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.326908"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.32717"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.327361"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:37.327563"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.594891"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.596197"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.596679"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#te002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.597124"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#ten01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.597512"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tep05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.597934"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tep06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.59835"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tep07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.59881"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tep08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.499395"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.599301"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tep09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.599679"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tep10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.600068"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tep11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.600481"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tep12>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.600942"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tep13>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.601397"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tep14>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.601818"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tep15>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.601826"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tin01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.601829"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tin02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.601836"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tin03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.500073"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.601839"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tin04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.601843"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tin05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.602517"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.603127"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.603685"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.604278"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.605201"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.60582"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.606211"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.606658"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.501185"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.60711"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.607576"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.60798"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.609238"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tla01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.610481"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tli01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.611184"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tli02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.611854"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tli03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.612515"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tli04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.613132"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tli05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.613799"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.501874"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.614437"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.615052"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.616176"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.616823"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.617469"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.618138"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.618783"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.619407"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.620033"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.620747"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.502533"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.621436"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.622139"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.624071"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm014>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.62568"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.627125"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.627767"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.628346"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.628954"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.629566"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.630172"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.489811"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.503274"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.630839"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.631429"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tn001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.632067"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tn002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.632698"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tn003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.633317"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tn004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.633984"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tn005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.634599"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tn006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.635217"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tn007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.635873"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tn008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.636569"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tn009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.504055"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.637179"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tn010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.639172"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tn011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.63918"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tp001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.640179"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tp002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.640902"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tp003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.642364"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tp004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.643014"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tp005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.643702"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tp006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.644363"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tp007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.645171"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tp008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.504777"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0023>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.645665"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tpi01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.646137"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tpi02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.646624"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tpi03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.647331"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tpi04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.647924"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tpi05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.648429"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tpi06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.649219"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tpr01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.64974"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tpr02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.650223"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tpr03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.650878"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tpr04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.505866"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0024>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.651597"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tpr05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.652235"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tr001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.652993"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tr002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.655626"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#ts001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.656912"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#ts002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.65775"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#ttn01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.658683"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#ttn02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.661243"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#ttn03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.682014"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.684376"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.50695"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0025>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.691993"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.701624"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.710203"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.712018"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.712807"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.713306"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.713931"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.714453"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.71493"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.71596"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.507687"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0026>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.717197"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.7184"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0014>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.719655"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.720205"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.72091"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.721441"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.721852"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.722504"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.72322"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.723719"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.508414"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0027>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.724421"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0023>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.724927"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0024>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.725538"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0025>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.726122"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0027>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.726658"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0028>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.727317"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0029>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.727748"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0030>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.728259"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0031>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.728724"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0032>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.729231"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0033>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.509127"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0028>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.729715"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0034>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.730185"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0035>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.73096"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0036>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.731615"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0037>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.732107"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0039>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.732643"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0040>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.734265"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0041>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.734916"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0042>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.735378"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0043>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.735885"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0044>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.509813"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0029>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.736319"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0045>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.736717"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0046>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.737162"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0047>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.737698"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0048>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.738136"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0049>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.738616"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0050>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.739367"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0051>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.739898"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0052>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.740394"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0053>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.740859"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0054>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.510893"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0030>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.741331"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0055>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.741941"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0056>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.742403"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0057>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.742902"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0058>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.743355"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0059>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.743932"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0060>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.744416"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0061>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.745069"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0062>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.745625"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0063>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.746095"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0064>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.490614"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.511588"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0031>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.746687"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0065>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.749423"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0066>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.750368"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0067>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.750841"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0068>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.751314"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0069>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.751804"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0070>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.752297"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0072>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.752872"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0073>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.753364"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0074>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.753803"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0075>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.512265"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0032>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.75423"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0076>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.754993"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0077>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.755576"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0078>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.756024"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0079>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.756539"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0080>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.757029"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0081>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.757484"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0082>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.757955"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0083>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.758425"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0084>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.758924"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0085>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.512983"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0033>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.759381"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0086>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.759857"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0087>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.760386"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0088>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.760776"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0089>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.761232"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0090>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.761795"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0091>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.762578"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0092>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.763389"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0093>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.764424"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0094>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.765414"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0095>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.5137"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0034>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.767"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0096>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.7675"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0097>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.767989"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0098>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.768432"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0099>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.768915"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0100>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.769376"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0101>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.769832"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0102>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.770296"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0103>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.771273"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0104>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.771766"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0105>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.515038"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0035>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.772226"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0106>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.772695"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0107>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.773154"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0108>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.773602"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0109>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.774118"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0110>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.774617"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0111>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.775175"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0112>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.775693"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0113>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.776791"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0114>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.777194"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0117>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.515862"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0036>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.777565"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0118>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.778007"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0119>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.778499"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0120>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.778866"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0121>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.778874"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0122>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.778877"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0123>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.780028"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0124>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.780836"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0125>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.78208"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0126>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.783884"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0127>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.516728"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0037>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.785625"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0128>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.786067"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0129>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.787032"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0130>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.787498"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.787973"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.78848"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.788951"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.789471"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.789908"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.790399"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.518438"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#ta038>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.790837"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.791277"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.791755"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.792277"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.792774"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.793901"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.794611"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc014>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.796088"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.797053"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.797834"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.519071"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0039>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.798203"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.798676"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.799016"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.799503"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.800043"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.800696"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc023>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.801121"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc024>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.801573"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc025>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.801916"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc026>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.802205"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc027>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.519679"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0040>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.802567"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc028>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.802748"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc029>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.802928"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc030>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.802934"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#untested>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc031>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.802938"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc032>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.802943"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc033>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.803694"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc034>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.804124"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc035>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.8046"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.805169"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.491353"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.520278"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0041>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.805595"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.806043"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.806529"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.80699"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.807475"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.807712"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.807947"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.808233"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tec01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.808247"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tec02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.809025"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tem01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.520992"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0042>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.809443"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ten01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.810337"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ten02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.811235"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ten03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.811692"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ten04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.81295"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ten05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.813236"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ten06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.813514"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tep02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.813811"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tep03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.814136"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.814443"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.521672"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0043>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.814852"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.815124"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.815403"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.81567"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.815995"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.816306"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.816579"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.816775"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter12>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.816977"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter13>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.81719"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter14>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.522464"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0044>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.817445"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter15>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.81771"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter17>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.817986"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter18>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.818252"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter19>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.818506"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter20>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.818801"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter21>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.819593"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter22>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.819914"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter23>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.820181"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter25>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.820447"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter26>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.523181"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0045>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.820678"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter27>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.820908"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter28>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.821134"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter29>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.821394"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter30>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.821671"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter31>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.821951"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter33>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.822249"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter34>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.822563"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter35>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.822854"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter36>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.823117"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter37>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.523816"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0046>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.823377"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter38>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.823674"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter39>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.823942"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter40>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.82422"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter41>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.82451"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter42>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.825198"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter43>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.825647"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter44>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.826757"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter48>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.827052"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter49>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.827332"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter50>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.52443"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0047>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.827602"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter51>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.827609"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter52>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.828067"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter53>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.82856"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tes01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.828858"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tes02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.829277"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tin01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.830328"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tin02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.83081"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tin03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.831276"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tin04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.831703"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tin05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.525128"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0048>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.832525"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tin06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.83281"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tin07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.833048"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tin08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.833288"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tin09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.833741"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.834487"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.834947"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.835393"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.835842"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.836136"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.525902"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0049>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.836465"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.836746"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.837073"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.837386"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.837825"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.838246"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs12>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.838723"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs13>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.839138"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs14>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.839487"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs15>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.840234"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs16>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.526639"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0050>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.841066"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs17>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.842478"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs18>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.84287"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs19>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.843248"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs20>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.843513"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs21>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.843762"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs22>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.844012"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs23>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.844574"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tl001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.845039"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tli01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/kazarena>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-04T02:12:36.845484"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/piprate/json-gold>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tli02>
+  ] .


### PR DESCRIPTION
Currently shows FAIL for all HTML tests, could probably use `earl:untested` or `earl:inapplicable` for things not specifically intended to pass.

cc/ @ kazarena