### PR TITLE
Implementation Report fixes

### DIFF
--- a/reports/index.html
+++ b/reports/index.html
@@ -5,14 +5,15 @@
 <link href='earl.jsonld' rel='alternate' />
 <link href='https://www.w3.org/StyleSheets/TR/base' rel='stylesheet' />
 <link href='rdf-parse.ttl' rel='related' />
-<link href='rust-sophia-earl.ttl' rel='related' />
+<link href='jsonld-js-earl.ttl' rel='related' />
 <link href='guile-jsonld-earl.ttl' rel='related' />
 <link href='pyld-earl.ttl' rel='related' />
-<link href='jsonld-streaming-serializer-earl.ttl' rel='related' />
-<link href='jsonld-streaming-parser-earl.ttl' rel='related' />
-<link href='jsonld-gold-earl.ttl' rel='related' />
-<link href='ruby-json-ld-earl.ttl' rel='related' />
 <link href='perl-jsonld-earl.ttl' rel='related' />
+<link href='rust-sophia-earl.ttl' rel='related' />
+<link href='jsonld-streaming-serializer-earl.ttl' rel='related' />
+<link href='jsonld-gold-earl.ttl' rel='related' />
+<link href='jsonld-streaming-parser-earl.ttl' rel='related' />
+<link href='ruby-json-ld-earl.ttl' rel='related' />
 <title>
 JSON-LD 1.1 Processor Conformance
 </title>
@@ -255,48 +256,55 @@ guile-jsonld
 </li>
 <li class='tocline'>
 <span class='secno'>A.3</span>
+<a class='tocxref' href='#subj_jsonld_js_JavaScript'>
+jsonld.js
+ (JavaScript)
+</a>
+</li>
+<li class='tocline'>
+<span class='secno'>A.4</span>
 <a class='tocxref' href='#subj_PyLD_Python'>
 PyLD
  (Python)
 </a>
 </li>
 <li class='tocline'>
-<span class='secno'>A.4</span>
+<span class='secno'>A.5</span>
 <a class='tocxref' href='#subj_Sophia_Rust'>
 Sophia
  (Rust)
 </a>
 </li>
 <li class='tocline'>
-<span class='secno'>A.5</span>
+<span class='secno'>A.6</span>
 <a class='tocxref' href='#subj_JSON_goLD_Go'>
 JSON-goLD
  (Go)
 </a>
 </li>
 <li class='tocline'>
-<span class='secno'>A.6</span>
+<span class='secno'>A.7</span>
 <a class='tocxref' href='#subj_JSON_LD_Ruby'>
 JSON::LD
  (Ruby)
 </a>
 </li>
 <li class='tocline'>
-<span class='secno'>A.7</span>
+<span class='secno'>A.8</span>
 <a class='tocxref' href='#subj_jsonld_streaming_parser_JavaScript'>
 jsonld-streaming-parser
  (JavaScript)
 </a>
 </li>
 <li class='tocline'>
-<span class='secno'>A.8</span>
+<span class='secno'>A.9</span>
 <a class='tocxref' href='#subj_jsonld_streaming_serializer_JavaScript'>
 jsonld-streaming-serializer
  (JavaScript)
 </a>
 </li>
 <li class='tocline'>
-<span class='secno'>A.9</span>
+<span class='secno'>A.10</span>
 <a class='tocxref' href='#subj_rdf_parse_JavaScript'>
 rdf-parse
  (JavaScript)
@@ -395,6 +403,13 @@ guile-jsonld
 </a>
 </th>
 <th>
+<a href='#subj_jsonld_js_JavaScript'>
+jsonld.js
+<br />
+(JavaScript)
+</a>
+</th>
+<th>
 <a href='#subj_PyLD_Python'>
 PyLD
 <br />
@@ -432,10 +447,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0002'>Test t0002: basic</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -466,10 +487,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0004'>Test t0004: optimize @set, keep empty arrays</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -500,10 +527,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0006'>Test t0006: keep expanded object format if @type doesn&#39;t match</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -534,10 +567,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0008'>Test t0008: alias keywords</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -568,10 +607,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0010'>Test t0010: array to @graph</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -602,10 +647,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0012'>Test t0012: native types</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -636,10 +687,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0014'>Test t0014: array to aliased @graph</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -670,10 +727,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0016'>Test t0016: recursive named graphs</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -704,10 +767,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0018'>Test t0018: best matching term for lists</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -738,10 +807,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0020'>Test t0020: Compact @id that is a property IRI when @container is @list</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -772,10 +847,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0022'>Test t0022: @list compaction of nested properties</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -806,10 +887,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0024'>Test t0024: most specific term matching in @list.</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -840,10 +927,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0026'>Test t0026: Language map term selection with complications</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -874,10 +967,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0028'>Test t0028: Alias keywords and use @vocab</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -908,10 +1007,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0030'>Test t0030: non-matching @container: @index</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -942,10 +1047,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0032'>Test t0032: Compact keys in reverse-maps</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -976,10 +1087,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0034'>Test t0034: Skip property with @reverse if no match</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1010,6 +1127,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -1027,10 +1147,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0037'>Test t0037: Compact keys in @reverse using @vocab</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1062,10 +1188,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0039'>Test t0039: @graph is array</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1096,10 +1228,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0041'>Test t0041: index rejects term having @list</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1130,10 +1268,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0043'>Test t0043: select term over @vocab</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1164,10 +1308,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0045'>Test t0045: @id value uses relative IRI, not term</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1198,10 +1348,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0047'>Test t0047: Round-trip relative URLs</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1232,10 +1388,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0049'>Test t0049: Round tripping of lists that contain just IRIs</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1266,10 +1428,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0051'>Test t0051: Round tripping @list with scalar</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1300,10 +1468,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0053'>Test t0053: Use @type: @vocab if no @type: @id</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1334,10 +1508,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0055'>Test t0055: Round tripping @type: @vocab</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1368,10 +1548,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0057'>Test t0057: Complex round tripping @type: @vocab and @type: @id</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1402,10 +1588,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0059'>Test t0059: Term with @type: @vocab if no @type: @id</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1436,10 +1628,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0061'>Test t0061: @type: @vocab/@id with values matching either</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1470,10 +1668,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0063'>Test t0063: Compact IRI round-tripping with @type: @vocab</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1504,10 +1708,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0065'>Test t0065: Language-tagged and indexed strings with language-map</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1538,10 +1748,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0067'>Test t0067: Reverse properties with blank nodes</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1572,10 +1788,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0069'>Test t0069: Single value reverse properties with @set</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1606,10 +1828,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0071'>Test t0071: Input has multiple @contexts, output has one</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1640,10 +1868,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0073'>Test t0073: Mapped @id and @type</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1674,6 +1908,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -1691,10 +1928,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0076'>Test t0076: Compacting IRI equivalent to base</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1726,11 +1969,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0078'>Test t0078: Compact a [@graph, @set] container</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1762,11 +2011,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0080'>Test t0080: Do not compact a graph having @id with a term having an @graph container</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1798,11 +2053,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0082'>Test t0082: Compact a [@graph, @index, @set] container</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1834,11 +2095,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0084'>Test t0084: Compact a simple graph with a [@graph, @id] container</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1870,11 +2137,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0086'>Test t0086: Compact a simple graph with a [@graph, @id, @set] container</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1906,6 +2179,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -1924,10 +2200,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0089'>Test t0089: Language map term selection with complications</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1959,11 +2241,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0091'>Test t0091: Compact input with @graph container to output without @graph container with compactArrays unset</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1995,11 +2283,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0093'>Test t0093: Compact input with [@graph, @set] container to output without [@graph, @set] container with compactArrays unset</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2031,10 +2325,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0095'>Test t0095: Relative propererty IRIs with @vocab: &#39;&#39;</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2066,11 +2366,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0097'>Test t0097: Compact [@graph, @set] container (multiple graphs)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2102,11 +2408,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0099'>Test t0099: Compact [@graph, @index, @set] container (multiple indexed objects)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2138,11 +2450,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0101'>Test t0101: Compact [@graph, @id, @set] container (multiple indexed objects)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2174,11 +2492,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0103'>Test t0103: Compact [@graph, @id] container (multiple ids and objects)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2210,11 +2534,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0105'>Test t0105: Compact @type with @container: @set using an alias of @type</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2246,6 +2576,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -2263,10 +2596,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0108'>Test t0108: context with JavaScript Object property names</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2298,11 +2637,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#t0110'>Test t0110: Compact [@graph, @set] container (multiple objects)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2334,11 +2679,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc002'>Test tc002: overriding a term</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2370,11 +2721,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc004'>Test tc004: deep @context affects nested nodes</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2406,11 +2763,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc006'>Test tc006: adding new term</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2442,11 +2805,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc008'>Test tc008: alias of @type</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2478,11 +2847,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc010'>Test tc010: scoped context layers on intemediate contexts</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2514,11 +2889,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc012'>Test tc012: orders @type terms when applying scoped contexts</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2550,11 +2931,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc014'>Test tc014: type-scoped context nullification</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2586,11 +2973,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc016'>Test tc016: type-scoped vocab</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2622,11 +3015,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc018'>Test tc018: multiple type-scoped types resolved against previous context</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2658,11 +3057,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc020'>Test tc020: type-scoped value</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2694,11 +3099,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc022'>Test tc022: type-scoped property-scoped contexts including @type:@vocab</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2730,11 +3141,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc024'>Test tc024: type-scoped + property-scoped + values evaluates against previous context</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2766,11 +3183,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tc026'>Test tc026: @propagate: true on type-scoped context</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2802,11 +3225,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi01'>Test tdi01: term direction null</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2838,11 +3267,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi03'>Test tdi03: term selection with lists and direction</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2874,11 +3309,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi05'>Test tdi05: simple language map with overriding term direction</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2910,11 +3351,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi07'>Test tdi07: simple language map with mismatching term direction</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2946,11 +3393,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#ten01'>Test ten01: Nest term not defined</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -2982,11 +3435,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tep06'>Test tep06: @version must be 1.1</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3018,11 +3477,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tep08'>Test tep08: @prefix must be a boolean</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3054,11 +3519,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tep10'>Test tep10: @nest is not allowed in 1.0</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3090,11 +3561,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tep12'>Test tep12: @container may not be an array in 1.0</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3126,11 +3603,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tep14'>Test tep14: @container may not be @type in 1.0</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3162,11 +3645,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tin01'>Test tin01: Basic Included array</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3192,6 +3681,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -3203,6 +3695,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tin03'>Test tin03: Multiple properties mapping to @included are folded together</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3228,6 +3723,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -3239,6 +3737,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tin05'>Test tin05: Property value with @included</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3270,11 +3771,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs02'>Test tjs02: Compact JSON literal (boolean false)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3306,11 +3813,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs04'>Test tjs04: Compact JSON literal (double-zero)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3342,11 +3855,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs06'>Test tjs06: Compact JSON literal (object)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3378,11 +3897,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs08'>Test tjs08: Compact already expanded JSON literal</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3414,11 +3939,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs10'>Test tjs10: Compact JSON literal (string)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3450,10 +3981,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tla01'>Test tla01: most specific term matching in @list.</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3485,11 +4022,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tli02'>Test tli02: coerced @list containing a list</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3521,11 +4064,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tli04'>Test tli04: coerced @list containing multiple lists</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3557,11 +4106,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tm001'>Test tm001: Indexes to object not having an @id</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3593,11 +4148,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tm003'>Test tm003: Indexes to object not having an @type</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3629,11 +4190,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tm005'>Test tm005: Indexes to object using compact IRI @id</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3665,11 +4232,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tm007'>Test tm007: When type is in a type map</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3701,11 +4274,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tm009'>Test tm009: @index map with @none value</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3737,11 +4316,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tm011'>Test tm011: @language map with no @language</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3773,11 +4358,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tm013'>Test tm013: id map using @none</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3809,11 +4400,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tm015'>Test tm015: type map using @none with alias</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3845,11 +4442,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tm017'>Test tm017: graph index map using @none</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3881,11 +4484,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tm019'>Test tm019: graph id map using alias of @none</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3917,11 +4526,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tm021'>Test tm021: node reference compacts to string value of type map with @type: @id</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3953,11 +4568,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tn001'>Test tn001: Indexes to @nest for property with @nest</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -3989,11 +4610,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tn003'>Test tn003: Nests using alias of @nest</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4025,11 +4652,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tn005'>Test tn005: Nested @container: @list</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4061,11 +4694,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tn007'>Test tn007: Nested @container: @language</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4097,11 +4736,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tn009'>Test tn009: Nested @container: @id</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4133,6 +4778,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -4151,11 +4799,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tp001'>Test tp001: Compact IRI will not use an expanded term definition in 1.0</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4187,11 +4841,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tp003'>Test tp003: Compact IRI does not use simple term that does not end with a gen-delim</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4223,11 +4883,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tp005'>Test tp005: Compact IRI uses term with definition including @prefix: true</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4259,11 +4925,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tp007'>Test tp007: Compact IRI not used as prefix</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4295,11 +4967,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tpi01'>Test tpi01: property-valued index indexes property value, instead of property (value)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4331,11 +5009,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tpi03'>Test tpi03: property-valued index indexes property value, instead of property (node)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4367,11 +5051,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tpi05'>Test tpi05: property-valued index indexes using @none if no property value exists</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4403,11 +5093,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tpr01'>Test tpr01: Check illegal clearing of context with protected terms</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4439,11 +5135,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tpr03'>Test tpr03: Check illegal overriding of protected term from type-scoped context</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4475,11 +5177,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tpr05'>Test tpr05: Check legal overriding of type-scoped protected term from nested node</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4511,11 +5219,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#tr002'>Test tr002: Expands and does not compact to document base with compactToRelative false</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4547,11 +5261,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#ts002'>Test ts002: @context with array including @set uses array values</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4583,11 +5303,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/compact-manifest#ttn02'>Test ttn02: @type: @none does not use arrays by default</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4619,10 +5345,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='summary'>
 <td>
 Percentage passed out of 238 Tests
