### PR TITLE
Added the errata management file

### DIFF
--- a/errata/errata.css
+++ b/errata/errata.css
@@ -1,0 +1,178 @@
+div#toc a, section#toc a {
+	text-decoration: none;
+}
+
+div#toc a:hover, section#toc a:hover {
+	background: yellow;
+	color: red;
+}
+
+div#toc ul, section#toc ul {
+	list-style-type: none;
+	margin-left: 1.5em;
+	padding-left: 0;
+}
+
+.tocvisible, .tochidden { cursor: pointer; }
+.tocvisible:before {
+	content: "▾ ";
+	font-size: 110%; 
+	font-family: monospace;
+}
+.tochidden:before  { 
+	content: "‣ "; 
+	font-size: 110%; 
+	font-family: monospace;
+}
+
+span.state_open {
+	padding-left: 0.2em;
+	padding-right: 0.2em;
+	background-color: darkseagreen;
+	color: black;
+}
+span.state_closed {
+	padding-left: 0.2em;
+	padding-right: 0.2em;
+	background-color: indianred;
+	color: black;
+}
+
+/* Careful: the content below are two non-breakable spaces (in UTF-8)! */
+span.tocnumber:not(.tocvisible):not(.tochidden):before {
+	content: "  ";
+	font-size: 120%;
+}
+
+body {
+	font-family: arial, helvetica, freesans, clean, sans-serif;
+	color:black;
+	/* line-height:1.4em; */
+	padding: 2em 2em;
+}
+
+section section {
+	margin-left: 4em;
+}
+/* Links... */
+
+a {
+	color: NavyBlue;
+	background: transparent;
+}
+
+a:link, a:active {
+	background: transparent;
+	text-decoration:none;
+}
+
+a:visited {
+	color: NavyBlue;
+	background: transparent;
+}
+
+a:hover{
+	background-color: yellow;
+	color: #00e;
+}
+
+a code, a:link code, a:visited code {
+	color:#4183c4;
+}
+
+a:link img, a:visited img {
+   border-style: none
+}
+
+/* Headers */
+h1, h2, h3, h4, h5, h6
+{
+	margin-bottom: 0.5em;
+	margin-top: 1em;
+	padding-bottom: 0.15em;
+	border-bottom: 1px solid #ccc;
+	background: transparent;
+	color: #005a9c;
+	font-weight: normal;
+}
+
+.title-date {
+	font-size: 1.4em;
+	color: #005a9c;
+	font-weight: normal;
+}
+
+footer
+{
+	margin-top: 2em;
+	border-top: 1px ridge #ccc;
+	font-size: 90%;
+}
+
+h1
+{
+	border-bottom: none;
+}
+
+h5, h6 {
+	border: none;
+	font-size: 100%;
+}
+
+headertoclevel1, .headertoclevel2, .headertoclevel3, .headertoclevel4
+{
+	border-bottom: 1px solid #ccc !important;
+}
+
+.headertoclevel1
+{
+  font-size: 1.5em !important;
+}
+
+.headertoclevel2
+{
+  font-size: 1.17em !important;
+}
+
+.headertoclevel3
+{
+	font-size: 1em !important;
+}
+
+.headertoclevel4, .headertoclevel5 {
+	border: none !important;
+	font-size: 1em !important;
+}
+/* --- */
+
+hr { border:1px solid #ddd; }
+
+dt {
+	font-weight:bold;
+	margin-left:1em;
+}
+
+sup {
+    font-size: 0.83em;
+    vertical-align: super;
+    line-height: 0;
+}
+
+.summary {
+	font-size: 1.4em;
+	color: #005a9c;
+	font-weight: normal;
+}
+div.issue {
+	margin-left: 1em;
+	margin-bottom: 0.3em;
+	padding-right: 0.5em;
+	padding-left: 0.5em;
+	padding-top: 0.2em;
+	border-radius: 10px;
+	border: solid black 1px;
+}
+span.what {
+	font-weight: bold;
+	font-style: italic;
+}

--- a/errata/index.html
+++ b/errata/index.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+  <!--
+    The data-githubrepo attribute provides the owner/repo name on github. For W3C repositories most of those are of the
+    form 'w3c/XXX', although there are groups that have their own owner for their repository.
+  -->
+  <head data-githubrepo="w3c/json-ld-api">
+    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
+    <title>Open Errata for the JSON-LD API specification published by the JSON-LD Working Group</title>
+    <link rel="stylesheet" type="text/css" href="https://w3c.github.io/display_errata/assets/errata.css"/>
+    <script src="https://w3c.github.io/display_errata/assets/errata.js" type="text/javascript"></script>
+    <script src="https://w3c.github.io/display_errata/assets/toc.js" type="text/javascript"></script>
+
+    <style type="text/css">
+      .todo {
+        background-color: yellow
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <p class="banner"><a accesskey="W" href="https://www.w3.org/"><img width="72" height="48" alt="W3C" src="https://www.w3.org/Icons/w3c_home" /></a> </p>
+      <br />
+      <h1 class="title" class="todo">Open Errata for the JSON-LD API specification published by the JSON-LD Working Group</h1>
+      <dl>
+        <dt>Latest errata update:</dt>
+        <dd><span id="date"></span></dd>
+        <dt>Number of recorded errata:</dt>
+        <dd><span id="number"></span></dd>
+        <dt>Link to all errata:</dt>
+        <dd><span id="errata_link"></span></dd>
+      </dl>
+
+      <section data-notoc>
+        <h1>How to Submit an Erratum?</h1>
+        <p>Errata are introduced and stored in the <a href="https://github.com/w3c/json-ld-api/issues/">issue list of the document‘s GitHub repository</a>. The workflow to add a new erratum is as follows:</p>
+        <ul>
+           <li>An issue is raised for a possible erratum. The label of the issue SHOULD be set to “<code>ErratumRaised</code>”. It is o.k. for an erratum to have several labels.</li>
+           <li>Issues labeled as “<code>Editorial</code>” are displayed separately, to make it easier to differentiate editorial errata from substantial ones.</li>
+          <li>The community discusses the issue. If it is accepted as a genuine erratum, the label “<code>Errata</code>” is added to the entry and the “<code>ErratumRaised</code>” label should be removed. Additionally, a new comment on the issue MAY be added, beginning with the word "Summary:" (if such a summary is useful based on the discussion).</li>
+          <li>If the community rejects the issue as an erratum, the issue should be closed.</li>
+          <li>Each errata may be labelled as “<code>Editorial</code>”; editorial errata are listed separately from the substantial ones.</li>
+          <li>ALL substantive errata are generally expected to have corresponding test(s), either in the form of new tests or modifications to existing tests, or must include the rationale for why test updates are not required for the erratum.</li>
+        </ul>
+
+        <p>If you have problems following this process, but you want nevertheless to report an error, you can also contact the staff contact of the Working Group, <a href="mailto:ivan@w3.org">Ivan Herman</a>.</p>
+      </section>
+    </header>
+
+    <div class="toc" id="toc"></div>
+
+    <main>
+      <section data-nolabel>
+        <h1>Open Errata on the “JSON-LD 1.1 Processing Algorithms and API” Recommendation</h1>
+        <dl>
+            <dt>Latest Published Version:</dt>
+            <dd><a href="https://www.w3.org/TR/json-ld11-api/">https://www.w3.org/TR/json-ld11-api/</a></dd>
+            <dt>Editor’s draft:</dt>
+            <dd><a class="todo" href="https://w3c.github.io/json-ld-api/">https://w3c.github.io/json-ld-api/</a></dd>
+            <dt>Latest Publication Date:</dt>
+            <dd class="todo">@@@@ @@@@, @@@@</dd>
+        </dl>
+        <section>
+          <h2>Substantial Issues</h2>
+        </section>
+        <section>
+          <h2>Editorial Issues</h2>
+        </section>
+      </section>
+    </main>
+
+    <footer>
+      <address><a href="mailto:ivan@w3.org" class=''>Ivan Herman</a>, &lt;ivan@w3.org&gt;, (W3C)</address>
+      <p class="copyright"><a href="/Consortium/Legal/ipr-notice#Copyright" rel="Copyright">Copyright</a> © <span>2020</span> <a href="/"><acronym title="World Wide Web Consortium">W3C</acronym></a> <sup>®</sup> (<a href="http://www.csail.mit.edu/"><acronym title="Massachusetts Institute of Technology">MIT</acronym></a>, <a href="http://www.ercim.org/"><acronym title="European Research Consortium for Informatics and Mathematics">ERCIM</acronym></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved.</p>
+    </footer>
+  </body>
+</html>

--- a/errata/index.html
+++ b/errata/index.html
@@ -48,8 +48,8 @@
       </section>
     </header>
 
-    <div class="toc" id="toc"></div>
-
+    <!-- <div class="toc" id="toc"></div>
+ -->
     <main>
       <section data-nolabel>
         <h1>Open Errata on the “JSON-LD 1.1 Processing Algorithms and API” Recommendation</h1>

--- a/errata/index.html
+++ b/errata/index.html
@@ -7,7 +7,7 @@
   <head data-githubrepo="w3c/json-ld-api">
     <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
     <title>Open Errata for the JSON-LD API specification published by the JSON-LD Working Group</title>
-    <link rel="stylesheet" type="text/css" href="https://w3c.github.io/display_errata/assets/errata.css"/>
+    <link rel="stylesheet" type="text/css" href="errata.css"/>
     <script src="https://w3c.github.io/display_errata/assets/errata.js" type="text/javascript"></script>
     <script src="https://w3c.github.io/display_errata/assets/toc.js" type="text/javascript"></script>
 
@@ -21,7 +21,7 @@
     <header>
       <p class="banner"><a accesskey="W" href="https://www.w3.org/"><img width="72" height="48" alt="W3C" src="https://www.w3.org/Icons/w3c_home" /></a> </p>
       <br />
-      <h1 class="title" class="todo">Open Errata for the JSON-LD API specification published by the JSON-LD Working Group</h1>
+      <h1 class="title" class="todo">Open Errata for the JSON-LD API specification</h1>
       <dl>
         <dt>Latest errata update:</dt>
         <dd><span id="date"></span></dd>
@@ -38,6 +38,7 @@
            <li>An issue is raised for a possible erratum. The label of the issue SHOULD be set to “<code>ErratumRaised</code>”. It is o.k. for an erratum to have several labels.</li>
            <li>Issues labeled as “<code>Editorial</code>” are displayed separately, to make it easier to differentiate editorial errata from substantial ones.</li>
           <li>The community discusses the issue. If it is accepted as a genuine erratum, the label “<code>Errata</code>” is added to the entry and the “<code>ErratumRaised</code>” label should be removed. Additionally, a new comment on the issue MAY be added, beginning with the word "Summary:" (if such a summary is useful based on the discussion).</li>
+          <li>All issues, labeled by “<code>Errata</code>”, are displayed in this report, whether they are opened or closed. Their status is added to the report on the individual errata.</li>
           <li>If the community rejects the issue as an erratum, the issue should be closed.</li>
           <li>Each errata may be labelled as “<code>Editorial</code>”; editorial errata are listed separately from the substantial ones.</li>
           <li>ALL substantive errata are generally expected to have corresponding test(s), either in the form of new tests or modifications to existing tests, or must include the rationale for why test updates are not required for the erratum.</li>


### PR DESCRIPTION
The file will be served from 

https://w3c.github.io/json-ld-api/errata/

(although we may want to set up redirections from W3C, to be discussed...)

See: https://raw.githack.com/w3c/json-ld-api/add-errata/errata/index.html for now.

If this is fine, the same file will be added to the syntax and framing specs (maybe to streaming?), with obvious copy-paste actions.