### PR TITLE
Add jsonld.js 3.1.0 test report.

### DIFF
--- a/reports/jsonld-js-earl.ttl
+++ b/reports/jsonld-js-earl.ttl
@@ -1,0 +1,16251 @@
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://github.com/digitalbazaar/jsonld.js> a <http://www.w3.org/ns/earl#TestSubject>,
+    doap:Project,
+    <http://www.w3.org/ns/earl#Software>;
+  dc:title "jsonld.js";
+  dc:creator <https://github.com/dlongley>;
+  doap:description "A JSON-LD processor for JavaScript";
+  doap:developer <https://github.com/dlongley>;
+  doap:homepage <https://github.com/digitalbazaar/jsonld.js>;
+  doap:license <https://github.com/digitalbazaar/jsonld.js/blob/master/LICENSE>;
+  doap:name "jsonld.js";
+  doap:programming-language "JavaScript";
+  doap:release [
+    doap:created "2020-04-15"^^xsd:date;
+    doap:name "jsonld.js 3.1.0";
+    doap:revision "3.1.0"
+  ] .
+
+<https://github.com/dlongley> a foaf:Person,
+    <http://www.w3.org/ns/earl#Assertor>;
+  foaf:homepage <https://github.com/dlongley>;
+  foaf:name "Dave Longley" .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tli03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tli04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tli05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tli06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tli07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0051>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tli08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tli09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tli10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0052>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm014>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0053>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tm020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tn001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tn002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tn003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tn004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tn005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tn006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tn007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0054>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tn008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tp001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tp002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tp003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tp004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0055>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0056>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr12>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr13>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr14>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr15>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0057>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr16>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr17>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr18>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr19>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr20>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr21>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr22>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr23>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr24>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr25>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0058>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr26>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr27>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr28>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr29>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr30>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr31>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr32>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr33>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr34>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr35>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0059>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr36>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr37>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr38>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr39>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr40>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tso01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tso02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tso03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tso05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tso06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0060>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tso07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tso08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tso09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tso10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tso11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tso12>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tso13>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ttn01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ttn02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0061>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0062>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0063>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0023>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0024>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0025>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0027>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0028>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0030>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0031>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0032>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0033>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0034>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0064>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0035>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0036>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0037>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0039>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0040>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0041>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0042>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0043>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0044>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0045>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0065>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0046>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0047>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0048>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0049>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#te001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#tin01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#tin02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#tin03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#tin04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#tin05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0066>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#tin06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#tli01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#tli02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/flatten-manifest#tli03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0067>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0014>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0068>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0023>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0024>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0025>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0026>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0069>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0070>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0071>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tli01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tli02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tli03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0072>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#tla01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#tla02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#tla03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#tla04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#tla05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0073>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0074>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0014>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0075>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0023>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0024>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0025>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0026>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0027>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0028>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0029>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0030>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0031>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0076>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0032>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0033>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0034>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0035>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0036>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0113>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0114>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0115>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0116>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0117>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0077>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0119>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0120>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0121>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0122>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0123>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0124>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0125>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0126>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0127>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0128>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0078>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0129>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0130>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0131>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0132>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0079>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc014>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0080>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc023>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc024>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc025>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc026>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0081>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc027>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc028>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc029>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc030>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc031>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc032>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc033>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc034>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc035>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0082>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0083>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0084>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0085>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te023>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te024>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te025>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te027>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te028>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te029>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te030>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te031>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te032>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te033>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0086>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te034>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te035>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te036>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te037>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te039>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te040>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te041>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te042>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te043>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te044>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0087>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te045>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te046>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te047>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te048>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te049>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te050>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te051>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te052>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te053>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te054>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0088>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te055>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te056>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te057>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te058>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te059>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te060>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te061>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te062>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te063>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te064>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0089>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te065>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te066>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te067>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te068>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te069>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te070>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te072>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te073>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te074>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te076>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0090>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te077>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te078>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te079>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te080>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te081>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te082>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te083>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te084>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te085>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te086>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0091>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te087>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te088>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te089>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te090>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te091>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te092>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te093>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te094>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te095>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te096>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0092>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te097>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te098>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te099>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te100>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te101>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te102>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te103>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te104>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te105>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te106>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0093>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te107>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te108>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te109>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te110>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te113>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te114>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te117>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te118>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te119>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te120>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0094>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te121>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te122>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te123>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te126>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te127>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te128>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te129>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te130>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tec01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tec02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0095>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tem01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ten01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ten02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ten03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ten04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ten05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ten06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tep02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tep03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0096>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter12>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter13>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0097>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter14>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter15>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter17>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter18>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter19>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter20>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter21>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter22>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter23>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter25>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0098>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter26>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter27>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter28>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter29>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter30>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter31>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter33>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter34>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter35>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter36>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0099>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter37>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter38>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter39>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter40>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter41>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter42>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter43>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter44>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter48>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter49>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0100>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter50>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter51>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter52>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter53>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0101>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0102>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs12>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs13>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs14>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs15>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs16>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs17>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0103>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs18>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs19>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs20>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs21>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs22>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs23>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0104>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0105>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm014>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0106>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0107>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0108>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt12>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt13>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt14>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt15>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt16>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0109>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tp001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tp002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tp003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tp004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0110>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr12>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr13>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr14>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr15>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr16>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr17>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr18>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr19>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr20>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr21>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr22>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr23>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr24>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr25>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr26>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr27>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr28>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr29>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr30>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr31>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr32>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr33>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr34>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr35>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr36>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr37>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr38>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr39>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr40>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#trt01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso12>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso13>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ttn01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ttn02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0014>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0023>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0024>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0025>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0026>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0027>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0028>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0029>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0030>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0031>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0032>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0033>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0034>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0035>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0036>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0037>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0038>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0039>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0040>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0041>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0042>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0043>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0044>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0045>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0046>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0047>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0048>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0049>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0050>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0051>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0052>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0053>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0054>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0055>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0056>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0057>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0058>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0059>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0060>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0061>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0062>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0063>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0064>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0065>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0066>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0067>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0068>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#teo01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc014>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tin01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tin02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tin03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp046>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp049>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp050>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tra01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tra02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-framing/tests/frame-manifest#tra03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc023>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc024>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc025>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0014>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc026>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tc027>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#te002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#ten01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tep05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tep06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tep07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tep08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tep09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tep10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tep11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tep12>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tep13>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tep14>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tep15>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tin01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tin02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tin03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tin04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tin05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tla01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tli01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tli02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tli03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tli04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tli05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm014>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tm022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tn001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tn002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tn003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tn004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tn005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tn006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tn007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tn008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tn009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tn010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tn011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tp001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tp002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tp003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tp004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tp005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tp006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tp007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tp008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tpi01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tpi02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tpi03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tpi04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tpi05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0023>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tpi06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tpr01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tpr02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tpr03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tpr04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tpr05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tr001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#tr002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#ts001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#ts002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0024>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#ttn01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#ttn02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#ttn03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0025>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0014>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0026>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0023>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0024>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0025>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0027>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0028>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0027>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0029>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0030>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0031>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0032>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0033>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0034>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0035>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0036>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0037>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0039>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0028>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0040>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0041>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0042>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0043>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0044>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0045>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0046>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0047>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0048>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0049>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0029>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0050>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0051>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0052>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0053>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0054>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0055>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0056>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0057>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0058>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0059>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0030>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0060>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0061>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0062>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0063>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0064>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0065>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0066>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0067>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0068>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0069>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0031>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0070>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0072>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0073>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0074>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0075>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0076>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0077>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0078>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0079>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0080>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0032>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0081>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0082>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0083>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0084>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0085>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0086>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0087>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0088>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0089>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0090>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0033>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0091>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0092>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0093>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0094>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0095>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0096>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0097>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0098>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0099>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0100>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0034>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0101>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0102>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0103>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0104>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0105>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0106>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0107>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0108>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0109>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0110>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0035>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0111>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0112>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0113>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0114>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0117>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0118>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0119>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0120>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0121>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0122>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0036>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0123>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0124>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0125>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0126>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0127>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0128>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0129>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#t0130>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc002>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0037>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc003>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc004>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc006>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc007>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc008>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc009>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc010>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc011>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc012>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#ta038>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc013>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc014>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc015>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc016>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc017>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc018>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc019>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc020>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc021>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc022>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0039>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc023>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc024>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc025>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc026>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc027>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc028>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc029>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc030>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc031>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc032>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0040>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc033>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc034>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tc035>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0041>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tec01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tec02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tem01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ten01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ten02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ten03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ten04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ten05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0042>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ten06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tep02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tep03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0043>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter12>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter13>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter14>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter15>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter17>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter18>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter19>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter20>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0044>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter21>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter22>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter23>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter25>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter26>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter27>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter28>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter29>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter30>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter31>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0045>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter33>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter34>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter35>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter36>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter37>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0005>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter38>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter39>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter40>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter41>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter42>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0046>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter43>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter44>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter48>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter49>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter50>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter51>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter52>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#ter53>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tes01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tes02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0047>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tin01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tin02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tin03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tin04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tin05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tin06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tin07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tin08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tin09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0048>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs02>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs03>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs04>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs05>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs06>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs07>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs08>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs09>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs10>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs11>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0049>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs12>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs13>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs14>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs15>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs16>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs17>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs18>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs19>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs20>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs21>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/compact-manifest#t0050>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs22>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs23>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tl001>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tli01>
+  ] .
+
+ [
+    a <http://www.w3.org/ns/earl#Assertion>;
+    <http://www.w3.org/ns/earl#assertedBy> <https://github.com/dlongley>;
+    <http://www.w3.org/ns/earl#mode> <http://www.w3.org/ns/earl#automatic>;
+    <http://www.w3.org/ns/earl#result> [
+      a <http://www.w3.org/ns/earl#TestResult>;
+      dc:date "2020-04-15T21:59:04.000Z"^^xsd:date;
+      <http://www.w3.org/ns/earl#outcome> <http://www.w3.org/ns/earl#passed>
+    ];
+    <http://www.w3.org/ns/earl#subject> <https://github.com/digitalbazaar/jsonld.js>;
+    <http://www.w3.org/ns/earl#test> <https://w3c.github.io/json-ld-api/tests/expand-manifest#tli02>
+  ] .


### PR DESCRIPTION
- Add report for jsonld.js 3.1.0.
- Unsure about naming convention.  Is "jsonld-js-earl.ttl" ok?
- This is missing the html support.  Still slowly trying to address that, but wanted to get in results for the rest.