+</td>
+<td class='passed-all'>
+100.0%
 </td>
 <td class='passed-all'>
 100.0%
@@ -4666,6 +5398,13 @@ guile-jsonld
 </a>
 </th>
 <th>
+<a href='#subj_jsonld_js_JavaScript'>
+jsonld.js
+<br />
+(JavaScript)
+</a>
+</th>
+<th>
 <a href='#subj_PyLD_Python'>
 PyLD
 <br />
@@ -4706,10 +5445,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0002'>Test t0002: basic</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4746,10 +5491,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0004'>Test t0004: optimize @set, keep empty arrays</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4786,10 +5537,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0006'>Test t0006: alias keywords</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4826,10 +5583,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0008'>Test t0008: @value with @language</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4866,10 +5629,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0010'>Test t0010: native types</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4906,10 +5675,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0012'>Test t0012: @graph with embed</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4946,10 +5721,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0014'>Test t0014: @set of @value objects with keyword aliases</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -4986,10 +5767,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0016'>Test t0016: context reset</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5026,10 +5813,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0018'>Test t0018: override default @language</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5066,10 +5859,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0020'>Test t0020: do not remove @graph if not at top-level</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5106,10 +5905,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0022'>Test t0022: expand value with default language</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5146,10 +5951,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0024'>Test t0024: Multiple contexts</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5186,10 +5997,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0027'>Test t0027: Duplicate values in @list and @set</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5226,10 +6043,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0029'>Test t0029: Relative IRIs</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5266,10 +6089,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0031'>Test t0031: type-coercion of native types</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5306,10 +6135,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0033'>Test t0033: Using @vocab with with type-coercion</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5346,10 +6181,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0035'>Test t0035: Language maps with @vocab, default language, and colliding property</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5386,10 +6227,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0037'>Test t0037: Expanding @reverse</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5426,10 +6273,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0040'>Test t0040: language and index expansion on non-objects</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5466,10 +6319,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0042'>Test t0042: Reverse properties</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5506,10 +6365,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0044'>Test t0044: Index maps with language mappings</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5546,10 +6411,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0046'>Test t0046: Free-floating nodes</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5586,10 +6457,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0048'>Test t0048: Terms are ignored in @id</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5626,10 +6503,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0050'>Test t0050: Term definitions with prefix separate from prefix definitions</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5666,10 +6549,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0052'>Test t0052: @vocab-relative IRIs in term definitions</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5706,10 +6595,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0054'>Test t0054: Expand term with @type: @vocab</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5746,10 +6641,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0056'>Test t0056: Use terms with @type: @vocab but not with @type: @id</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5786,10 +6687,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0058'>Test t0058: Expand compact IRI with @type: @vocab</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5826,10 +6733,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0060'>Test t0060: Overwrite document base with @base and reset it again</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5866,10 +6779,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0062'>Test t0062: Various relative IRIs with with @base</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5906,10 +6825,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0064'>Test t0064: bnode values of reverse properties</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5946,10 +6871,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0066'>Test t0066: Reverse-map keys with @vocab</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -5986,10 +6917,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0068'>Test t0068: _:suffix values are not a compact IRI</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6026,10 +6963,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0070'>Test t0070: Compact IRI as term defined using equivalent compact IRI</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6066,10 +7009,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0073'>Test t0073: @context not first property</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6106,10 +7055,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0075'>Test t0075: @vocab as blank node identifier</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6146,6 +7101,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -6166,10 +7124,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0078'>Test t0078: multiple reverse properties</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6207,11 +7171,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0080'>Test t0080: expand [@graph, @set] container</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6249,11 +7219,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0082'>Test t0082: expand [@graph, @index] container</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6291,11 +7267,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0084'>Test t0084: Do not expand [@graph, @index] container if value is a graph</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6333,11 +7315,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0086'>Test t0086: expand [@graph, @id, @set] container</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6375,10 +7363,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0088'>Test t0088: Do not expand native values to IRIs</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6415,6 +7409,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -6435,10 +7432,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0091'>Test t0091: relative and absolute @base overrides base option and document location</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6476,11 +7479,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0093'>Test t0093: expand @graph container (multiple objects)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6518,11 +7527,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0095'>Test t0095: Creates an @graph container if value is a graph (multiple objects)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6560,11 +7575,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0097'>Test t0097: expand [@graph, @index, @set] container (multiple objects)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6602,11 +7623,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0099'>Test t0099: expand [@graph, @id] container (multiple objects)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6644,11 +7671,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0101'>Test t0101: Do not expand [@graph, @id] container if value is a graph (multiple objects)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6686,11 +7719,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0103'>Test t0103: Expand @graph container if value is a graph (multiple graphs)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6728,11 +7767,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0105'>Test t0105: Do not expand [@graph, @index] container if value is a graph (mixed graph and object)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6770,11 +7815,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0107'>Test t0107: expand [@graph, @index] container (indexes with multiple objects)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6812,10 +7863,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0109'>Test t0109: IRI expansion of fragments including &#39;:&#39;</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6853,11 +7910,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0111'>Test t0111: Various relative IRIs as properties with with relative @vocab itself relative to an existing vocabulary base</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6895,10 +7958,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0113'>Test t0113: context with JavaScript Object property names</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6936,11 +8005,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0117'>Test t0117: A term starting with a colon can expand to a different IRI</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -6978,11 +8053,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0119'>Test t0119: Ignore some terms with @, allow others.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7020,11 +8101,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0121'>Test t0121: Ignore some values of @reverse with @, allow others.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7056,6 +8143,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -7067,6 +8157,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0123'>Test t0123: Value objects including invalid literal datatype IRIs are rejected</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7104,11 +8197,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0125'>Test t0125: term as @vocab</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7146,11 +8245,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0127'>Test t0127: A scoped context may include itself recursively (indirect)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7188,6 +8293,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -7208,10 +8316,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#t0130'>Test t0130: Base without trailing slash, with path</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7249,11 +8363,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc002'>Test tc002: overriding a term</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7291,11 +8411,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc004'>Test tc004: deep @context affects nested nodes</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7333,11 +8459,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc006'>Test tc006: adding new term</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7375,11 +8507,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc008'>Test tc008: alias of @type</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7417,11 +8555,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc010'>Test tc010: scoped context layers on intemediate contexts</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7459,11 +8603,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc012'>Test tc012: deep property-term scoped @context in @type-scoped @context affects nested nodes</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7501,11 +8651,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc014'>Test tc014: type-scoped context nullification</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7543,11 +8699,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc016'>Test tc016: type-scoped vocab</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7585,11 +8747,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc018'>Test tc018: multiple type-scoped types resolved against previous context</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7627,11 +8795,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc020'>Test tc020: type-scoped value</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7669,11 +8843,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc022'>Test tc022: type-scoped property-scoped contexts including @type:@vocab</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7711,11 +8891,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc024'>Test tc024: type-scoped + property-scoped + values evaluates against previous context</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7753,11 +8939,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc026'>Test tc026: @propagate: true on type-scoped context</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7795,11 +8987,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc028'>Test tc028: @propagate: false on embedded context</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7837,11 +9035,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc030'>Test tc030: @propagate must be boolean valued</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7873,6 +9077,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='UNTESTED'>
 UNTESTED
 </td>
