### PR TITLE
Update PyLD test report for 2.0.0.

### DIFF
--- a/reports/pyld-earl.ttl
+++ b/reports/pyld-earl.ttl
@@ -4,12 +4,12 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://github.com/digitalbazaar/pyld> a doap:Project,
-    <http://www.w3.org/ns/earl#Software>,
-    <http://www.w3.org/ns/earl#TestSubject>;
+<https://github.com/digitalbazaar/pyld> a <http://www.w3.org/ns/earl#TestSubject>,
+    doap:Project,
+    <http://www.w3.org/ns/earl#Software>;
   dc:title "PyLD";
   dc:creator <https://github.com/dlongley>;
-  dc:date "2020-04-01"^^xsd:date;
+  dc:date "2020-04-15"^^xsd:date;
   doap:description "A JSON-LD processor for Python";
   doap:developer <https://github.com/dlongley>;
   doap:homepage <https://github.com/digitalbazaar/pyld>;
@@ -17,12 +17,12 @@
   doap:name "PyLD";
   doap:programming-language "Python";
   doap:release [
-    doap:created "2020-04-01"^^xsd:date;
-    doap:revision "1.0.6-dev"
+    doap:created "2020-04-15"^^xsd:date;
+    doap:revision "2.0.0"
   ] .
 
-<https://github.com/dlongley> a foaf:Person,
-    <http://www.w3.org/ns/earl#Assertor>;
+<https://github.com/dlongley> a <http://www.w3.org/ns/earl#Assertor>,
+    foaf:Person;
   foaf:homepage <https://github.com/dlongley>;
   foaf:name "Dave Longley" .
 
