### PR TITLE
Fix trailing comma syntax error.

### DIFF
--- a/tests/context.jsonld
+++ b/tests/context.jsonld
@@ -32,6 +32,6 @@
     "processorFeature":     { "@type": "xsd:string" },
     "produceGeneralizedRdf":{ "@type": "xsd:boolean" },
     "specVersion":          { "@type": "xsd:string" },
-    "useNativeTypes":       { "@type": "xsd:boolean" },
+    "useNativeTypes":       { "@type": "xsd:boolean" }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/w3c/json-ld-api/issues/467.