@@ -7894,6 +9101,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -7905,6 +9115,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc033'>Test tc033: Unused context with an embedded context error.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7942,11 +9155,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tc035'>Test tc035: Term scoping with embedded contexts.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -7984,11 +9203,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi02'>Test tdi02: Expand string using default and term directions and languages</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8026,11 +9251,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi04'>Test tdi04: simple language map with term direction</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8068,11 +9299,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi06'>Test tdi06: simple language mapwith overriding null direction</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8110,11 +9347,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi08'>Test tdi08: @direction must be one of ltr or rtl</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8152,6 +9395,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -8173,11 +9419,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tec02'>Test tec02: Term definition on @type with empty map</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8215,11 +9467,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ten01'>Test ten01: @nest MUST NOT have a string value</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8257,11 +9515,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ten03'>Test ten03: @nest MUST NOT have a numeric value</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8299,11 +9563,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ten05'>Test ten05: does not allow a keyword other than @nest for the value of @nest</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8341,11 +9611,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tep02'>Test tep02: processingMode json-ld-1.0 conflicts with @version: 1.1</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8383,6 +9659,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -8403,10 +9682,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter04'>Test ter04: Error dereferencing a remote context</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8444,10 +9729,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter06'>Test ter06: Invalid local context</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8484,10 +9775,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter08'>Test ter08: Invalid vocab mapping</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8524,10 +9821,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter10'>Test ter10: Cyclic IRI mapping</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8564,10 +9867,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter12'>Test ter12: Invalid type mapping (not a string)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8604,10 +9913,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter14'>Test ter14: Invalid reverse property (contains @id)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8644,10 +9959,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter17'>Test ter17: Invalid reverse property (invalid @container)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8684,6 +10005,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -8704,10 +10028,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter20'>Test ter20: Invalid IRI mapping (no vocab mapping)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8745,10 +10075,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter22'>Test ter22: Invalid language mapping</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8785,10 +10121,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter25'>Test ter25: Invalid reverse property map</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8825,10 +10167,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter27'>Test ter27: Invalid @id value</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8865,10 +10213,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter29'>Test ter29: Invalid value object value</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8905,10 +10259,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter31'>Test ter31: Invalid @index value</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8945,10 +10305,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter34'>Test ter34: Invalid reverse property value (in @reverse)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -8985,10 +10351,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter36'>Test ter36: Invalid reverse property value (through coercion)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9025,10 +10397,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter38'>Test ter38: Invalid value object (@type and @language)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9065,6 +10443,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -9085,10 +10466,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter41'>Test ter41: Invalid set or list object</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9126,11 +10513,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter43'>Test ter43: Term definition with @id: @type</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9168,11 +10561,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter48'>Test ter48: Invalid term as relative IRI</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9210,10 +10609,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter50'>Test ter50: Invalid reverse id</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9250,10 +10655,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter52'>Test ter52: Definition for the empty term</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9274,6 +10685,9 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ter53'>Test ter53: Invalid prefix value</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9311,11 +10725,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tes02'>Test tes02: Mapping @container: [@list, @set] is invalid</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9353,11 +10773,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tin02'>Test tin02: Basic Included object</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9395,11 +10821,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tin04'>Test tin04: Included containing @included</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9437,11 +10869,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tin06'>Test tin06: json.api example</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9479,11 +10917,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tin08'>Test tin08: Error if @included value is a value object</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9521,11 +10965,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs01'>Test tjs01: Expand JSON literal (boolean true)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9563,11 +11013,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs03'>Test tjs03: Expand JSON literal (double)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9605,11 +11061,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs05'>Test tjs05: Expand JSON literal (integer)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9647,11 +11109,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs07'>Test tjs07: Expand JSON literal (array)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9689,11 +11157,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs09'>Test tjs09: Transform JSON literal with string canonicalization</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9731,11 +11205,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs11'>Test tjs11: Expand JSON literal with unicode canonicalization</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9773,11 +11253,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs13'>Test tjs13: Expand JSON literal with wierd canonicalization</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9815,11 +11301,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs15'>Test tjs15: Expand JSON literal aleady in expanded form</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9857,11 +11349,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs17'>Test tjs17: Expand JSON literal (string)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9899,11 +11397,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs19'>Test tjs19: Expand JSON literal with aliased @type</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9941,11 +11445,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs21'>Test tjs21: Expand JSON literal with @context</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -9983,11 +11493,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs23'>Test tjs23: Expand JSON literal (empty array).</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -10025,11 +11541,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tli01'>Test tli01: @list containing @list</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -10067,11 +11589,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tli03'>Test tli03: @list containing @list (with coercion)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -10109,11 +11637,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tli05'>Test tli05: coerced @list containing an array</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -10151,11 +11685,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tli07'>Test tli07: coerced @list containing deep arrays</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -10193,11 +11733,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tli09'>Test tli09: coerced @list containing multiple lists</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -10235,11 +11781,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tm001'>Test tm001: Adds @id to object not having an @id</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -10277,11 +11829,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tm003'>Test tm003: Adds @type to object not having an @type</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -10319,11 +11877,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tm005'>Test tm005: Adds expanded @id to object</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -10361,11 +11925,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tm007'>Test tm007: Adds document expanded @type to object</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -10403,11 +11973,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tm009'>Test tm009: language map with @none</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -10445,11 +12021,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tm011'>Test tm011: id map with @none</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -10487,11 +12069,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tm013'>Test tm013: graph index map with @none</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -10529,11 +12117,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tm015'>Test tm015: graph id index map with aliased @none</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -10571,11 +12165,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tm017'>Test tm017: string value of type map expands to node reference</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -10613,11 +12213,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tm019'>Test tm019: string value of type map expands to node reference with @type: @vocab</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -10655,11 +12261,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tn001'>Test tn001: Expands input using @nest</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -10697,11 +12309,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tn003'>Test tn003: Appends nested values when property at base and nested</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -10739,11 +12357,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tn005'>Test tn005: Nested nested containers</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -10781,11 +12405,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tn007'>Test tn007: A nest of arrays</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -10823,11 +12453,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tp001'>Test tp001: @version may be specified after first context</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -10865,11 +12501,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tp003'>Test tp003: @version setting [1.1, 1.0]</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -10907,11 +12549,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi01'>Test tpi01: error if @version is json-ld-1.0 for property-valued index</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -10949,11 +12597,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi03'>Test tpi03: error if @index is a keyword for property-valued index</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -10991,11 +12645,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi05'>Test tpi05: error if attempting to add property to value object for property-valued index</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11033,11 +12693,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi07'>Test tpi07: property-valued index appends to property value, instead of @index (value)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11075,11 +12741,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi09'>Test tpi09: property-valued index appends to property value, instead of @index (node)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11117,11 +12789,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi11'>Test tpi11: property-valued index adds property to graph object</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11159,11 +12837,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr02'>Test tpr02: Set a term to not be protected</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11201,11 +12885,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr04'>Test tpr04: Do not protect term with @protected: false</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11243,11 +12933,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr06'>Test tpr06: Clear active context of protected terms from a term.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11285,11 +12981,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr09'>Test tpr09: Attempt to redefine term in other protected context.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11327,11 +13029,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr11'>Test tpr11: Fail to override protected term.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11369,11 +13077,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr13'>Test tpr13: Override unprotected term.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11411,11 +13125,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr15'>Test tpr15: Clear protection with array with null context</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11453,11 +13173,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr17'>Test tpr17: Fail to override protected terms with type.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11495,11 +13221,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr19'>Test tpr19: Mix of protected and unprotected terms.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11537,11 +13269,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr21'>Test tpr21: Fail with mix of protected and unprotected terms with type+null.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11579,11 +13317,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr23'>Test tpr23: Allows redefinition of protected alias term with same definition.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11621,11 +13365,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr25'>Test tpr25: Allows redefinition of terms with scoped contexts using same definitions.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11663,6 +13413,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -11684,11 +13437,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr28'>Test tpr28: Fails if trying to redefine a protected null term.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11726,11 +13485,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr30'>Test tpr30: Keywords may be protected.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11768,11 +13533,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr32'>Test tpr32: Protected @type cannot be overridden.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11810,11 +13581,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr34'>Test tpr34: Ignores a non-keyword term starting with &#39;@&#39;</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11852,11 +13629,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr36'>Test tpr36: Ignores a term mapping to a value in the form of a keyword.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11894,11 +13677,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr38'>Test tpr38: Ignores a term mapping to a value in the form of a keyword (@reverse).</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11920,6 +13709,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr39'>Test tpr39: Ignores a term mapping to a value in the form of a keyword (@reverse with @vocab).</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11957,11 +13749,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tso01'>Test tso01: @import is invalid in 1.0.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -11999,11 +13797,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tso03'>Test tso03: @import overflow</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12041,11 +13845,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tso06'>Test tso06: @propagate: false on property-scoped context with @import</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12083,11 +13893,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tso08'>Test tso08: Override term defined in sourced context</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12125,11 +13941,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tso10'>Test tso10: Protect terms in sourced context</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12167,11 +13989,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#tso12'>Test tso12: @import may not be used in an imported context.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12209,11 +14037,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/expand-manifest#ttn01'>Test ttn01: @type: @none is illegal in 1.0.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12251,10 +14085,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='summary'>
 <td>
 Percentage passed out of 366 Tests
+</td>
+<td class='passed-all'>
+100.0%
 </td>
 <td class='passed-all'>
 100.0%
@@ -12291,6 +14131,13 @@ Test
 guile-jsonld
 <br />
 (GNU Guile)
+</a>
+</th>
+<th>
+<a href='#subj_jsonld_js_JavaScript'>
+jsonld.js
+<br />
+(JavaScript)
 </a>
 </th>
 <th>
@@ -12331,10 +14178,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0002'>Test t0002: basic</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12365,10 +14218,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0004'>Test t0004: optimize @set, keep empty arrays</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12399,10 +14258,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0006'>Test t0006: alias keywords</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12433,10 +14298,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0008'>Test t0008: @value with @language</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12467,10 +14338,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0010'>Test t0010: native types</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12501,10 +14378,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0012'>Test t0012: @graph with embed</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12535,10 +14418,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0015'>Test t0015: collapse set of sets, keep empty lists</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12569,10 +14458,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0017'>Test t0017: @graph and @id aliased</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12603,10 +14498,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0019'>Test t0019: remove @value = null</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12637,10 +14538,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0021'>Test t0021: do not remove @graph at top-level if not only property</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12671,10 +14578,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0023'>Test t0023: Flattening list/set with coercion</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12705,10 +14618,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0025'>Test t0025: Problematic IRI flattening tests</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12739,10 +14658,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0028'>Test t0028: Use @vocab in properties and @type but not in @id</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12773,10 +14698,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0031'>Test t0031: type-coercion of native types</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12807,10 +14738,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0033'>Test t0033: Using @vocab with with type-coercion</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12841,10 +14778,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0035'>Test t0035: Language maps with @vocab, default language, and colliding property</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12875,10 +14818,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0037'>Test t0037: Flattening reverse properties</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12909,10 +14858,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0040'>Test t0040: language and index expansion on non-objects</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12943,10 +14898,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0042'>Test t0042: List objects not equivalent</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -12977,10 +14938,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0044'>Test t0044: compactArrays option</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13011,10 +14978,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0046'>Test t0046: Empty string as identifier</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13045,6 +15018,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -13062,10 +15038,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0049'>Test t0049: context with JavaScript Object property names</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13097,11 +15079,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#tin01'>Test tin01: Basic Included array</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13133,11 +15121,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#tin03'>Test tin03: Multiple properties mapping to @included are folded together</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13169,11 +15163,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#tin05'>Test tin05: Property value with @included</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13205,11 +15205,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#tli01'>Test tli01: @list containing an deep list</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13241,11 +15247,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/flatten-manifest#tli03'>Test tli03: @list containing mixed list values</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13276,6 +15288,9 @@ Percentage passed out of 55 Tests
 <td class='passed-all'>
 100.0%
 </td>
+<td class='passed-all'>
+100.0%
+</td>
 </tr>
 </table>
 </section>
@@ -13290,6 +15305,13 @@ Percentage passed out of 55 Tests
 <tr>
 <th>
 Test
+</th>
+<th>
+<a href='#subj_jsonld_js_JavaScript'>
+jsonld.js
+<br />
+(JavaScript)
+</a>
 </th>
 <th>
 <a href='#subj_PyLD_Python'>
@@ -13326,10 +15348,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0002'>Test t0002: reframe w/extra CURIE value.</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13354,10 +15382,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0004'>Test t0004: reframe (type)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13382,10 +15416,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0006'>Test t0006: reframe (non-explicit)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13410,10 +15450,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0008'>Test t0008: array framing cases</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13438,11 +15484,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0011'>Test t0011: @embed true/false</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13467,10 +15519,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0013'>Test t0013: Replace existing embed</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13495,10 +15553,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0015'>Test t0015: Replace deeply-nested embed</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13523,10 +15587,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0017'>Test t0017: Non-flat input</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13551,10 +15621,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0019'>Test t0019: Resources can be re-embedded again in each top-level frame match</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13580,11 +15656,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0021'>Test t0021: Blank nodes in @type</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13609,11 +15691,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0023'>Test t0023: No match on []</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13639,11 +15727,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0025'>Test t0025: @requireAll with missing values and @default</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13663,6 +15757,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -13674,6 +15771,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0027'>Test t0027: non-existent framed properties create null property</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13693,6 +15793,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -13704,6 +15807,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0029'>Test t0029: embed matched frames with reversed property</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13723,6 +15829,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -13738,6 +15847,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -13749,6 +15861,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0032'>Test t0032: single @id match</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13774,11 +15889,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0034'>Test t0034: wildcard and match none</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13798,6 +15919,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -13809,6 +15933,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0036'>Test t0036: matches exact value pattern</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13828,6 +15955,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -13839,6 +15969,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0038'>Test t0038: matches wildcard @type in value pattern</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13858,6 +15991,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -13869,6 +16005,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0040'>Test t0040: matches match none @type in value pattern</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13888,6 +16027,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -13899,6 +16041,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0042'>Test t0042: matches some @value in value pattern</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13918,6 +16063,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -13933,6 +16081,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -13944,6 +16095,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0045'>Test t0045: excludes non-matched values in value pattern</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13969,11 +16123,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0047'>Test t0047: Frame default graph if outer @graph is used</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -13989,6 +16149,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0048'>Test t0048: Merge one graph and preserve another</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14014,11 +16177,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0050'>Test t0050: Library example with named graphs</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14034,6 +16203,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0051'>Test t0051: Compacting values of @preserve</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14059,11 +16231,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0053'>Test t0053: @type must not include a blank node identifier</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14089,10 +16267,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0055'>Test t0055: Framing list with mixed values</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14118,6 +16302,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -14133,11 +16320,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0058'>Test t0058: Frame matching with no matching value in list</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14163,11 +16356,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0060'>Test t0060: @embed: @once only embeds first value with node reference</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14187,6 +16386,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -14198,6 +16400,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0062'>Test t0062: An array with a single value remains an array if container is @set.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14217,6 +16422,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -14228,6 +16436,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0064'>Test t0064: Using @default in @type.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14247,6 +16458,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -14258,6 +16472,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0066'>Test t0066: Match on value reference</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14277,6 +16494,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -14292,6 +16512,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -14303,6 +16526,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#teo01'>Test teo01: @embed true/false</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14328,11 +16554,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg002'>Test tg002: Simple embed</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14352,6 +16584,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -14363,6 +16598,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg004'>Test tg004: Embed with indirect circular reference</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14388,11 +16626,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg006'>Test tg006: Embed with nested indirect circular reference via set</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14412,6 +16656,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -14423,6 +16670,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg008'>Test tg008: A tangle of nastiness</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14442,6 +16692,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -14453,6 +16706,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg010'>Test tg010: Framing blank node unnamed graphs</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14472,6 +16728,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -14487,6 +16746,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -14498,6 +16760,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tin03'>Test tin03: json.api example</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14523,11 +16788,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp021'>Test tp021: Blank nodes in @type (prune bnodes)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14547,6 +16818,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -14558,6 +16832,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp049'>Test tp049: Merge one graph and deep preserve another (prune bnodes)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14577,6 +16854,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -14588,6 +16868,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-framing/tests/frame-manifest#tra01'>Test tra01: @requireAll only matches if @type and other properties are present</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -14607,6 +16890,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -14622,6 +16908,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -14632,6 +16921,9 @@ PASS
 <tr class='summary'>
 <td>
 Percentage passed out of 89 Tests