@@ -32,7 +32,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.088685"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -45,7 +45,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.378660"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -58,7 +58,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.379013"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -71,7 +71,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.379362"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -84,7 +84,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.379692"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -97,7 +97,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.380041"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -110,7 +110,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.125659"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -123,7 +123,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.380377"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -136,7 +136,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.380749"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -149,7 +149,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.381109"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -162,7 +162,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.381531"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -175,7 +175,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.381977"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -188,7 +188,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.382409"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -201,7 +201,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.382867"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -214,7 +214,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.383267"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -227,7 +227,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.383636"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -240,7 +240,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.384029"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -253,7 +253,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.126265"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -266,7 +266,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.384637"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -279,7 +279,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.385043"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -292,7 +292,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.385460"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -305,7 +305,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.385918"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -318,7 +318,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.386350"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -331,7 +331,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.386734"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -344,7 +344,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.387141"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -357,7 +357,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.387514"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -370,7 +370,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.387938"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -383,7 +383,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.388317"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -396,7 +396,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.126682"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -409,7 +409,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.388698"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -422,7 +422,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.389054"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -435,7 +435,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.389296"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -448,7 +448,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.389641"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -461,7 +461,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.390013"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -474,7 +474,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.390410"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -487,7 +487,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.390853"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -500,7 +500,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.391262"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -513,7 +513,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.391707"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -526,7 +526,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.392160"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -539,7 +539,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.127131"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -552,7 +552,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.392542"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -565,7 +565,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.392904"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -578,7 +578,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.393369"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -591,7 +591,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.393799"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -604,7 +604,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.394268"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -617,7 +617,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.394503"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -630,7 +630,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.394729"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -643,7 +643,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.394971"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -656,7 +656,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.395212"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -669,7 +669,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.395552"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -682,7 +682,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.127642"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -695,7 +695,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.396058"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -708,7 +708,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.396664"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -721,7 +721,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.397164"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -734,7 +734,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.397760"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -747,7 +747,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.398273"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -760,7 +760,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.092423"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -773,7 +773,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.398684"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -786,7 +786,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.398999"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -799,7 +799,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.399489"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -812,7 +812,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.399842"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -825,7 +825,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.400194"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -838,7 +838,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.128123"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -851,7 +851,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.400484"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -864,7 +864,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.400854"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -877,7 +877,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.401873"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -890,7 +890,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.402213"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -903,7 +903,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.402619"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -916,7 +916,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.402988"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -929,7 +929,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.403353"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -942,7 +942,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.403834"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -955,7 +955,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.404374"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -968,7 +968,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.404864"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -981,7 +981,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.129028"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -994,7 +994,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.405623"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1007,7 +1007,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.406140"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1020,7 +1020,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.406523"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1033,7 +1033,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.407160"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1046,7 +1046,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.407588"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1059,7 +1059,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.407939"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1072,7 +1072,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.408887"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1085,7 +1085,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.409342"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1098,7 +1098,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.409744"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1111,7 +1111,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.416213"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1124,7 +1124,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.129493"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1137,7 +1137,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.418719"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1150,7 +1150,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.419174"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1163,7 +1163,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.419468"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1176,7 +1176,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.419890"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1189,7 +1189,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.420383"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1202,7 +1202,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.420767"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1215,7 +1215,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.421138"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1228,7 +1228,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.421386"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1241,7 +1241,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.421719"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1254,7 +1254,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.422062"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1267,7 +1267,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.129983"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1280,7 +1280,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.422401"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1293,7 +1293,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.422769"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1306,7 +1306,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.423158"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1319,7 +1319,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.423545"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1332,7 +1332,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.424173"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1345,7 +1345,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.424403"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1358,7 +1358,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.424623"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1371,7 +1371,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.424924"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1384,7 +1384,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.425617"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1397,7 +1397,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.426632"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1410,7 +1410,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.130488"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1423,7 +1423,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.427092"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1436,7 +1436,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.427534"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1449,7 +1449,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.428039"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1462,7 +1462,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.428424"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1475,7 +1475,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.428855"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1488,7 +1488,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.429133"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1501,7 +1501,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.429409"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1514,7 +1514,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.429673"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1527,7 +1527,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.430331"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1540,7 +1540,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.430935"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1553,7 +1553,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.131015"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1566,7 +1566,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.431582"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1579,7 +1579,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.431851"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1592,7 +1592,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.432649"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1605,7 +1605,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.433218"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1618,7 +1618,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.433700"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1631,7 +1631,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.434173"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1644,7 +1644,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.434594"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1657,7 +1657,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.435346"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1670,7 +1670,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.435767"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1683,7 +1683,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.436187"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1696,7 +1696,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.131493"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1709,7 +1709,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.436969"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1722,7 +1722,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.437568"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1735,7 +1735,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.438330"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1748,7 +1748,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.439128"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1761,7 +1761,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.439963"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1774,7 +1774,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.440545"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1787,7 +1787,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.440854"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1800,7 +1800,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.441694"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1813,7 +1813,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.442622"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1826,7 +1826,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.442949"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1839,7 +1839,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.131992"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1852,7 +1852,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.443802"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1865,7 +1865,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.444330"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1878,7 +1878,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.444734"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1891,7 +1891,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.445268"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1904,7 +1904,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.445796"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1917,7 +1917,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.446189"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1930,7 +1930,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.446670"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1943,7 +1943,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.447025"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1956,7 +1956,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.447434"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1969,7 +1969,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.447891"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1982,7 +1982,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.132529"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -1995,7 +1995,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.448357"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2008,7 +2008,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.449746"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2021,7 +2021,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.450133"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2034,7 +2034,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.450602"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2047,7 +2047,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.451104"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2060,7 +2060,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.451533"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2073,7 +2073,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.451971"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2086,7 +2086,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.452440"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2099,7 +2099,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.452905"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2112,7 +2112,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.453313"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2125,7 +2125,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.133068"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2138,7 +2138,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.453785"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2151,7 +2151,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.454230"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2164,7 +2164,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.454591"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2177,7 +2177,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.454988"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2190,7 +2190,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.455223"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2203,7 +2203,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.093466"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2216,7 +2216,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.455603"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2229,7 +2229,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.455969"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2242,7 +2242,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.456396"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2255,7 +2255,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.456814"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2268,7 +2268,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.457198"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2281,7 +2281,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.134198"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2294,7 +2294,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.460107"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2307,7 +2307,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.460481"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2320,7 +2320,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.460777"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2333,7 +2333,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.461214"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2346,7 +2346,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.462726"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2359,7 +2359,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.463028"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2372,7 +2372,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.463310"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2385,7 +2385,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.463639"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2398,7 +2398,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.463965"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2411,7 +2411,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.464361"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2424,7 +2424,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.134855"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2437,7 +2437,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.464664"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2450,7 +2450,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.465014"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2463,7 +2463,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.465306"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2476,7 +2476,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.465622"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2489,7 +2489,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.465920"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2502,7 +2502,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.466234"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2515,7 +2515,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.466577"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2528,7 +2528,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.466889"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2541,7 +2541,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.467228"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2554,7 +2554,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.467527"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2567,7 +2567,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.135422"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2580,7 +2580,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.467815"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2593,7 +2593,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.468090"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2606,7 +2606,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.468397"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2619,7 +2619,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.468699"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2632,7 +2632,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.468979"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2645,7 +2645,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.469193"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2658,7 +2658,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.469420"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2671,7 +2671,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.469647"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2684,7 +2684,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.469857"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2697,7 +2697,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.470066"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2710,7 +2710,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.135999"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2723,7 +2723,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.470302"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2736,7 +2736,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.470543"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2749,7 +2749,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.470846"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2762,7 +2762,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.471166"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2775,7 +2775,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.471528"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2788,7 +2788,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.471782"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2801,7 +2801,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.472064"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2814,7 +2814,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.472309"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2827,7 +2827,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.472527"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2840,46 +2840,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.473030"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi11>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.136455"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0070>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.473475"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi12>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.473711"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2892,7 +2853,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.473930"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0070>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2905,7 +2879,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.474147"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2918,7 +2892,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.474361"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2931,7 +2905,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.474575"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2944,7 +2918,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.474790"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2957,7 +2931,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.475005"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2970,7 +2944,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.475468"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2983,7 +2957,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.475687"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -2996,20 +2970,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.136991"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0071>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.475914"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3022,7 +2983,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.476131"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3035,7 +2996,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.476368"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0071>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3048,7 +3022,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.476684"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3061,7 +3035,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.476987"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3074,7 +3048,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.578839"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3087,7 +3061,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.681150"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3100,7 +3074,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.785527"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3113,7 +3087,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.891751"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3126,8 +3100,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.999397"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0005>
@@ -3139,7 +3113,33 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.137363"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3152,33 +3152,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:19.104103"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0006>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:19.208454"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0007>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:19.303426"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3191,7 +3165,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:19.412452"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3204,8 +3178,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:19.519701"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0010>
@@ -3217,8 +3191,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:19.642828"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0011>
@@ -3230,8 +3204,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:19.746512"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0012>
@@ -3243,8 +3217,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:19.856293"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0013>
@@ -3256,8 +3230,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:19.959786"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#tla01>
@@ -3269,7 +3243,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.058625"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3282,20 +3256,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.137890"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0073>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.166108"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3308,7 +3269,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.268447"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3321,8 +3282,21 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.364545"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0073>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#tla05>
@@ -3334,7 +3308,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.366949"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3347,7 +3321,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.367399"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3360,7 +3334,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.367851"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3373,7 +3347,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.368283"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3386,7 +3360,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.368788"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3399,7 +3373,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.369198"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3412,7 +3386,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.369550"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3425,20 +3399,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.138346"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0074>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.370005"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3451,7 +3412,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.370491"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3464,7 +3425,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.371019"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0074>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3477,7 +3451,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.371559"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3490,7 +3464,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.372048"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3503,7 +3477,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.372485"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3516,7 +3490,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.373053"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3529,7 +3503,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.373737"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3542,7 +3516,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.374113"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3555,7 +3529,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.374485"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3568,20 +3542,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.138789"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0075>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.374851"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3594,7 +3555,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.375292"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3607,7 +3568,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.375756"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0075>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3620,7 +3594,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.376355"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3633,7 +3607,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.376817"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3646,20 +3620,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.094145"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0008>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.377268"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3672,7 +3633,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.377819"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3685,7 +3646,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.378313"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3698,7 +3672,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.379346"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3711,7 +3685,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.380199"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3724,20 +3698,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.139192"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0076>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.380887"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3750,7 +3711,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.381800"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3763,7 +3724,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.382379"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0076>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3776,7 +3750,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.383046"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3789,7 +3763,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.383714"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3802,7 +3776,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.384384"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3815,7 +3789,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.385110"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3828,7 +3802,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.386026"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3841,7 +3815,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.386421"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3854,7 +3828,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.386845"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3867,20 +3841,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.139769"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0077>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.387487"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3893,7 +3854,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.387934"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3906,7 +3867,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.388426"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0077>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3919,7 +3893,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.389125"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3932,7 +3906,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.393285"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3945,7 +3919,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.397415"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3958,7 +3932,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.401707"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3971,7 +3945,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.406172"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3984,7 +3958,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.410391"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -3997,7 +3971,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.414589"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4010,20 +3984,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.140345"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0078>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.418797"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4036,7 +3997,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.419674"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4049,7 +4010,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.420321"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0078>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4062,7 +4036,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.421035"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4075,7 +4049,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.421508"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4088,7 +4062,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.421968"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4101,7 +4075,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.422428"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4114,7 +4088,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.423184"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4127,7 +4101,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.423941"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4140,7 +4114,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.424694"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4153,20 +4127,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.140827"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0079>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.425512"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4179,7 +4140,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.426602"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4192,7 +4153,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.427383"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0079>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4205,7 +4179,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.428243"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4218,7 +4192,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.429080"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4231,7 +4205,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.429875"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4244,7 +4218,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.430871"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4257,7 +4231,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.431882"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4270,7 +4244,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.432997"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4283,7 +4257,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.434521"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4296,20 +4270,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.141327"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0080>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.435204"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4322,7 +4283,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.436144"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4335,7 +4296,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.437182"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0080>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4348,7 +4322,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.438467"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4361,7 +4335,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.439320"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4374,7 +4348,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.441593"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4387,7 +4361,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.442359"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4400,7 +4374,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.443996"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4413,7 +4387,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.445073"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4426,7 +4400,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.446652"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4439,20 +4413,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.141822"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0081>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.449615"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4465,7 +4426,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.451009"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4478,7 +4439,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.451741"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0081>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4491,7 +4465,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.452733"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4504,7 +4478,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.453464"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4517,7 +4491,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.453729"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4530,7 +4504,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.453959"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4543,7 +4517,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.455237"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4556,7 +4530,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.455595"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4569,7 +4543,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.455915"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4582,20 +4556,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.142321"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0082>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.457054"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4608,7 +4569,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.457671"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4621,7 +4582,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.458320"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0082>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4634,7 +4608,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.459459"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4647,7 +4621,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.460243"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4660,7 +4634,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.460803"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4673,7 +4647,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.461391"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4686,7 +4660,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.461986"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4699,7 +4673,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.462546"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4712,7 +4686,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.462807"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4725,20 +4699,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.142839"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0083>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.463230"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4751,7 +4712,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.463680"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4764,11 +4725,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.464294"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi11>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0083>
   ] .
 
  [
@@ -4777,20 +4738,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.464948"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi12>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.465242"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4803,7 +4751,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.466141"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4816,7 +4764,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.466475"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4829,7 +4777,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.467690"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4842,7 +4790,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.468459"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4855,7 +4803,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.469099"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4868,20 +4816,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.143324"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0084>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.469736"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4894,7 +4829,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.470262"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4907,7 +4842,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.471310"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4920,7 +4855,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.471855"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4933,7 +4868,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.472408"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0084>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4946,7 +4894,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.473450"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4959,7 +4907,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.474236"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4972,7 +4920,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.475240"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4985,7 +4933,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.476437"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -4998,7 +4946,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.477507"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5011,20 +4959,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.143822"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0085>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.478380"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5037,7 +4972,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.478748"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5050,7 +4985,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.480006"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5063,7 +4998,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.481575"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5076,7 +5011,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.482024"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0085>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5089,20 +5037,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.094677"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0009>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.483700"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5115,7 +5050,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.484424"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5128,7 +5063,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.485049"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5141,7 +5076,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.486616"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5154,7 +5089,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.487299"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5167,20 +5115,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.144313"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0086>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.490103"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5193,7 +5128,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.490698"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5206,7 +5141,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.491341"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5219,7 +5154,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.491781"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5232,7 +5167,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.492394"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0086>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5245,7 +5193,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.493042"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5258,7 +5206,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.493689"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5271,7 +5219,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.495844"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5284,7 +5232,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.496391"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5297,7 +5245,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.497032"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5310,20 +5258,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.144817"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0087>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.497685"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5336,7 +5271,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.498383"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5349,7 +5284,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.498929"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5362,7 +5297,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.499599"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5375,7 +5310,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.500174"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0087>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5388,7 +5336,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.500451"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5401,7 +5349,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.500834"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5414,7 +5362,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.501356"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5427,7 +5375,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.502039"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5440,7 +5388,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.502570"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5453,20 +5401,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.145311"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0088>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.503122"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5479,7 +5414,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.503613"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5492,7 +5427,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.504170"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5505,7 +5440,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.504605"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5518,7 +5453,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.505057"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0088>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5531,7 +5479,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.505496"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5544,7 +5492,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.506120"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5557,7 +5505,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.506577"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5570,7 +5518,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.507032"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5583,7 +5531,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.507694"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5596,20 +5544,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.146039"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0089>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.508573"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5622,7 +5557,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.509276"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5635,7 +5570,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.512725"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5648,7 +5583,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.513433"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5661,7 +5596,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.514166"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0089>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5674,7 +5622,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.514748"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5687,7 +5635,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.515462"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5700,7 +5648,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.515933"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5713,7 +5661,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.516440"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5726,7 +5674,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.516913"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5739,20 +5687,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.146601"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0090>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.517391"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5765,7 +5700,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.518003"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5778,7 +5713,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.518676"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5791,7 +5726,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.519345"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5804,8 +5739,21 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.520037"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0090>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te075>
@@ -5817,7 +5765,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.520457"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5830,7 +5778,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.521534"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5843,7 +5791,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.522540"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5856,7 +5804,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.523181"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5869,7 +5817,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.523917"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5882,20 +5830,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.147168"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0091>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.524551"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5908,7 +5843,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.525166"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5921,7 +5856,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.525783"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5934,7 +5869,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.526411"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5947,7 +5882,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.526964"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0091>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5960,7 +5908,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.527516"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5973,7 +5921,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.528081"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5986,7 +5934,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.529496"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -5999,7 +5947,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.529927"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6012,7 +5960,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.530355"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6025,20 +5973,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.147805"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0092>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.530818"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6051,7 +5986,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.531838"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6064,7 +5999,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.532667"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6077,7 +6012,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.533506"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6090,7 +6025,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.534499"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0092>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6103,7 +6051,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.535323"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6116,7 +6064,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.536151"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6129,7 +6077,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.537009"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6142,7 +6090,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.537907"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6155,7 +6103,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.538642"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6168,20 +6116,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.148454"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0093>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.539380"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6194,7 +6129,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.540136"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6207,7 +6142,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.541130"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6220,7 +6155,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.541963"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6233,7 +6168,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.543203"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0093>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6246,7 +6194,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.543934"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6259,7 +6207,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.545153"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6272,7 +6220,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.546087"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6285,7 +6233,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.546639"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6298,7 +6246,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.547724"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6311,21 +6259,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.149021"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0094>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.549144"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te111>
@@ -6337,8 +6272,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.550643"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te112>
@@ -6350,7 +6285,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.551201"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6363,7 +6298,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.551717"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6376,7 +6311,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.552304"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0094>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6389,7 +6337,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.552864"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6402,7 +6350,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.553416"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6415,7 +6363,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.554048"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6428,7 +6376,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.554728"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6441,8 +6389,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.555328"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te122>
@@ -6454,20 +6402,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.149770"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0095>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.555670"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6480,33 +6415,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.556187"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0124>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.556703"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0125>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.557877"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6519,7 +6428,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.559350"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6532,20 +6441,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.095279"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0010>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.560917"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6558,7 +6454,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.561333"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0095>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6571,7 +6480,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.561752"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6584,7 +6493,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.562014"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6597,7 +6506,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.562246"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6610,20 +6519,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.150389"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0096>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.562502"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6636,7 +6532,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.562774"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6649,7 +6558,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.563047"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6662,7 +6571,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.563319"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6675,7 +6584,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.563597"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6688,7 +6597,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.563851"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6701,7 +6610,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.564093"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0096>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6714,7 +6636,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.564320"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6727,7 +6649,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.564543"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6740,7 +6662,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.564771"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6753,20 +6675,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.151018"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0097>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.565234"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6779,7 +6688,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.565565"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6792,7 +6701,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.565783"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6805,7 +6714,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.566008"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6818,7 +6727,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.566228"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6831,7 +6740,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.566455"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6844,7 +6753,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.566708"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0097>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6857,7 +6779,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.566938"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6870,7 +6792,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.567185"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6883,7 +6805,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.567438"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6896,20 +6818,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.151614"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0098>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.567675"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6922,7 +6831,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.567911"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6935,7 +6844,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.568162"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6948,7 +6857,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.568398"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6961,7 +6870,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.568638"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6974,7 +6883,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.568873"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -6987,7 +6896,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.569126"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0098>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7000,7 +6922,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.569373"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7013,7 +6935,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.569625"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7026,7 +6948,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.569957"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7039,20 +6961,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.152214"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0099>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.570276"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7065,7 +6974,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.570541"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7078,7 +6987,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.570804"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7091,7 +7000,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.571062"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7104,7 +7013,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.571312"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7117,7 +7026,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.571562"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7130,7 +7039,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.571889"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0099>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7143,7 +7065,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.572231"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7156,7 +7078,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.572576"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7169,7 +7091,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.572910"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7182,20 +7104,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.152814"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0100>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.573172"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7208,7 +7117,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.573447"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7221,7 +7130,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.573711"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7234,7 +7143,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.573983"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7247,7 +7156,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.574255"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7260,7 +7169,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.574489"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7273,7 +7182,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.574758"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0100>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7286,7 +7208,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.575034"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7299,7 +7221,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.575284"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7312,7 +7234,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.575537"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7325,20 +7247,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.153446"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0101>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.575784"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7351,7 +7260,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.576096"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7364,7 +7273,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.576352"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7377,7 +7286,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.576606"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7390,7 +7299,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.577154"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7403,7 +7312,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.577687"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7416,7 +7325,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.578278"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0101>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7429,7 +7351,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.578901"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7442,7 +7364,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.579501"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7455,7 +7377,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.583201"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7468,20 +7390,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.154369"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0102>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.583560"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7494,7 +7403,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.583896"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7507,7 +7416,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.584223"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7520,7 +7429,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.584684"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7533,7 +7442,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.585133"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7546,7 +7455,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.585580"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7559,7 +7468,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.586030"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0102>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7572,7 +7494,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.586480"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7585,7 +7507,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.587255"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7598,7 +7520,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.587821"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7611,20 +7533,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.155204"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0103>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.588380"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7637,7 +7546,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.588874"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7650,7 +7559,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.589446"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7663,7 +7572,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.589931"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7676,7 +7585,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.590535"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7689,7 +7598,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.591216"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7702,7 +7611,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.591691"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0103>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7715,7 +7637,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.592128"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7728,7 +7650,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.592665"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7741,7 +7663,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.593113"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7754,20 +7676,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.155622"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0104>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.593563"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7780,7 +7689,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.594062"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7793,7 +7702,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.594561"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7806,7 +7715,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.595021"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7819,7 +7728,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.595435"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7832,7 +7741,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.595847"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7845,7 +7754,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.596470"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0104>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7858,7 +7780,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.596953"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7871,7 +7793,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.597632"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7884,7 +7806,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.598193"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7897,20 +7819,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.156021"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0105>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.598857"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7923,7 +7832,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.599402"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7936,7 +7845,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.600171"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7949,7 +7858,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.600822"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7962,7 +7871,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.601707"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -7975,20 +7884,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.095935"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0011>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.602486"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8001,7 +7897,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.603174"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0105>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8014,7 +7923,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.603878"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8027,7 +7936,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.604741"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8040,7 +7949,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.605884"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8053,20 +7962,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.156497"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0106>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.606422"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8079,7 +7975,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.607027"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8092,7 +8001,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.607652"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8105,7 +8014,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.608486"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8118,7 +8027,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.609056"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8131,7 +8040,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.609638"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8144,7 +8053,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.610401"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0106>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8157,7 +8079,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.611140"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8170,7 +8092,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.611749"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8183,7 +8105,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.612376"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8196,20 +8118,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.157258"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0107>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.612982"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8222,7 +8131,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.613631"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8235,7 +8144,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.614140"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8248,7 +8157,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.614647"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8261,7 +8170,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.615139"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8274,7 +8183,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.615429"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8287,7 +8196,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.615931"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0107>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8300,7 +8222,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.616470"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8313,7 +8235,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.617062"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8326,7 +8248,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.617766"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8339,20 +8261,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.157788"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0108>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.618442"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8365,7 +8274,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.619179"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8378,7 +8287,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.620011"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8391,7 +8300,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.620647"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8404,7 +8313,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.620944"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8417,7 +8326,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.621218"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8430,7 +8339,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.621578"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0108>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8443,7 +8365,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.622019"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8456,7 +8378,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.622329"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8469,7 +8391,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.622603"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8482,20 +8404,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.158355"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0109>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.622869"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8508,7 +8417,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.623131"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8521,7 +8430,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.623391"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8534,7 +8443,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.623710"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8547,7 +8456,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.623983"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8560,7 +8469,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.624245"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8573,7 +8482,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.624506"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0109>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8586,7 +8508,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.624766"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8599,7 +8521,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.625025"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8612,7 +8534,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.625284"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8625,20 +8547,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.158933"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0110>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.625767"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8651,7 +8560,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.626356"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8664,7 +8573,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.626928"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8677,7 +8586,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.627549"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8690,7 +8599,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.627828"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8703,7 +8612,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.628090"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8716,7 +8625,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.628367"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0110>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8729,7 +8651,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.628642"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8742,7 +8664,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.629013"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8755,7 +8677,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.629728"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8768,20 +8690,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.159594"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc001>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.630635"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8794,7 +8703,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.631335"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8807,7 +8716,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.632211"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8820,7 +8729,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.632898"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8833,7 +8742,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.633574"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8846,7 +8755,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.633928"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8859,7 +8768,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.634704"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8872,7 +8794,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.635102"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8885,7 +8807,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.635500"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8898,7 +8820,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.635822"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8911,20 +8833,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.160294"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc002>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.636328"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8937,7 +8846,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.637736"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8950,7 +8859,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.638130"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8963,7 +8872,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.638774"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8976,7 +8885,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.639184"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -8989,7 +8898,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.639590"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9002,7 +8911,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.640315"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9015,7 +8937,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.641024"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9028,7 +8950,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.641729"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9041,7 +8963,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.642746"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9054,20 +8976,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.160953"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc003>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.643271"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9080,7 +8989,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.643671"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9093,7 +9002,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.644576"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9106,7 +9015,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.645036"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9119,7 +9028,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.645418"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9132,7 +9041,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.646624"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9145,7 +9054,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.647136"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9158,7 +9080,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.647650"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9171,7 +9093,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.654653"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9184,7 +9106,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.657503"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9197,20 +9119,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.161680"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc004>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.658071"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9223,7 +9132,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.658397"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9236,7 +9145,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.658939"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9249,7 +9158,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.659444"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9262,7 +9171,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.659845"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9275,7 +9184,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.660248"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9288,7 +9197,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.660532"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9301,7 +9223,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.660965"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9314,7 +9236,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.661402"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9327,7 +9249,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.661840"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9340,20 +9262,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.162509"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc005>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.662368"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9366,7 +9275,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.662816"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9379,7 +9288,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.663435"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9392,7 +9301,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.664166"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9405,8 +9314,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.664982"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#trt01>
@@ -9418,20 +9327,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.096383"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0012>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.665227"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9444,7 +9340,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.665479"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9457,7 +9366,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.665813"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9470,7 +9379,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.666802"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9483,7 +9392,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.668107"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9496,20 +9405,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.163195"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc006>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.668615"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9522,7 +9418,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.669167"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9535,7 +9444,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.669733"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9548,7 +9457,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.670147"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9561,7 +9470,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.670690"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9574,7 +9483,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.671015"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9587,7 +9496,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.671343"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9600,7 +9522,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.671698"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9613,8 +9535,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.673241"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ttn02>
@@ -9626,7 +9548,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.673586"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9639,20 +9561,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.163967"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc007>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.673873"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9665,7 +9574,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.674242"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9678,7 +9587,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.674620"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9691,8 +9600,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.675190"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf05>
@@ -9704,7 +9613,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.675543"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9717,8 +9626,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.676130"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te001>
@@ -9730,8 +9639,21 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.676673"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tex01>
@@ -9743,8 +9665,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.677221"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te002>
@@ -9756,8 +9678,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.677629"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te003>
@@ -9769,8 +9691,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.678176"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te004>
@@ -9782,21 +9704,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.164737"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc008>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.678726"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te005>
@@ -9808,7 +9717,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.678920"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9821,8 +9730,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.679457"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te007>
@@ -9834,8 +9743,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.680004"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te010>
@@ -9847,7 +9756,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.680152"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9860,7 +9769,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.680280"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9873,7 +9782,20 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.680406"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9886,8 +9808,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.680740"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te014>
@@ -9899,8 +9821,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.681072"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te015>
@@ -9912,8 +9834,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.681400"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te016>
@@ -9925,7 +9847,85 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.165455"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -9938,86 +9938,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.681730"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te017>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.682281"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te018>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.682830"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te019>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.683383"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te020>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.683931"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te021>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.684337"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#te022>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.684984"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tc001>
@@ -10029,8 +9951,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.685604"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tc002>
@@ -10042,8 +9964,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.686054"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tc003>
@@ -10055,8 +9977,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.686659"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tc004>
@@ -10068,7 +9990,85 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.166225"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tf001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tf002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tf003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tf004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10081,86 +10081,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.687456"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tf001>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.688226"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tf002>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.688783"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tf003>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.689477"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tf004>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.690025"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr001>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.690580"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr002>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.690987"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr003>
@@ -10172,8 +10094,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.691535"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr004>
@@ -10185,8 +10107,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.692077"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr005>
@@ -10198,8 +10120,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.692692"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr006>
@@ -10211,21 +10133,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.167161"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
-    ];
-    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc011>
-  ] .
-
- [
-    a <http://www.w3.org/ns/earl#Assertion>;
-    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
-    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
-    <http://www.w3.org/ns/earl#result> [
-      a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.693248"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr007>
@@ -10237,8 +10146,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.693878"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr010>
@@ -10250,7 +10159,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.694035"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10263,7 +10172,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.694162"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10276,7 +10185,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.694287"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10289,8 +10198,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.694618"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr014>
@@ -10302,8 +10211,21 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.694946"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr015>
@@ -10315,8 +10237,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.695269"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr016>
@@ -10328,8 +10250,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.695597"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr017>
@@ -10341,8 +10263,8 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.696155"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
     <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr018>
@@ -10354,7 +10276,85 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.168242"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10367,11 +10367,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.696701"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr019>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0003>
   ] .
 
  [
@@ -10380,11 +10380,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.697246"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr020>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0004>
   ] .
 
  [
@@ -10393,11 +10393,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.697792"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr021>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0005>
   ] .
 
  [
@@ -10406,11 +10406,11 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:20.698192"^^xsd:date;
-      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#failed>
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
-    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/html-manifest#tr022>
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0006>
   ] .
 
  [
@@ -10419,7 +10419,85 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.169411"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10432,7 +10510,137 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.170012"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0014>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0023>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10445,7 +10653,137 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.171078"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0024>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0025>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0026>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0027>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0028>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0029>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0030>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0031>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0032>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0033>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10458,7 +10796,72 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.096822"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0034>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0035>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0036>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0037>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0038>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10471,7 +10874,72 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.171916"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0039>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0040>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0041>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0042>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0043>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10484,7 +10952,137 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.173168"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0044>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0045>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0046>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0047>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0048>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0049>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0050>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0051>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0052>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0053>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10497,7 +11095,137 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.173930"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0054>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0055>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0056>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0057>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0058>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0059>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0060>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0061>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0062>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0063>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10510,7 +11238,137 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.176440"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0064>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0065>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0066>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0067>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0068>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#teo01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10523,7 +11381,137 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.177205"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tin01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tin02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tin03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10536,7 +11524,98 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.178687"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp046>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp049>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp050>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tra01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tra02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tra03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10549,7 +11628,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.179852"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10562,7 +11641,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.181587"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10575,7 +11654,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.184546"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10588,7 +11667,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.185963"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10601,7 +11680,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.097443"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10614,7 +11693,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.186628"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10627,7 +11706,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.187733"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10640,7 +11719,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.188219"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10653,7 +11732,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.188702"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10666,7 +11745,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.189278"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10679,7 +11758,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.190003"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10692,7 +11771,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.190623"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10705,7 +11784,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.191236"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10718,7 +11797,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.191866"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10731,7 +11810,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.192273"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10744,7 +11823,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.098324"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10757,7 +11836,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.192607"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10770,7 +11849,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.193690"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10783,7 +11862,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.193952"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10796,7 +11875,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.194245"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10809,7 +11888,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.194646"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10822,7 +11901,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.090038"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10835,7 +11914,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.194975"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10848,7 +11927,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.195267"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10861,7 +11940,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.195556"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10874,7 +11953,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.195859"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10887,7 +11966,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.196195"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10900,7 +11979,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.099049"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10913,7 +11992,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.196540"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10926,7 +12005,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.196880"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10939,7 +12018,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.197393"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10952,7 +12031,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.197863"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10965,7 +12044,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.198374"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10978,7 +12057,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.198912"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -10991,7 +12070,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.199387"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11004,7 +12083,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.199817"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11017,7 +12096,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.200246"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11030,7 +12109,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.200678"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11043,7 +12122,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.099657"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11056,7 +12135,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.201110"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11069,7 +12148,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.201543"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11082,7 +12161,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.201977"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11095,7 +12174,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.202422"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11108,7 +12187,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.202827"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11121,7 +12200,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.203297"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11134,7 +12213,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.203777"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11147,7 +12226,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.204214"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11160,7 +12239,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.205616"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11173,7 +12252,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.206060"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11186,7 +12265,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.101802"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11199,7 +12278,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.206523"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11212,7 +12291,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.207008"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11225,7 +12304,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.207526"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11238,7 +12317,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.208012"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11251,7 +12330,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.208599"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11264,7 +12343,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.209266"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11277,7 +12356,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.209880"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11290,7 +12369,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.210509"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11303,7 +12382,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.211071"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11316,7 +12395,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.211588"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11329,7 +12408,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.102565"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11342,7 +12421,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.212395"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11355,7 +12434,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.212939"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11368,7 +12447,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.213447"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11381,7 +12460,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.213975"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11394,7 +12473,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.214558"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11407,7 +12486,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.215165"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11420,7 +12499,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.215658"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11433,7 +12512,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.216166"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11446,7 +12525,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.216662"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11459,7 +12538,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.217177"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11472,7 +12551,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.103098"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11485,7 +12564,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.217674"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11498,7 +12577,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.218166"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11511,7 +12590,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.218672"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11524,7 +12603,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.219203"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11537,7 +12616,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.219731"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11550,7 +12629,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.220240"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11563,7 +12642,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.220773"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11576,7 +12655,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.221308"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11589,7 +12668,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.221803"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11602,7 +12681,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.222359"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11615,7 +12694,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.103734"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11628,7 +12707,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.222943"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11641,7 +12720,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.223487"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11654,7 +12733,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.224017"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11667,7 +12746,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.224649"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11680,7 +12759,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.225286"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11693,7 +12772,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.225807"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11706,7 +12785,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.226303"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11719,7 +12798,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.226805"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11732,7 +12811,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.227306"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11745,7 +12824,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.227796"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11758,7 +12837,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.104722"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11771,7 +12850,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.228533"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11784,7 +12863,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.229027"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11797,7 +12876,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.229521"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11810,7 +12889,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.229960"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11823,7 +12902,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.230474"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11836,7 +12915,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.231274"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11849,7 +12928,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.232147"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11862,7 +12941,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.233028"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11875,7 +12954,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.234051"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11888,7 +12967,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.234695"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11901,7 +12980,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.105426"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11914,7 +12993,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.235553"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11927,7 +13006,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.235929"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11940,7 +13019,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.236322"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11953,7 +13032,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.237007"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11966,7 +13045,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.237782"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11979,7 +13058,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.239040"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -11992,7 +13071,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.239537"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12005,7 +13084,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.239984"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12018,7 +13097,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.241009"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12031,7 +13110,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.241874"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12044,7 +13123,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.106926"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12057,7 +13136,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.242773"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12070,7 +13149,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.243227"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12083,7 +13162,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.243692"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12096,7 +13175,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.246397"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12109,7 +13188,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.247047"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12122,7 +13201,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.247334"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12135,7 +13214,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.248156"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12148,7 +13227,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.248750"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12161,7 +13240,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.249223"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12174,7 +13253,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.249694"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12187,7 +13266,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.107602"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12200,7 +13279,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.250125"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12213,7 +13292,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.250848"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12226,7 +13305,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.251274"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12239,7 +13318,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.251696"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12252,7 +13331,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.252422"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12265,7 +13344,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.090398"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12278,7 +13357,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.252918"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12291,7 +13370,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.253773"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12304,7 +13383,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.254513"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12317,7 +13396,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.255323"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12330,7 +13409,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.256185"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12343,7 +13422,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.108294"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12356,7 +13435,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.256765"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12369,7 +13448,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.257098"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12382,7 +13461,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.257913"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12395,7 +13474,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.258834"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12408,7 +13487,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.259173"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12421,7 +13500,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.259974"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12434,7 +13513,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.260526"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12447,7 +13526,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.260927"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12460,7 +13539,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.261469"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12473,7 +13552,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.261975"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12486,7 +13565,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.108992"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12499,7 +13578,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.262904"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12512,7 +13591,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.263299"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12525,7 +13604,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.263770"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12538,7 +13617,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.264134"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12551,7 +13630,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.264535"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12564,7 +13643,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.264992"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12577,7 +13656,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.265442"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12590,7 +13669,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.266592"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12603,7 +13682,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.267012"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12616,7 +13695,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.267510"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12629,7 +13708,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.109561"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12642,7 +13721,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.268020"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12655,7 +13734,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.268487"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12668,7 +13747,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.268915"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12681,7 +13760,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.269396"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12694,7 +13773,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.269839"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12707,7 +13786,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.270118"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12720,7 +13799,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.270538"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12733,7 +13812,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.271008"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12746,7 +13825,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.271524"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12759,7 +13838,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.271938"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12772,7 +13851,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.110095"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12785,7 +13864,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.272336"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12798,7 +13877,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.272752"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12811,7 +13890,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.273120"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12824,7 +13903,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.273476"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12837,7 +13916,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.273824"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12850,7 +13929,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.274158"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12863,7 +13942,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.274650"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12876,7 +13955,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.275001"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12889,7 +13968,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.275349"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12902,7 +13981,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.275845"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12915,7 +13994,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.111889"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12928,7 +14007,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.276633"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12941,7 +14020,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.277030"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12954,7 +14033,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.278050"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12967,7 +14046,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.278551"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12980,7 +14059,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.279005"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -12993,7 +14072,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.279455"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13006,7 +14085,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.279979"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13019,7 +14098,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.280348"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13032,7 +14111,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.280714"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13045,7 +14124,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.281093"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13058,7 +14137,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.112467"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13071,7 +14150,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.281510"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13084,7 +14163,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.282042"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13097,7 +14176,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.282597"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13110,7 +14189,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.283143"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13123,7 +14202,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.283499"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13136,7 +14215,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.283904"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13149,7 +14228,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.284864"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13162,7 +14241,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.285772"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13175,7 +14254,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.286318"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13188,7 +14267,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.286874"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13201,7 +14280,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.113069"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13214,7 +14293,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.287450"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13227,7 +14306,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.287898"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13240,7 +14319,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.288289"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13253,7 +14332,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.288773"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13266,7 +14345,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.289162"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13279,7 +14358,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.289617"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13292,7 +14371,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.290026"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13305,7 +14384,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.290611"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13318,7 +14397,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.290968"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13331,7 +14410,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.291325"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13344,7 +14423,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.113668"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13357,7 +14436,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.291720"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13370,7 +14449,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.292329"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13383,7 +14462,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.292769"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13396,7 +14475,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.293211"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13409,7 +14488,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.293672"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13422,7 +14501,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.294110"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13435,7 +14514,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.294539"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13448,7 +14527,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.295001"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13461,7 +14540,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.295439"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13474,7 +14553,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.295879"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13487,7 +14566,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.114353"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13500,7 +14579,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.296342"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13513,7 +14592,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.296772"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13526,7 +14605,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.297215"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13539,7 +14618,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.297638"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13552,7 +14631,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.298201"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13565,7 +14644,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.298665"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13578,7 +14657,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.299206"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13591,7 +14670,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.299756"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13604,7 +14683,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.300148"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13617,7 +14696,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.300755"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13630,7 +14709,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.114968"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13643,7 +14722,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.301393"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13656,7 +14735,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.302048"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13669,7 +14748,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.302428"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13682,7 +14761,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.302794"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13695,7 +14774,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.303377"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13708,7 +14787,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.091178"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13721,7 +14800,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.303862"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13734,7 +14813,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.304302"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13747,7 +14826,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.304834"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13760,7 +14839,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.305340"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13773,7 +14852,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.305809"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13786,7 +14865,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.115705"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13799,7 +14878,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.306125"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13812,7 +14891,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.306561"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13825,7 +14904,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.306999"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13838,7 +14917,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.308050"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13851,7 +14930,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.309395"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13864,7 +14943,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.310826"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13877,7 +14956,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.311216"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13890,7 +14969,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.311607"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13903,7 +14982,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.312195"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13916,7 +14995,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.313010"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13929,7 +15008,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.116445"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13942,7 +15021,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.313755"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13955,7 +15034,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.314497"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13968,7 +15047,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.315436"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13981,7 +15060,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.316148"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -13994,7 +15073,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.316933"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14007,7 +15086,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.317737"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14020,7 +15099,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.318485"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14033,7 +15112,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.319370"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14046,7 +15125,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.320516"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14059,7 +15138,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.321750"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14072,7 +15151,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.118864"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14085,7 +15164,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.323380"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14098,7 +15177,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.323961"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14111,7 +15190,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.324959"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14124,7 +15203,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.325593"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14137,7 +15216,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.326475"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14150,7 +15229,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.327103"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14163,7 +15242,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.328876"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14176,7 +15255,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.329499"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14189,7 +15268,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.330618"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14202,7 +15281,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.331555"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14215,7 +15294,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.119326"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14228,7 +15307,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.332863"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14241,7 +15320,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.335641"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14254,7 +15333,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.336703"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14267,7 +15346,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.337257"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14280,7 +15359,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.338168"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14293,7 +15372,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.338750"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14306,7 +15385,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.339032"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14319,7 +15398,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.339303"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14332,7 +15411,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.340622"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14345,7 +15424,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.340992"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14358,7 +15437,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.119739"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14371,7 +15450,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.341354"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14384,7 +15463,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.342466"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14397,7 +15476,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.343077"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14410,7 +15489,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.343640"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14423,7 +15502,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.344539"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14436,7 +15515,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.345087"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14449,7 +15528,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.345625"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14462,7 +15541,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.346151"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14475,7 +15554,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.346690"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14488,7 +15567,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.347226"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14501,7 +15580,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.120273"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14514,7 +15593,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.347498"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14527,7 +15606,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.347833"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14540,7 +15619,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.348120"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14553,7 +15632,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.348377"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14566,7 +15645,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.348668"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14579,7 +15658,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.348982"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14592,7 +15671,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.349294"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14605,7 +15684,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.349618"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14618,7 +15697,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.349950"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14631,7 +15710,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.350266"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14644,7 +15723,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.120862"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14657,7 +15736,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.350536"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14670,7 +15749,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.350791"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14683,7 +15762,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.351047"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14696,7 +15775,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.351300"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14709,7 +15788,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.352143"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14722,7 +15801,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.352530"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14735,7 +15814,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.352782"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14748,7 +15827,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.353040"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14761,7 +15840,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.353304"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14774,7 +15853,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.353589"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14787,7 +15866,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.121310"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14800,7 +15879,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.353821"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14813,7 +15892,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.354022"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14826,7 +15905,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.354240"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14839,7 +15918,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.354467"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14852,7 +15931,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.354680"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14865,7 +15944,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.354892"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14878,7 +15957,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.355114"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14891,7 +15970,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.355377"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14904,7 +15983,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.355678"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14917,7 +15996,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.355975"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14930,7 +16009,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.121969"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14943,7 +16022,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.356290"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14956,7 +16035,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.356599"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14969,7 +16048,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.356968"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14982,7 +16061,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.357377"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -14995,7 +16074,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.357783"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15008,7 +16087,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.357988"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15021,7 +16100,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.358187"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15034,7 +16113,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.358412"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15047,7 +16126,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.358628"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15060,7 +16139,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.358844"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15073,7 +16152,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.122674"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15086,7 +16165,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.359186"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15099,7 +16178,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.359509"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15112,7 +16191,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.359822"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15125,7 +16204,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.360129"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15138,7 +16217,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.360359"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15151,7 +16230,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.091796"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15164,7 +16243,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.360602"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15177,7 +16256,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.360832"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15190,7 +16269,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.361071"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15203,7 +16282,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.361314"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15216,7 +16295,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.361516"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15229,7 +16308,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.123143"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15242,7 +16321,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.361751"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15255,7 +16334,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.361995"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15268,7 +16347,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.362209"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15281,7 +16360,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.362431"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15294,7 +16373,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.362642"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15307,7 +16386,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.362917"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15320,7 +16399,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.363139"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15333,7 +16412,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.363358"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15346,7 +16425,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.363583"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15359,7 +16438,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.363805"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15372,7 +16451,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.123643"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15385,7 +16464,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.364175"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15398,7 +16477,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.364539"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15411,7 +16490,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.364966"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15424,7 +16503,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.365369"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15437,7 +16516,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.365741"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15450,7 +16529,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.368541"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15463,7 +16542,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.368800"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15476,7 +16555,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.369063"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15489,7 +16568,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.369333"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15502,7 +16581,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.369663"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15515,7 +16594,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.124130"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15528,7 +16607,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.369987"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15541,7 +16620,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.370313"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15554,7 +16633,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.370638"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15567,7 +16646,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.371029"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15580,7 +16659,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.371372"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15593,7 +16672,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.371711"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15606,7 +16685,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.372101"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15619,7 +16698,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.372467"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15632,7 +16711,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.372845"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15645,7 +16724,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.373248"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15658,7 +16737,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.124665"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15671,7 +16750,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.373622"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15684,7 +16763,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.373982"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15697,7 +16776,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.374316"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15710,7 +16789,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.374621"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15723,7 +16802,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.375020"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15736,7 +16815,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.375349"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15749,7 +16828,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.375678"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15762,7 +16841,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.376041"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15775,7 +16854,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.376405"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15788,7 +16867,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.376726"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15801,7 +16880,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.125281"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15814,7 +16893,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.377017"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15827,7 +16906,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.377316"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15840,7 +16919,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.377695"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15853,7 +16932,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.378008"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;
@@ -15866,7 +16945,7 @@
     <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
     <http://www.w3.org/ns/earl#result> [
       a <http://www.w3.org/ns/earl#TestResult>;
-      dc:date "2020-04-01T20:24:18.378300"^^xsd:date;
+      dc:date "2020-04-15T05:28:35"^^xsd:date;
       <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
     ];
     <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/pyld>;


### PR DESCRIPTION
- Renamed report since it's easier to create api+framing reports now.
- I generated output index.html and it looks ok, I think.  Lots of data, hard to check it all by sight.
- My tools had odd parsing errors rebuilding manifest.nt, I'm not sure how that effects things.
- Generating earl.jsonld and index.html caused huge diff bloat due to non-deterministic ordering.  So I left them out of this PR for now. Do the tools allow output property sorting to avoid that?  I'm not sure about the jsonld part, but perhaps the html template itself could do some of that?
- What time resolution is needed for these tests? I dropped the subsecond part for PyLD tests.  Seems like just the day would be enough for this purpose.  That could help a bit with any daily report update diff churn and make files a bit smaller.