### PR TITLE
supersede remark

### DIFF
--- a/index.html
+++ b/index.html
@@ -324,6 +324,9 @@
   <p>There is a
     <a href="https://json-ld.org/playground/">live JSON-LD playground</a> that is capable
     of demonstrating the features described in this document.</p>
+  
+    <p>This specification is intended to <a href='https://www.w3.org/2019/Process-20190301/#rec-rescind'>supersede</a> the [[[JSON-LD10-API]]] [[JSON-LD10-API]] specification. </p>
+
 
   <section>
     <h2>Set of Documents</h2>

--- a/publication-snapshots/PR/Overview.html
+++ b/publication-snapshots/PR/Overview.html
@@ -1072,6 +1072,9 @@
   <p>There is a
     <a href="https://json-ld.org/playground/">live JSON-LD playground</a> that is capable
     of demonstrating the features described in this document.</p>
+  
+    <p>This specification is intended to <a href="https://www.w3.org/2019/Process-20190301/#rec-rescind">supersede</a> the <cite><a href="https://www.w3.org/TR/2014/REC-json-ld-api-20140116/">JSON-LD 1.0 Processing Algorithms And API</a></cite> [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld10-api" title="JSON-LD 1.0 Processing Algorithms And API">JSON-LD10-API</a></cite>] specification. </p>
+
 
   <p>
     This document was published by the <a href="https://www.w3.org/2018/json-ld-wg/">JSON-LD Working Group</a> as a
@@ -1277,7 +1280,7 @@ to show the results of transforming an example into other representations.</pre>
 
     <div data-oninclude="restrictReferences"><section><h4 id="terms-imported-from-other-specifications">Terms imported from Other Specifications<a class="self-link" aria-label="§" href="#terms-imported-from-other-specifications"></a></h4>
 <p>Terms imported from <cite><a href="https://tc39.es/ecma262/">ECMAScript Language Specification</a></cite> [<cite><a class="bibref" data-link-type="biblio" href="#bib-ecmascript" title="ECMAScript Language Specification">ECMASCRIPT</a></cite>], <cite><a href="https://tools.ietf.org/html/rfc8259">The JavaScript Object Notation (JSON) Data Interchange Format</a></cite> [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8259" title="The JavaScript Object Notation (JSON) Data Interchange Format">RFC8259</a></cite>], <cite><a href="https://infra.spec.whatwg.org/">Infra Standard</a></cite> [<cite><a class="bibref" data-link-type="biblio" href="#bib-infra" title="Infra Standard">INFRA</a></cite>], and <cite><a href="https://heycam.github.io/webidl/">Web IDL</a></cite> [<cite><a class="bibref" data-link-type="biblio" href="#bib-webidl" title="Web IDL">WEBIDL</a></cite>]</p>
-<dl class="termlist" data-sort="" id="terms-0"><dt><dfn class="preserve" data-dfn-type="dfn" data-plurals="arrays" id="dfn-array" data-no-export=""><a href="https://infra.spec.whatwg.org/#list">array</a></dfn></dt><dd>
+<dl class="termlist" data-sort="" id="terms"><dt><dfn class="preserve" data-dfn-type="dfn" data-plurals="arrays" id="dfn-array" data-no-export=""><a href="https://infra.spec.whatwg.org/#list">array</a></dfn></dt><dd>
     In the JSON serialization,
     an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">array</a> structure is represented as square brackets surrounding zero or more values.
     Values are separated by commas.
@@ -1652,7 +1655,7 @@ to show the results of transforming an example into other representations.</pre>
 
     <p>The Following terms are used within specific algorithms.</p>
 
-    <div data-oninclude="restrictReferences"><dl class="termlist" data-sort="" id="terms"><dt><dfn id="dfn-active-graph" data-dfn-type="dfn">active graph</dfn></dt><dd>
+    <div data-oninclude="restrictReferences"><dl class="termlist" data-sort="" id="terms-0"><dt><dfn id="dfn-active-graph" data-dfn-type="dfn">active graph</dfn></dt><dd>
     The name of the currently active graph that the processor should use when processing.</dd>
   
   <dt><dfn id="dfn-active-property" data-dfn-type="dfn">active property</dfn></dt><dd>


### PR DESCRIPTION
Added the superseding remark to SOTD


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/486.html" title="Last updated on May 6, 2020, 7:30 PM UTC (b78153f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/486/462ad7c...b78153f.html" title="Last updated on May 6, 2020, 7:30 PM UTC (b78153f)">Diff</a>