+</td>
+<td class='passed-all'>
+100.0%
 </td>
 <td class='passed-all'>
 100.0%
@@ -15764,6 +18056,13 @@ guile-jsonld
 </a>
 </th>
 <th>
+<a href='#subj_jsonld_js_JavaScript'>
+jsonld.js
+<br />
+(JavaScript)
+</a>
+</th>
+<th>
 <a href='#subj_PyLD_Python'>
 PyLD
 <br />
@@ -15801,10 +18100,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0002'>Test t0002: load JSON document</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15835,10 +18140,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0004'>Test t0004: loading an unknown type raises loading document failed</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15869,10 +18180,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0006'>Test t0006: Load JSON-LD through 303 redirect</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15903,10 +18220,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0008'>Test t0008: Non-existant file (404)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15937,10 +18260,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0010'>Test t0010: load JSON document with link</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15971,10 +18300,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0012'>Test t0012: Multiple context link headers</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -15996,6 +18331,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='UNTESTED'>
+UNTESTED
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -16009,6 +18347,9 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#tla01'>Test tla01: Redirects if type is text/html</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16040,10 +18381,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#tla03'>Test tla03: Does not redirect if link type is not application/ld+json</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16074,11 +18421,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#tla05'>Test tla05: Base is that of the alternate URL</a>
 (feature: HTML Script Extraction)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16099,6 +18452,9 @@ Percentage passed out of 18 Tests
 </td>
 <td class='passed-all'>
 100.0%
+</td>
+<td class='passed-some'>
+94.4%
 </td>
 <td class='passed-all'>
 100.0%
@@ -16136,6 +18492,13 @@ JSONLD
 guile-jsonld
 <br />
 (GNU Guile)
+</a>
+</th>
+<th>
+<a href='#subj_jsonld_js_JavaScript'>
+jsonld.js
+<br />
+(JavaScript)
 </a>
 </th>
 <th>
@@ -16189,10 +18552,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0002'>Test t0002: Plain literal with CURIE from default context</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16235,10 +18604,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0004'>Test t0004: Literal with language tag</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16281,10 +18656,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0006'>Test t0006: Typed literal</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16327,10 +18708,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0008'>Test t0008: Test prefix defined in @context</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16373,10 +18760,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0010'>Test t0010: Test object processing defines object</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16419,10 +18812,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0012'>Test t0012: Multiple Objects for a Single Property</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16465,10 +18864,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0014'>Test t0014: Creation of a list with single element</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16511,10 +18916,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0016'>Test t0016: Empty IRI expands to resource location</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16557,10 +18968,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0018'>Test t0018: Frag ID expands relative resource location</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16603,10 +19020,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0020'>Test t0020: Test type coercion to typed literal</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16649,10 +19072,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0023'>Test t0023: Test coercion of integer value</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16695,10 +19124,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0025'>Test t0025: Test list coercion with single element</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16741,10 +19176,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0027'>Test t0027: Simple named graph (Wikidata)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16787,10 +19228,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0029'>Test t0029: named graph with embedded named graph</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16833,10 +19280,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0031'>Test t0031: Reverse property</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16879,10 +19332,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0033'>Test t0033: @id reordering</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16925,10 +19384,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0035'>Test t0035: non-fractional numbers converted to xsd:double</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -16971,10 +19436,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0113'>Test t0113: Dataset with a IRI named graph</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17017,10 +19488,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0115'>Test t0115: Dataset with a default and two named graphs</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17063,10 +19540,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0117'>Test t0117: Dataset from node with embedded named graph (bnode)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17109,6 +19592,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -17119,6 +19605,9 @@ PASS
 </td>
 <td class='FAIL'>
 FAIL
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17146,6 +19635,9 @@ FAIL
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='UNTESTED'>
 UNTESTED
 </td>
@@ -17165,6 +19657,9 @@ PASS
 </td>
 <td class='FAIL'>
 FAIL
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17192,6 +19687,9 @@ FAIL
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='UNTESTED'>
 UNTESTED
 </td>
@@ -17210,14 +19708,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='FAIL'>
-FAIL
-</td>
 <td class='PASS'>
 PASS
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='PASS'>
+PASS
+</td>
+<td class='UNTESTED'>
+UNTESTED
 </td>
 <td class='PASS'>
 PASS
@@ -17243,6 +19744,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='UNTESTED'>
+UNTESTED
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -17259,6 +19763,9 @@ PASS
 </td>
 <td class='FAIL'>
 FAIL
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17286,6 +19793,9 @@ FAIL
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='UNTESTED'>
 UNTESTED
 </td>
@@ -17305,6 +19815,9 @@ PASS
 </td>
 <td class='FAIL'>
 FAIL
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17332,6 +19845,9 @@ FAIL
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='UNTESTED'>
 UNTESTED
 </td>
@@ -17345,6 +19861,9 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0130'>Test t0130: IRI Resolution (10)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17378,6 +19897,9 @@ FAIL
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='UNTESTED'>
 UNTESTED
 </td>
@@ -17401,6 +19923,9 @@ FAIL
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='UNTESTED'>
 UNTESTED
 </td>
@@ -17415,6 +19940,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc001'>Test tc001: adding new term</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17458,11 +19986,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc003'>Test tc003: property and value with different terms mapping to the same expanded property</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17506,11 +20040,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc005'>Test tc005: scoped context layers on intemediate contexts</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17554,11 +20094,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc007'>Test tc007: overriding a term</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17602,11 +20148,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc009'>Test tc009: deep @type-scoped @context does NOT affect nested nodes</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17650,11 +20202,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc011'>Test tc011: orders @type terms when applying scoped contexts</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17698,11 +20256,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc013'>Test tc013: type maps use scoped context from type index and not scoped context from containing</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17746,11 +20310,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc015'>Test tc015: type-scoped base</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17794,11 +20364,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc017'>Test tc017: multiple type-scoped contexts are properly reverted</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17842,11 +20418,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc019'>Test tc019: type-scoped context with multiple property scoped terms</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17890,11 +20472,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc021'>Test tc021: type-scoped value mix</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17938,11 +20526,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc023'>Test tc023: composed type-scoped property-scoped contexts including @type:@vocab</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17986,11 +20580,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc025'>Test tc025: type-scoped + graph container</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18034,11 +20634,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc027'>Test tc027: @propagate: false on property-scoped context</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18082,11 +20688,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc029'>Test tc029: @propagate is invalid in 1.0</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18130,11 +20742,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc031'>Test tc031: @context resolutions respects relative URLs.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18169,6 +20787,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -18183,6 +20804,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc033'>Test tc033: Unused context with an embedded context error.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18226,11 +20850,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc035'>Test tc035: Term scoping with embedded contexts.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18274,11 +20904,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi02'>Test tdi02: Expand string using default and term directions and languages</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18322,11 +20958,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi04'>Test tdi04: simple language map with term direction</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18370,11 +21012,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi06'>Test tdi06: simple language mapwith overriding null direction</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18418,11 +21066,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi08'>Test tdi08: @direction must be one of ltr or rtl</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18466,11 +21120,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='non-normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi10'>Test tdi10: rdfDirection: i18n-datatype with direction and language</a>
 (new in JSON-LD 1.1, non-normative)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18505,6 +21165,9 @@ PASS
 <td class='UNTESTED'>
 UNTESTED
 </td>
+<td class='UNTESTED'>
+UNTESTED
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -18529,6 +21192,9 @@ PASS
 <td class='UNTESTED'>
 UNTESTED
 </td>
+<td class='UNTESTED'>
+UNTESTED
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -18542,6 +21208,9 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te001'>Test te001: drop free-floating nodes</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18584,10 +21253,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te003'>Test te003: drop null and unmapped properties</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18630,10 +21305,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te005'>Test te005: do not expand aliased @id/@type</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18676,10 +21357,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te007'>Test te007: date type-coercion</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18722,10 +21409,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te009'>Test te009: @graph with terms</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18768,10 +21461,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te011'>Test te011: coerced @id</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18814,10 +21513,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te013'>Test te013: expand already expanded</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18860,10 +21565,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te016'>Test te016: context reset</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18906,10 +21617,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te018'>Test te018: override default @language</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18952,10 +21669,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te020'>Test te020: do not remove @graph if not at top-level</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -18998,10 +21721,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te022'>Test te022: expand value with default language</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -19044,10 +21773,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te024'>Test te024: Multiple contexts</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -19090,10 +21825,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te027'>Test te027: Keep duplicate values in @list and @set</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -19136,10 +21877,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te029'>Test te029: Relative IRIs</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -19182,10 +21929,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te031'>Test te031: type-coercion of native types</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -19228,10 +21981,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te033'>Test te033: Using @vocab with with type-coercion</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -19274,10 +22033,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te035'>Test te035: Language maps with @vocab, default language, and colliding property</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -19320,10 +22085,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te037'>Test te037: Expanding @reverse</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -19366,10 +22137,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te040'>Test te040: language and index expansion on non-objects</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -19412,10 +22189,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te042'>Test te042: Expanding reverse properties</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -19458,10 +22241,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te044'>Test te044: Ensure index maps use language mapping</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -19504,10 +22293,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te046'>Test te046: Free-floating nodes are removed</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -19550,10 +22345,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te048'>Test te048: Terms are ignored in @id</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -19596,10 +22397,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te050'>Test te050: Term definitions with prefix separate from prefix definitions</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -19642,10 +22449,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te052'>Test te052: @vocab-relative IRIs in term definitions</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -19688,10 +22501,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te054'>Test te054: Expand term with @type: @vocab</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -19734,10 +22553,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te056'>Test te056: Use terms with @type: @vocab but not with @type: @id</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -19780,10 +22605,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te058'>Test te058: Expand compact IRI with @type: @vocab</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -19826,10 +22657,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te060'>Test te060: Overwrite document base with @base and reset it again</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -19872,10 +22709,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te062'>Test te062: Various relative IRIs with with @base</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -19918,10 +22761,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te064'>Test te064: Expand reverse property whose values are unlabeled blank nodes</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -19964,10 +22813,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te066'>Test te066: Use @vocab to expand keys in reverse-maps</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -20010,10 +22865,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te068'>Test te068: _::sufffix not a compact IRI</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -20056,10 +22917,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te070'>Test te070: Redefine compact IRI with itself</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -20102,10 +22969,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te073'>Test te073: @context not first property</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -20148,6 +23021,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -20158,6 +23034,9 @@ UNTESTED
 </td>
 <td class='INAPPLICABLE'>
 INAPPLICABLE
+</td>
+<td class='UNTESTED'>
+UNTESTED
 </td>
 <td class='PASS'>
 PASS
@@ -20175,6 +23054,9 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te076'>Test te076: base option overrides document location</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -20217,10 +23099,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te078'>Test te078: multiple reverse properties</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -20264,11 +23152,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te080'>Test te080: expand [@graph, @set] container</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -20312,11 +23206,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te082'>Test te082: expand [@graph, @index] container</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -20360,11 +23260,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te084'>Test te084: Do not expand [@graph, @index] container if value is a graph</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -20408,11 +23314,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te086'>Test te086: expand [@graph, @id, @set] container</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -20456,10 +23368,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te088'>Test te088: Do not expand native values to IRIs</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -20502,6 +23420,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -20525,10 +23446,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te091'>Test te091: relative and absolute @base overrides base option and document location</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -20572,11 +23499,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te093'>Test te093: expand @graph container (multiple objects)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -20620,11 +23553,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te095'>Test te095: Creates an @graph container if value is a graph (multiple objects)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -20668,11 +23607,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te097'>Test te097: expand [@graph, @index, @set] container (multiple objects)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -20716,11 +23661,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te099'>Test te099: expand [@graph, @id] container (multiple objects)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -20764,11 +23715,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te101'>Test te101: Do not expand [@graph, @id] container if value is a graph (multiple objects)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -20812,11 +23769,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te103'>Test te103: Expand @graph container if value is a graph (multiple graphs)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -20860,11 +23823,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te105'>Test te105: Do not expand [@graph, @index] container if value is a graph (mixed graph and object)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -20908,11 +23877,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te107'>Test te107: expand [@graph, @index] container (indexes with multiple objects)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -20956,10 +23931,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te109'>Test te109: IRI expansion of fragments including &#39;:&#39;</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -21003,6 +23984,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -21014,6 +23998,9 @@ PASS
 </td>
 <td class='FAIL'>
 FAIL
+</td>
+<td class='UNTESTED'>
+UNTESTED
 </td>
 <td class='PASS'>
 PASS
@@ -21039,6 +24026,9 @@ PASS
 <td class='FAIL'>
 FAIL
 </td>
+<td class='UNTESTED'>
+UNTESTED
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -21055,6 +24045,9 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te113'>Test te113: context with JavaScript Object property names</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -21098,11 +24091,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te117'>Test te117: A term starting with a colon can expand to a different IRI</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -21146,11 +24145,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te119'>Test te119: Ignore some terms with @, allow others.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -21194,11 +24199,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te121'>Test te121: Ignore some values of @reverse with @, allow others.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -21242,11 +24253,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te123'>Test te123: Value objects including invalid literal datatype IRIs are rejected</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -21275,14 +24292,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='FAIL'>
-FAIL
-</td>
 <td class='PASS'>
 PASS
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='PASS'>
+PASS
+</td>
+<td class='UNTESTED'>
+UNTESTED
 </td>
 <td class='PASS'>
 PASS
@@ -21308,6 +24328,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='UNTESTED'>
+UNTESTED
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -21319,6 +24342,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te126'>Test te126: A scoped context may include itself recursively (direct)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -21362,11 +24388,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te128'>Test te128: Two scoped context may include a shared context</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -21410,11 +24442,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te130'>Test te130: Base without trailing slash, with path</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -21458,11 +24496,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tec02'>Test tec02: Term definition on @type with empty map</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -21506,11 +24550,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ten01'>Test ten01: @nest MUST NOT have a string value</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -21554,11 +24604,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ten03'>Test ten03: @nest MUST NOT have a numeric value</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -21602,11 +24658,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ten05'>Test ten05: does not allow a keyword other than @nest for the value of @nest</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -21650,11 +24712,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tep02'>Test tep02: processingMode json-ld-1.0 conflicts with @version: 1.1</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -21698,6 +24766,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -21721,10 +24792,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter04'>Test ter04: Error dereferencing a remote context</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -21768,10 +24845,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter06'>Test ter06: Invalid local context</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -21814,10 +24897,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter08'>Test ter08: Invalid vocab mapping</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -21860,10 +24949,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter10'>Test ter10: Cyclic IRI mapping</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -21906,10 +25001,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter12'>Test ter12: Invalid type mapping (not a string)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -21952,10 +25053,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter14'>Test ter14: Invalid reverse property (contains @id)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -21998,10 +25105,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter17'>Test ter17: Invalid reverse property (invalid @container)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -22044,6 +25157,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -22067,10 +25183,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter20'>Test ter20: Invalid IRI mapping (no vocab mapping)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -22114,10 +25236,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter22'>Test ter22: Invalid language mapping</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -22160,10 +25288,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter25'>Test ter25: Invalid reverse property map</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -22206,10 +25340,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter27'>Test ter27: Invalid @id value</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -22252,10 +25392,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter29'>Test ter29: Invalid value object value</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -22298,10 +25444,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter31'>Test ter31: Invalid @index value</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -22344,10 +25496,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter34'>Test ter34: Invalid reverse property value (in @reverse)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -22390,10 +25548,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter36'>Test ter36: Invalid reverse property value (through coercion)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -22436,10 +25600,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter38'>Test ter38: Invalid value object (@type and @language)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -22482,6 +25652,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -22505,10 +25678,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter41'>Test ter41: Invalid set or list object</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -22552,11 +25731,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter43'>Test ter43: Term definition with @id: @type</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -22600,11 +25785,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter48'>Test ter48: Invalid term as relative IRI</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -22648,10 +25839,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter50'>Test ter50: Invalid reverse id</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -22694,10 +25891,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter52'>Test ter52: Definition for the empty term</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -22721,6 +25924,9 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter53'>Test ter53: Invalid prefix value</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -22764,11 +25970,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin02'>Test tin02: Basic Included object</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -22812,11 +26024,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin04'>Test tin04: Included containing @included</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -22860,11 +26078,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin06'>Test tin06: json.api example</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -22908,11 +26132,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin08'>Test tin08: Error if @included value is a value object</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -22956,11 +26186,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs01'>Test tjs01: Transform JSON literal (boolean true)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -23004,11 +26240,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs03'>Test tjs03: Transform JSON literal (double)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -23052,11 +26294,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs05'>Test tjs05: Transform JSON literal (integer)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -23100,11 +26348,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs07'>Test tjs07: Transform JSON literal (array)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -23148,11 +26402,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs09'>Test tjs09: Transform JSON literal with string canonicalization</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -23196,11 +26456,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs11'>Test tjs11: Transform JSON literal with unicode canonicalization</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -23244,6 +26510,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -23268,11 +26537,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs14'>Test tjs14: Transform JSON literal without expanding contents</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -23316,11 +26591,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs16'>Test tjs16: Transform JSON literal aleady in expanded form with aliased keys</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -23364,11 +26645,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs18'>Test tjs18: Transform JSON literal (null)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -23412,11 +26699,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs20'>Test tjs20: Transform JSON literal with aliased @value</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -23460,11 +26753,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs22'>Test tjs22: Transform JSON literal (null) aleady in expanded form.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -23508,11 +26807,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli01'>Test tli01: @list containing @list</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -23556,11 +26861,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli03'>Test tli03: @list containing @list (with coercion)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -23604,11 +26915,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli05'>Test tli05: coerced @list containing an array</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -23652,11 +26969,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli07'>Test tli07: coerced @list containing deep arrays</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -23700,11 +27023,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli09'>Test tli09: coerced @list containing multiple lists</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -23748,11 +27077,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm001'>Test tm001: Adds @id to object not having an @id</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -23796,11 +27131,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm003'>Test tm003: Adds @type to object not having an @type</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -23844,11 +27185,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm005'>Test tm005: Adds expanded @id to object</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -23892,11 +27239,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm007'>Test tm007: Adds document expanded @type to object</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -23940,11 +27293,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm009'>Test tm009: language map with @none</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -23988,11 +27347,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm011'>Test tm011: id map with @none</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -24036,11 +27401,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm013'>Test tm013: graph index map with @none</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -24084,11 +27455,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm015'>Test tm015: graph id index map with aliased @none</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -24132,11 +27509,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm017'>Test tm017: string value of type map expands to node reference</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -24180,11 +27563,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm019'>Test tm019: string value of type map expands to node reference with @type: @vocab</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -24228,11 +27617,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn001'>Test tn001: Expands input using @nest</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -24276,11 +27671,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn003'>Test tn003: Appends nested values when property at base and nested</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -24324,11 +27725,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn005'>Test tn005: Nested nested containers</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -24372,11 +27779,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn007'>Test tn007: A nest of arrays</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -24420,10 +27833,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt01'>Test tnt01: literal_ascii_boundaries</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -24466,10 +27885,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt03'>Test tnt03: literal_all_controls</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -24512,10 +27937,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt05'>Test tnt05: literal_with_squote</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -24558,10 +27989,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt07'>Test tnt07: literal_with_dquote</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -24604,10 +28041,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt09'>Test tnt09: literal_with_REVERSE_SOLIDUS2</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -24650,10 +28093,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt11'>Test tnt11: literal_with_BACKSPACE</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -24696,10 +28145,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt13'>Test tnt13: literal_with_CARRIAGE_RETURN</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -24742,6 +28197,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -24765,10 +28223,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt16'>Test tnt16: literal_with_numeric_escape4</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -24812,11 +28276,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tp002'>Test tp002: @version setting [1.0, 1.1, 1.0]</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -24860,11 +28330,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tp004'>Test tp004: @version setting [1.1, 1.0, 1.1]</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -24908,11 +28384,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi02'>Test tpi02: error if @container does not include @index for property-valued index</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -24956,11 +28438,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi04'>Test tpi04: error if @index is not a string for property-valued index</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -25004,11 +28492,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi06'>Test tpi06: property-valued index expands to property value, instead of @index (value)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -25052,11 +28546,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi08'>Test tpi08: property-valued index expands to property value, instead of @index (node)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -25100,11 +28600,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi10'>Test tpi10: property-valued index does not output property for @none</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -25148,11 +28654,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr01'>Test tpr01: Protect a term</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -25196,11 +28708,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr03'>Test tpr03: Protect all terms in context</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -25244,11 +28762,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr05'>Test tpr05: Clear active context with protected terms from an embedded context</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -25292,11 +28816,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr08'>Test tpr08: Term with protected scoped context.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -25340,11 +28870,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr10'>Test tpr10: Simple protected and unprotected terms.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -25388,11 +28924,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr12'>Test tpr12: Scoped context fail to override protected term.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -25436,11 +28978,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr14'>Test tpr14: Clear protection with null context.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -25484,11 +29032,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr16'>Test tpr16: Override protected terms after null.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -25532,11 +29086,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr18'>Test tpr18: Fail to override protected terms with type+null+ctx.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -25580,11 +29140,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr20'>Test tpr20: Fail with mix of protected and unprotected terms with type+null+ctx.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -25628,11 +29194,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr22'>Test tpr22: Check legal overriding of type-scoped protected term from nested node.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -25676,11 +29248,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr24'>Test tpr24: Allows redefinition of protected prefix term with same definition.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -25724,11 +29302,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr26'>Test tpr26: Fails on redefinition of terms with scoped contexts using different definitions.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -25772,11 +29356,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr28'>Test tpr28: Fails if trying to redefine a protected null term.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -25820,11 +29410,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr30'>Test tpr30: Keywords may be protected.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -25868,11 +29464,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr32'>Test tpr32: Protected @type cannot be overridden.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -25916,11 +29518,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr34'>Test tpr34: Ignores a non-keyword term starting with &#39;@&#39;</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -25964,11 +29572,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr36'>Test tpr36: Ignores a term mapping to a value in the form of a keyword.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -26012,11 +29626,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr38'>Test tpr38: Ignores a term mapping to a value in the form of a keyword (@reverse).</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -26041,6 +29661,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr39'>Test tpr39: Ignores a term mapping to a value in the form of a keyword (@reverse with @vocab).</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -26084,6 +29707,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -26108,11 +29734,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso01'>Test tso01: @import is invalid in 1.0.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -26156,11 +29788,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso03'>Test tso03: @import overflow</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -26204,11 +29842,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso06'>Test tso06: @propagate: false on property-scoped context with @import</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -26252,11 +29896,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso08'>Test tso08: Override term defined in sourced context</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -26300,11 +29950,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso10'>Test tso10: Protect terms in sourced context</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -26348,11 +30004,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso12'>Test tso12: @import may not be used in an imported context.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -26396,11 +30058,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ttn01'>Test ttn01: @type: @none is illegal in 1.0.</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -26444,11 +30112,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf01'>Test twf01: Triples including invalid subject IRIs are rejected</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -26492,11 +30166,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf03'>Test twf03: Triples including invalid object IRIs are rejected</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -26540,6 +30220,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -26551,6 +30234,9 @@ PASS
 </td>
 <td class='PASS'>
 PASS
+</td>
+<td class='UNTESTED'>
+UNTESTED
 </td>
 <td class='PASS'>
 PASS
@@ -26588,6 +30274,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='summary'>
 <td>
@@ -26597,13 +30286,16 @@ Percentage passed out of 442 Tests
 99.8%
 </td>
 <td class='passed-most'>
-95.5%
+95.9%
+</td>
+<td class='passed-most'>
+98.6%
 </td>
 <td class='passed-most'>
 99.5%
 </td>
-<td class='passed-most'>
-95.5%
+<td class='passed-some'>
+94.6%
 </td>
 <td class='passed-all'>
 100.0%
@@ -26631,6 +30323,13 @@ Test
 guile-jsonld
 <br />
 (GNU Guile)
+</a>
+</th>
+<th>
+<a href='#subj_jsonld_js_JavaScript'>
+jsonld.js
+<br />
+(JavaScript)
 </a>
 </th>
 <th>
@@ -26691,10 +30390,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0002'>Test t0002: Native Types</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -26734,6 +30439,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -26741,6 +30449,9 @@ FAIL
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0004'>Test t0004: Lists</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -26780,6 +30491,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -26787,6 +30501,9 @@ FAIL
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0006'>Test t0006: Two graphs having same subject but different values</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -26829,10 +30546,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0009'>Test t0009: List conversion with IRI nodes</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -26875,10 +30598,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0011'>Test t0011: List pattern with extra properties</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -26921,10 +30650,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0013'>Test t0013: List pattern with multiple values of rdf:first</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -26948,6 +30683,9 @@ FAIL
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0014'>Test t0014: List pattern with multiple values of rdf:rest</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -26990,10 +30728,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0016'>Test t0016: List pattern with type rdf:List</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -27017,6 +30761,9 @@ FAIL
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0017'>Test t0017: Remove duplicate triples</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -27059,10 +30806,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0019'>Test t0019: use rdf:type flag set to false</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -27105,10 +30858,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0021'>Test t0021: list with node shared across graphs (same triple in different graphs)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -27132,6 +30891,9 @@ FAIL
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0022'>Test t0022: list from duplicate triples</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -27174,10 +30936,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0024'>Test t0024: multiple languages for same subject+property+value</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -27220,10 +30988,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0026'>Test t0026: triple with rdf:first property and rdf:nil value</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -27267,11 +31041,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi02'>Test tdi02: rdfDirection: null with i18n literal with direction and language</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -27315,11 +31095,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi04'>Test tdi04: rdfDirection: null with compound literal with direction and language</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -27354,6 +31140,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -27368,6 +31157,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi06'>Test tdi06: rdfDirection: i18n-datatype with i18n literal with direction and language</a>
 (new in JSON-LD 1.1, non-normative)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -27411,11 +31203,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='non-normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi08'>Test tdi08: rdfDirection: i18n-datatype with compound literal with direction and language</a>
 (new in JSON-LD 1.1, non-normative)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -27459,11 +31257,17 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='non-normative'>
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi10'>Test tdi10: rdfDirection: compound-literal with i18n literal with direction and language</a>
 (new in JSON-LD 1.1, non-normative)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -27495,6 +31299,9 @@ PASS
 <td class='UNTESTED'>
 UNTESTED
 </td>
+<td class='UNTESTED'>
+UNTESTED
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -27519,6 +31326,9 @@ PASS
 <td class='UNTESTED'>
 UNTESTED
 </td>
+<td class='UNTESTED'>
+UNTESTED
+</td>
 <td class='PASS'>
 PASS
 </td>
@@ -27536,6 +31346,9 @@ FAIL
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs01'>Test tjs01: JSON literal (boolean true)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -27570,6 +31383,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -27584,6 +31400,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs03'>Test tjs03: JSON literal (double)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -27618,6 +31437,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -27632,6 +31454,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs05'>Test tjs05: JSON literal (integer)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -27666,6 +31491,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -27680,6 +31508,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs07'>Test tjs07: JSON literal (array)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -27714,6 +31545,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -27728,6 +31562,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs09'>Test tjs09: Invalid JSON literal (invalid structure)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -27762,6 +31599,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -27776,6 +31616,9 @@ PASS
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs11'>Test tjs11: JSON literal (null)</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -27816,6 +31659,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -27824,6 +31670,9 @@ FAIL
 <td>
 <a href='https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tli02'>Test tli02: @list containing multiple lists</a>
 (new in JSON-LD 1.1)
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -27864,6 +31713,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 <td class='FAIL'>
 FAIL
 </td>
@@ -27874,6 +31726,9 @@ Percentage passed out of 51 Tests
 </td>
 <td class='passed-all'>
 100.0%
+</td>
+<td class='passed-most'>
+96.1%
 </td>
 <td class='passed-most'>
 96.1%
@@ -28041,7 +31896,7 @@ Remote document
 Transform JSON-LD to RDF
 </td>
 <td class='passed-most'>
-422/442 (95.5%)
+424/442 (95.9%)
 </td>
 </tr>
 <tr>
@@ -28057,8 +31912,104 @@ Transform RDF to JSON-LD
 </dd>
 </dl>
 </dd>
-<dt id='subj_PyLD_Python'>
+<dt id='subj_jsonld_js_JavaScript'>
 <span class='secno'>A.3</span>
+<a href='https://github.com/digitalbazaar/jsonld.js'>
+<span about='https://github.com/digitalbazaar/jsonld.js' property='doap:name'>jsonld.js</span>
+</a>
+</dt>
+<dd>
+<dl>
+<dt>Release</dt>
+<dd property='doap:release'><span property='doap:revision'>3.1.0</span></dd>
+<dt>Programming Language</dt>
+<dd property='doap:programming-language'>JavaScript</dd>
+<dt>Home Page</dt>
+<dd>
+<a href='https://github.com/digitalbazaar/jsonld.js' property='doap:homepage'>
+https://github.com/digitalbazaar/jsonld.js
+</a>
+</dd>
+<dt>Developer</dt>
+<dd rel='doap:developer'>
+<div>
+<a href='https://github.com/dlongley'>
+<span property='foaf:name'>Dave Longley</span>
+</a>
+<a href-@id='https://github.com/dlongley' href-@type='[&quot;Assertor&quot;, &quot;foaf:Person&quot;]' href-foaf:homepage='https://github.com/dlongley' href-foaf:name='Dave Longley' property='foaf:homepage'>
+https://github.com/dlongley
+</a>
+</div>
+</dd>
+<dt>
+Test Suite Compliance
+</dt>
+<dd>
+<table class='report'>
+<tbody>
+<tr>
+<td>
+Compaction
+</td>
+<td class='passed-all'>
+238/238 (100.0%)
+</td>
+</tr>
+<tr>
+<td>
+Expansion
+</td>
+<td class='passed-all'>
+366/366 (100.0%)
+</td>
+</tr>
+<tr>
+<td>
+Flattening
+</td>
+<td class='passed-all'>
+55/55 (100.0%)
+</td>
+</tr>
+<tr>
+<td>
+Framing
+</td>
+<td class='passed-all'>
+89/89 (100.0%)
+</td>
+</tr>
+<tr>
+<td>
+Remote document
+</td>
+<td class='passed-most'>
+17/18 (94.4%)
+</td>
+</tr>
+<tr>
+<td>
+Transform JSON-LD to RDF
+</td>
+<td class='passed-most'>
+436/442 (98.6%)
+</td>
+</tr>
+<tr>
+<td>
+Transform RDF to JSON-LD
+</td>
+<td class='passed-most'>
+49/51 (96.1%)
+</td>
+</tr>
+</tbody>
+</table>
+</dd>
+</dl>
+</dd>
+<dt id='subj_PyLD_Python'>
+<span class='secno'>A.4</span>
 <a href='https://github.com/digitalbazaar/pyld'>
 <span about='https://github.com/digitalbazaar/pyld' property='doap:name'>PyLD</span>
 </a>
@@ -28081,7 +32032,7 @@ https://github.com/digitalbazaar/pyld
 <a href='https://github.com/dlongley'>
 <span property='foaf:name'>Dave Longley</span>
 </a>
-<a href-@id='https://github.com/dlongley' href-@type='[&quot;foaf:Person&quot;, &quot;Assertor&quot;]' href-foaf:homepage='https://github.com/dlongley' href-foaf:name='Dave Longley' property='foaf:homepage'>
+<a href-@id='https://github.com/dlongley' href-@type='[&quot;Assertor&quot;, &quot;foaf:Person&quot;]' href-foaf:homepage='https://github.com/dlongley' href-foaf:name='Dave Longley' property='foaf:homepage'>
 https://github.com/dlongley
 </a>
 </div>
@@ -28162,7 +32113,7 @@ Transform RDF to JSON-LD
 </dl>
 </dd>
 <dt id='subj_Sophia_Rust'>
-<span class='secno'>A.4</span>
+<span class='secno'>A.5</span>
 <a href='https://github.com/pchampin/sophia_rs'>
 <span about='https://github.com/pchampin/sophia_rs' property='doap:name'>Sophia</span>
 </a>
@@ -28209,7 +32160,7 @@ Transform RDF to JSON-LD
 </dl>
 </dd>
 <dt id='subj_JSON_goLD_Go'>
-<span class='secno'>A.5</span>
+<span class='secno'>A.6</span>
 <a href='https://github.com/piprate/json-gold'>
 <span about='https://github.com/piprate/json-gold' property='doap:name'>JSON-goLD</span>
 </a>
@@ -28232,7 +32183,7 @@ https://github.com/piprate/json-gold
 <a href='https://github.com/kazarena'>
 <span property='foaf:name'>Stan Nazarenko</span>
 </a>
-<a href-@id='https://github.com/kazarena' href-@type='[&quot;foaf:Person&quot;, &quot;Assertor&quot;]' href-foaf:homepage='https://github.com/kazarena' href-foaf:name='Stan Nazarenko' property='foaf:homepage'>
+<a href-@id='https://github.com/kazarena' href-@type='[&quot;Assertor&quot;, &quot;foaf:Person&quot;]' href-foaf:homepage='https://github.com/kazarena' href-foaf:name='Stan Nazarenko' property='foaf:homepage'>
 https://github.com/kazarena
 </a>
 </div>
@@ -28288,7 +32239,7 @@ Remote document
 Transform JSON-LD to RDF
 </td>
 <td class='passed-most'>
-422/442 (95.5%)
+418/442 (94.6%)
 </td>
 </tr>
 <tr>
@@ -28305,7 +32256,7 @@ Transform RDF to JSON-LD
 </dl>
 </dd>
 <dt id='subj_JSON_LD_Ruby'>
-<span class='secno'>A.6</span>
+<span class='secno'>A.7</span>
 <a href='https://rubygems.org/gems/json-ld'>
 <span about='https://rubygems.org/gems/json-ld' property='doap:name'>JSON::LD</span>
 </a>
@@ -28408,7 +32359,7 @@ Transform RDF to JSON-LD
 </dl>
 </dd>
 <dt id='subj_jsonld_streaming_parser_JavaScript'>
-<span class='secno'>A.7</span>
+<span class='secno'>A.8</span>
 <a href='https://www.npmjs.com/package/jsonld-streaming-parser/'>
 <span about='https://www.npmjs.com/package/jsonld-streaming-parser/' property='doap:name'>jsonld-streaming-parser</span>
 </a>
@@ -28458,7 +32409,7 @@ Transform JSON-LD to RDF
 </dl>
 </dd>
 <dt id='subj_jsonld_streaming_serializer_JavaScript'>
-<span class='secno'>A.8</span>
+<span class='secno'>A.9</span>
 <a href='https://www.npmjs.com/package/jsonld-streaming-serializer/'>
 <span about='https://www.npmjs.com/package/jsonld-streaming-serializer/' property='doap:name'>jsonld-streaming-serializer</span>
 </a>
@@ -28508,7 +32459,7 @@ Transform RDF to JSON-LD
 </dl>
 </dd>
 <dt id='subj_rdf_parse_JavaScript'>
-<span class='secno'>A.9</span>
+<span class='secno'>A.10</span>
 <a href='https://www.npmjs.com/package/rdf-parse/'>
 <span about='https://www.npmjs.com/package/rdf-parse/' property='doap:name'>rdf-parse</span>
 </a>
@@ -28572,7 +32523,7 @@ Individual test results used to construct this report are available here:
 <a class='source' href='rdf-parse.ttl'>rdf-parse.ttl</a>
 </li>
 <li>
-<a class='source' href='rust-sophia-earl.ttl'>rust-sophia-earl.ttl</a>
+<a class='source' href='jsonld-js-earl.ttl'>jsonld-js-earl.ttl</a>
 </li>
 <li>
 <a class='source' href='guile-jsonld-earl.ttl'>guile-jsonld-earl.ttl</a>
@@ -28581,23 +32532,26 @@ Individual test results used to construct this report are available here:
 <a class='source' href='pyld-earl.ttl'>pyld-earl.ttl</a>
 </li>
 <li>
-<a class='source' href='jsonld-streaming-serializer-earl.ttl'>jsonld-streaming-serializer-earl.ttl</a>
+<a class='source' href='perl-jsonld-earl.ttl'>perl-jsonld-earl.ttl</a>
 </li>
 <li>
-<a class='source' href='jsonld-streaming-parser-earl.ttl'>jsonld-streaming-parser-earl.ttl</a>
+<a class='source' href='rust-sophia-earl.ttl'>rust-sophia-earl.ttl</a>
+</li>
+<li>
+<a class='source' href='jsonld-streaming-serializer-earl.ttl'>jsonld-streaming-serializer-earl.ttl</a>
 </li>
 <li>
 <a class='source' href='jsonld-gold-earl.ttl'>jsonld-gold-earl.ttl</a>
 </li>
 <li>
-<a class='source' href='ruby-json-ld-earl.ttl'>ruby-json-ld-earl.ttl</a>
+<a class='source' href='jsonld-streaming-parser-earl.ttl'>jsonld-streaming-parser-earl.ttl</a>
 </li>
 <li>
-<a class='source' href='perl-jsonld-earl.ttl'>perl-jsonld-earl.ttl</a>
+<a class='source' href='ruby-json-ld-earl.ttl'>ruby-json-ld-earl.ttl</a>
 </li>
 </ul>
 </section>
-<section class='appendix' id='report-generation-software' property='earl:generatedBy' resource='http://rubygems.org/gems/earl-report' typeof='Software doap:Project'>
+<section class='appendix' id='report-generation-software' property='earl:generatedBy' resource='http://rubygems.org/gems/earl-report' typeof='doap:Project Software'>
 <h2>
 <span class='secno'>C.</span>
 Report Generation Software

--- a/reports/index.html
+++ b/reports/index.html
@@ -4,15 +4,15 @@
 <meta content='text/html;charset=utf-8' http-equiv='Content-Type' />
 <link href='earl.jsonld' rel='alternate' />
 <link href='https://www.w3.org/StyleSheets/TR/base' rel='stylesheet' />
-<link href='jsonld-gold-earl.ttl' rel='related' />
-<link href='pyld-earl.ttl' rel='related' />
-<link href='ruby-json-ld-earl.ttl' rel='related' />
-<link href='guile-jsonld-earl.ttl' rel='related' />
-<link href='jsonld-streaming-parser-earl.ttl' rel='related' />
-<link href='rust-sophia-earl.ttl' rel='related' />
-<link href='jsonld-streaming-serializer-earl.ttl' rel='related' />
-<link href='perl-jsonld-earl.ttl' rel='related' />
 <link href='rdf-parse.ttl' rel='related' />
+<link href='rust-sophia-earl.ttl' rel='related' />
+<link href='guile-jsonld-earl.ttl' rel='related' />
+<link href='pyld-earl.ttl' rel='related' />
+<link href='jsonld-streaming-serializer-earl.ttl' rel='related' />
+<link href='jsonld-streaming-parser-earl.ttl' rel='related' />
+<link href='jsonld-gold-earl.ttl' rel='related' />
+<link href='ruby-json-ld-earl.ttl' rel='related' />
+<link href='perl-jsonld-earl.ttl' rel='related' />
 <title>
 JSON-LD 1.1 Processor Conformance
 </title>
@@ -241,63 +241,63 @@ Test Subjects
 <ul class='toc'>
 <li class='tocline'>
 <span class='secno'>A.1</span>
-<a class='tocxref' href='#subj_0'>
+<a class='tocxref' href='#subj_JSONLD_Perl'>
 JSONLD
  (Perl)
 </a>
 </li>
 <li class='tocline'>
 <span class='secno'>A.2</span>
-<a class='tocxref' href='#subj_1'>
+<a class='tocxref' href='#subj_guile_jsonld_GNU_Guile'>
 guile-jsonld
  (GNU Guile)
 </a>
 </li>
 <li class='tocline'>
 <span class='secno'>A.3</span>
-<a class='tocxref' href='#subj_2'>
+<a class='tocxref' href='#subj_PyLD_Python'>
 PyLD
  (Python)
 </a>
 </li>
 <li class='tocline'>
 <span class='secno'>A.4</span>
-<a class='tocxref' href='#subj_3'>
+<a class='tocxref' href='#subj_Sophia_Rust'>
 Sophia
  (Rust)
 </a>
 </li>
 <li class='tocline'>
 <span class='secno'>A.5</span>
-<a class='tocxref' href='#subj_4'>
+<a class='tocxref' href='#subj_JSON_goLD_Go'>
 JSON-goLD
  (Go)
 </a>
 </li>
 <li class='tocline'>
 <span class='secno'>A.6</span>
-<a class='tocxref' href='#subj_5'>
+<a class='tocxref' href='#subj_JSON_LD_Ruby'>
 JSON::LD
  (Ruby)
 </a>
 </li>
 <li class='tocline'>
 <span class='secno'>A.7</span>
-<a class='tocxref' href='#subj_6'>
+<a class='tocxref' href='#subj_jsonld_streaming_parser_JavaScript'>
 jsonld-streaming-parser
  (JavaScript)
 </a>
 </li>
 <li class='tocline'>
 <span class='secno'>A.8</span>
-<a class='tocxref' href='#subj_7'>
+<a class='tocxref' href='#subj_jsonld_streaming_serializer_JavaScript'>
 jsonld-streaming-serializer
  (JavaScript)
 </a>
 </li>
 <li class='tocline'>
 <span class='secno'>A.9</span>
-<a class='tocxref' href='#subj_8'>
+<a class='tocxref' href='#subj_rdf_parse_JavaScript'>
 rdf-parse
  (JavaScript)
 </a>
@@ -311,14 +311,8 @@ Individual Test Results
 </a>
 </li>
 <li class='tocline'>
-<a class='tocxref' href='#test-definitions'>
-<span class='secno'>C.</span>
-Test Definitions
-</a>
-</li>
-<li class='tocline'>
 <a class='tocxref' href='#report-generation-software'>
-<span class='secno'>D.</span>
+<span class='secno'>C.</span>
 Report Generation Software
 </a>
 </li>
@@ -394,28 +388,28 @@ Test Manifests
 Test
 </th>
 <th>
-<a href='#subj_1'>
+<a href='#subj_guile_jsonld_GNU_Guile'>
 guile-jsonld
 <br />
 (GNU Guile)
 </a>
 </th>
 <th>
-<a href='#subj_2'>
+<a href='#subj_PyLD_Python'>
 PyLD
 <br />
 (Python)
 </a>
 </th>
 <th>
-<a href='#subj_4'>
+<a href='#subj_JSON_goLD_Go'>
 JSON-goLD
 <br />
 (Go)
 </a>
 </th>
 <th>
-<a href='#subj_5'>
+<a href='#subj_JSON_LD_Ruby'>
 JSON::LD
 <br />
 (Ruby)
@@ -4658,35 +4652,35 @@ Percentage passed out of 238 Tests
 Test
 </th>
 <th>
-<a href='#subj_0'>
+<a href='#subj_JSONLD_Perl'>
 JSONLD
 <br />
 (Perl)
 </a>
 </th>
 <th>
-<a href='#subj_1'>
+<a href='#subj_guile_jsonld_GNU_Guile'>
 guile-jsonld
 <br />
 (GNU Guile)
 </a>
 </th>
 <th>
-<a href='#subj_2'>
+<a href='#subj_PyLD_Python'>
 PyLD
 <br />
 (Python)
 </a>
 </th>
 <th>
-<a href='#subj_4'>
+<a href='#subj_JSON_goLD_Go'>
 JSON-goLD
 <br />
 (Go)
 </a>
 </th>
 <th>
-<a href='#subj_5'>
+<a href='#subj_JSON_LD_Ruby'>
 JSON::LD
 <br />
 (Ruby)
@@ -12293,28 +12287,28 @@ Percentage passed out of 366 Tests
 Test
 </th>
 <th>
-<a href='#subj_1'>
+<a href='#subj_guile_jsonld_GNU_Guile'>
 guile-jsonld
 <br />
 (GNU Guile)
 </a>
 </th>
 <th>
-<a href='#subj_2'>
+<a href='#subj_PyLD_Python'>
 PyLD
 <br />
 (Python)
 </a>
 </th>
 <th>
-<a href='#subj_4'>
+<a href='#subj_JSON_goLD_Go'>
 JSON-goLD
 <br />
 (Go)
 </a>
 </th>
 <th>
-<a href='#subj_5'>
+<a href='#subj_JSON_LD_Ruby'>
 JSON::LD
 <br />
 (Ruby)
@@ -13298,21 +13292,21 @@ Percentage passed out of 55 Tests
 Test
 </th>
 <th>
-<a href='#subj_2'>
+<a href='#subj_PyLD_Python'>
 PyLD
 <br />
 (Python)
 </a>
 </th>
 <th>
-<a href='#subj_4'>
+<a href='#subj_JSON_goLD_Go'>
 JSON-goLD
 <br />
 (Go)
 </a>
 </th>
 <th>
-<a href='#subj_5'>
+<a href='#subj_JSON_LD_Ruby'>
 JSON::LD
 <br />
 (Ruby)
@@ -14664,35 +14658,35 @@ Percentage passed out of 89 Tests
 Test
 </th>
 <th>
-<a href='#subj_1'>
+<a href='#subj_guile_jsonld_GNU_Guile'>
 guile-jsonld
 <br />
 (GNU Guile)
 </a>
 </th>
 <th>
-<a href='#subj_2'>
+<a href='#subj_PyLD_Python'>
 PyLD
 <br />
 (Python)
 </a>
 </th>
 <th>
-<a href='#subj_4'>
+<a href='#subj_JSON_goLD_Go'>
 JSON-goLD
 <br />
 (Go)
 </a>
 </th>
 <th>
-<a href='#subj_5'>
+<a href='#subj_JSON_LD_Ruby'>
 JSON::LD
 <br />
 (Ruby)
 </a>
 </th>
 <th>
-<a href='#subj_8'>
+<a href='#subj_rdf_parse_JavaScript'>
 rdf-parse
 <br />
 (JavaScript)
@@ -15763,28 +15757,28 @@ Percentage passed out of 49 Tests
 Test
 </th>
 <th>
-<a href='#subj_1'>
+<a href='#subj_guile_jsonld_GNU_Guile'>
 guile-jsonld
 <br />
 (GNU Guile)
 </a>
 </th>
 <th>
-<a href='#subj_2'>
+<a href='#subj_PyLD_Python'>
 PyLD
 <br />
 (Python)
 </a>
 </th>
 <th>
-<a href='#subj_4'>
+<a href='#subj_JSON_goLD_Go'>
 JSON-goLD
 <br />
 (Go)
 </a>
 </th>
 <th>
-<a href='#subj_5'>
+<a href='#subj_JSON_LD_Ruby'>
 JSON::LD
 <br />
 (Ruby)
@@ -16131,42 +16125,42 @@ Percentage passed out of 18 Tests
 Test
 </th>
 <th>
-<a href='#subj_0'>
+<a href='#subj_JSONLD_Perl'>
 JSONLD
 <br />
 (Perl)
 </a>
 </th>
 <th>
-<a href='#subj_1'>
+<a href='#subj_guile_jsonld_GNU_Guile'>
 guile-jsonld
 <br />
 (GNU Guile)
 </a>
 </th>
 <th>
-<a href='#subj_2'>
+<a href='#subj_PyLD_Python'>
 PyLD
 <br />
 (Python)
 </a>
 </th>
 <th>
-<a href='#subj_4'>
+<a href='#subj_JSON_goLD_Go'>
 JSON-goLD
 <br />
 (Go)
 </a>
 </th>
 <th>
-<a href='#subj_5'>
+<a href='#subj_JSON_LD_Ruby'>
 JSON::LD
 <br />
 (Ruby)
 </a>
 </th>
 <th>
-<a href='#subj_6'>
+<a href='#subj_jsonld_streaming_parser_JavaScript'>
 jsonld-streaming-parser
 <br />
 (JavaScript)
@@ -17210,20 +17204,20 @@ PASS
 </tr>
 <tr class='normative'>
 <td>
-<a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0124'>Test t0124: IRI Resolution (4)</a>
+<a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0124'>Test t0124: compact IRI as @vocab</a>
 (new in JSON-LD 1.1)
 </td>
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
 </td>
-<td class='UNTESTED'>
-UNTESTED
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -17246,8 +17240,8 @@ FAIL
 <td class='PASS'>
 PASS
 </td>
-<td class='UNTESTED'>
-UNTESTED
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -21275,20 +21269,20 @@ PASS
 </tr>
 <tr class='normative'>
 <td>
-<a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0124'>Test t0124: IRI Resolution (4)</a>
+<a href='https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0124'>Test t0124: compact IRI as @vocab</a>
 (new in JSON-LD 1.1)
 </td>
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
+<td class='FAIL'>
+FAIL
 </td>
 <td class='PASS'>
 PASS
 </td>
-<td class='UNTESTED'>
-UNTESTED
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -21311,8 +21305,8 @@ FAIL
 <td class='PASS'>
 PASS
 </td>
-<td class='UNTESTED'>
-UNTESTED
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -26603,13 +26597,13 @@ Percentage passed out of 442 Tests
 99.8%
 </td>
 <td class='passed-most'>
-95.9%
+95.5%
 </td>
 <td class='passed-most'>
 99.5%
 </td>
-<td class='passed-some'>
-94.6%
+<td class='passed-most'>
+95.5%
 </td>
 <td class='passed-all'>
 100.0%
@@ -26633,42 +26627,42 @@ Percentage passed out of 442 Tests
 Test
 </th>
 <th>
-<a href='#subj_1'>
+<a href='#subj_guile_jsonld_GNU_Guile'>
 guile-jsonld
 <br />
 (GNU Guile)
 </a>
 </th>
 <th>
-<a href='#subj_2'>
+<a href='#subj_PyLD_Python'>
 PyLD
 <br />
 (Python)
 </a>
 </th>
 <th>
-<a href='#subj_3'>
+<a href='#subj_Sophia_Rust'>
 Sophia
 <br />
 (Rust)
 </a>
 </th>
 <th>
-<a href='#subj_4'>
+<a href='#subj_JSON_goLD_Go'>
 JSON-goLD
 <br />
 (Go)
 </a>
 </th>
 <th>
-<a href='#subj_5'>
+<a href='#subj_JSON_LD_Ruby'>
 JSON::LD
 <br />
 (Ruby)
 </a>
 </th>
 <th>
-<a href='#subj_7'>
+<a href='#subj_jsonld_streaming_serializer_JavaScript'>
 jsonld-streaming-serializer
 <br />
 (JavaScript)
@@ -27909,7 +27903,7 @@ Test Subjects
 This report was tested using the following test subjects:
 </p>
 <dl>
-<dt id='subj_0'>
+<dt id='subj_JSONLD_Perl'>
 <span class='secno'>A.1</span>
 <a href='http://purl.org/NET/cpan-uri/dist/JSONLD/project'>
 <span about='http://purl.org/NET/cpan-uri/dist/JSONLD/project' property='doap:name'>JSONLD</span>
@@ -27965,7 +27959,7 @@ Transform JSON-LD to RDF
 </dd>
 </dl>
 </dd>
-<dt id='subj_1'>
+<dt id='subj_guile_jsonld_GNU_Guile'>
 <span class='secno'>A.2</span>
 <a href='https://framagit.org/tyreunom/guile-jsonld'>
 <span about='https://framagit.org/tyreunom/guile-jsonld' property='doap:name'>guile-jsonld</span>
@@ -28047,7 +28041,7 @@ Remote document
 Transform JSON-LD to RDF
 </td>
 <td class='passed-most'>
-424/442 (95.9%)
+422/442 (95.5%)
 </td>
 </tr>
 <tr>
@@ -28063,7 +28057,7 @@ Transform RDF to JSON-LD
 </dd>
 </dl>
 </dd>
-<dt id='subj_2'>
+<dt id='subj_PyLD_Python'>
 <span class='secno'>A.3</span>
 <a href='https://github.com/digitalbazaar/pyld'>
 <span about='https://github.com/digitalbazaar/pyld' property='doap:name'>PyLD</span>
@@ -28072,7 +28066,7 @@ Transform RDF to JSON-LD
 <dd>
 <dl>
 <dt>Release</dt>
-<dd property='doap:release'><span property='doap:revision'>2.0.0</span></dd>
+<dd property='doap:release'><span property='doap:revision'>2.0.1</span></dd>
 <dt>Programming Language</dt>
 <dd property='doap:programming-language'>Python</dd>
 <dt>Home Page</dt>
@@ -28087,7 +28081,7 @@ https://github.com/digitalbazaar/pyld
 <a href='https://github.com/dlongley'>
 <span property='foaf:name'>Dave Longley</span>
 </a>
-<a href-@id='https://github.com/dlongley' href-@type='[&quot;Assertor&quot;, &quot;foaf:Person&quot;]' href-foaf:homepage='https://github.com/dlongley' href-foaf:name='Dave Longley' property='foaf:homepage'>
+<a href-@id='https://github.com/dlongley' href-@type='[&quot;foaf:Person&quot;, &quot;Assertor&quot;]' href-foaf:homepage='https://github.com/dlongley' href-foaf:name='Dave Longley' property='foaf:homepage'>
 https://github.com/dlongley
 </a>
 </div>
@@ -28167,7 +28161,7 @@ Transform RDF to JSON-LD
 </dd>
 </dl>
 </dd>
-<dt id='subj_3'>
+<dt id='subj_Sophia_Rust'>
 <span class='secno'>A.4</span>
 <a href='https://github.com/pchampin/sophia_rs'>
 <span about='https://github.com/pchampin/sophia_rs' property='doap:name'>Sophia</span>
@@ -28214,7 +28208,7 @@ Transform RDF to JSON-LD
 </dd>
 </dl>
 </dd>
-<dt id='subj_4'>
+<dt id='subj_JSON_goLD_Go'>
 <span class='secno'>A.5</span>
 <a href='https://github.com/piprate/json-gold'>
 <span about='https://github.com/piprate/json-gold' property='doap:name'>JSON-goLD</span>
@@ -28238,7 +28232,7 @@ https://github.com/piprate/json-gold
 <a href='https://github.com/kazarena'>
 <span property='foaf:name'>Stan Nazarenko</span>
 </a>
-<a href-@id='https://github.com/kazarena' href-@type='[&quot;Assertor&quot;, &quot;foaf:Person&quot;]' href-foaf:homepage='https://github.com/kazarena' href-foaf:name='Stan Nazarenko' property='foaf:homepage'>
+<a href-@id='https://github.com/kazarena' href-@type='[&quot;foaf:Person&quot;, &quot;Assertor&quot;]' href-foaf:homepage='https://github.com/kazarena' href-foaf:name='Stan Nazarenko' property='foaf:homepage'>
 https://github.com/kazarena
 </a>
 </div>
@@ -28294,7 +28288,7 @@ Remote document
 Transform JSON-LD to RDF
 </td>
 <td class='passed-most'>
-418/442 (94.6%)
+422/442 (95.5%)
 </td>
 </tr>
 <tr>
@@ -28310,7 +28304,7 @@ Transform RDF to JSON-LD
 </dd>
 </dl>
 </dd>
-<dt id='subj_5'>
+<dt id='subj_JSON_LD_Ruby'>
 <span class='secno'>A.6</span>
 <a href='https://rubygems.org/gems/json-ld'>
 <span about='https://rubygems.org/gems/json-ld' property='doap:name'>JSON::LD</span>
@@ -28413,7 +28407,7 @@ Transform RDF to JSON-LD
 </dd>
 </dl>
 </dd>
-<dt id='subj_6'>
+<dt id='subj_jsonld_streaming_parser_JavaScript'>
 <span class='secno'>A.7</span>
 <a href='https://www.npmjs.com/package/jsonld-streaming-parser/'>
 <span about='https://www.npmjs.com/package/jsonld-streaming-parser/' property='doap:name'>jsonld-streaming-parser</span>
@@ -28463,7 +28457,7 @@ Transform JSON-LD to RDF
 </dd>
 </dl>
 </dd>
-<dt id='subj_7'>
+<dt id='subj_jsonld_streaming_serializer_JavaScript'>
 <span class='secno'>A.8</span>
 <a href='https://www.npmjs.com/package/jsonld-streaming-serializer/'>
 <span about='https://www.npmjs.com/package/jsonld-streaming-serializer/' property='doap:name'>jsonld-streaming-serializer</span>
@@ -28513,7 +28507,7 @@ Transform RDF to JSON-LD
 </dd>
 </dl>
 </dd>
-<dt id='subj_8'>
+<dt id='subj_rdf_parse_JavaScript'>
 <span class='secno'>A.9</span>
 <a href='https://www.npmjs.com/package/rdf-parse/'>
 <span about='https://www.npmjs.com/package/rdf-parse/' property='doap:name'>rdf-parse</span>
@@ -28575,37 +28569,37 @@ Individual test results used to construct this report are available here:
 </p>
 <ul>
 <li>
-<a class='source' href='jsonld-gold-earl.ttl'>jsonld-gold-earl.ttl</a>
-</li>
-<li>
-<a class='source' href='pyld-earl.ttl'>pyld-earl.ttl</a>
-</li>
-<li>
-<a class='source' href='ruby-json-ld-earl.ttl'>ruby-json-ld-earl.ttl</a>
-</li>
-<li>
-<a class='source' href='guile-jsonld-earl.ttl'>guile-jsonld-earl.ttl</a>
-</li>
-<li>
-<a class='source' href='jsonld-streaming-parser-earl.ttl'>jsonld-streaming-parser-earl.ttl</a>
+<a class='source' href='rdf-parse.ttl'>rdf-parse.ttl</a>
 </li>
 <li>
 <a class='source' href='rust-sophia-earl.ttl'>rust-sophia-earl.ttl</a>
 </li>
 <li>
+<a class='source' href='guile-jsonld-earl.ttl'>guile-jsonld-earl.ttl</a>
+</li>
+<li>
+<a class='source' href='pyld-earl.ttl'>pyld-earl.ttl</a>
+</li>
+<li>
 <a class='source' href='jsonld-streaming-serializer-earl.ttl'>jsonld-streaming-serializer-earl.ttl</a>
+</li>
+<li>
+<a class='source' href='jsonld-streaming-parser-earl.ttl'>jsonld-streaming-parser-earl.ttl</a>
+</li>
+<li>
+<a class='source' href='jsonld-gold-earl.ttl'>jsonld-gold-earl.ttl</a>
+</li>
+<li>
+<a class='source' href='ruby-json-ld-earl.ttl'>ruby-json-ld-earl.ttl</a>
 </li>
 <li>
 <a class='source' href='perl-jsonld-earl.ttl'>perl-jsonld-earl.ttl</a>
 </li>
-<li>
-<a class='source' href='rdf-parse.ttl'>rdf-parse.ttl</a>
-</li>
 </ul>
 </section>
-<section class='appendix' id='report-generation-software' property='earl:generatedBy' resource='http://rubygems.org/gems/earl-report' typeof='doap:Project Software'>
+<section class='appendix' id='report-generation-software' property='earl:generatedBy' resource='http://rubygems.org/gems/earl-report' typeof='Software doap:Project'>
 <h2>
-<span class='secno'>D.</span>
+<span class='secno'>C.</span>
 Report Generation Software
 </h2>
 <p>

--- a/reports/template.haml
+++ b/reports/template.haml
@@ -200,12 +200,8 @@
             %span.secno="B."
             Individual Test Results
         %li.tocline
-          %a.tocxref{href: "#test-definitions"}
-            %span.secno="C."
-            Test Definitions
-        %li.tocline
           %a.tocxref{href: "#report-generation-software"}
-            %span.secno="D."
+            %span.secno="C."
             Report Generation Software
     %section#introduction
       :markdown
@@ -424,7 +420,7 @@
               %a.source{href: file}<= file
     %section.appendix#report-generation-software{property: "earl:generatedBy", resource: tests['generatedBy']['@id'], typeof: tests['generatedBy']['@type'].join(' ')}
       %h2
-        %span.secno="D."
+        %span.secno="C."
         Report Generation Software
       - doap = tests['generatedBy']
       - rel = doap['release']

--- a/reports/template.haml
+++ b/reports/template.haml
@@ -84,7 +84,8 @@
     - subject_refs = {}
     - passed_tests = []
     - subjects.each_with_index do |subject, index|
-      - subject_refs[subject['@id']] = "subj_#{index}"
+      - frag_id = "subj_#{subject['name']}-#{subject['language']}".gsub(/[\W_]+/, '_')
+      - subject_refs[subject['@id']] = frag_id
     %div.head{role: :contentinfo}
       %p
         %a{href: "http://www.w3.org/"}


### PR DESCRIPTION
* Remove Test Definition's appendix, which was missing.
* Use stable identifiers for subject references within implementation report.

Fixes #469.