### PR TITLE
add JSONP-LD 0.2.2 EARL

### DIFF
--- a/reports/java-jsonp-ld-earl.ttl
+++ b/reports/java-jsonp-ld-earl.ttl
@@ -1,0 +1,7459 @@
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix earl: <http://www.w3.org/ns/earl#> .
+
+<> foaf:primaryTopic <https://github.com/filip26/jsonp-ld>;
+  dc:issued "2020-05-30T19:06:36Z"^^xsd:dateTime;
+  foaf:maker <https://github.com/filip26>.
+
+<https://github.com/filip26/jsonp-ld> a earl:TestSubject,
+    doap:Project,
+    earl:Software;
+  dc:title "JSONP-LD" ;
+  dc:creator <https://github.com/filip26>;
+  doap:name "JSONP-LD";
+  doap:description "A JSON-LD 1.1 Processor & API for Java";
+  doap:developer <https://github.com/filip26>;
+  doap:homepage <https://github.com/filip26/jsonp-ld>;
+  doap:license <https://github.com/filip26/jsonp-ld/blob/master/LICENSE>;
+  doap:release [
+    doap:name "JSONP-LD 0.2.2";
+    doap:revision "0.2.2";
+    doap:created "2020-05-30"^^xsd:date;
+  ] ;
+  doap:programming-language "Java".
+
+<https://github.com/filip26> a earl:Assertor, foaf:Person;
+  foaf:name "Filip Kolarik";
+  foaf:homepage <https://github.com/filip26>.
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0001>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0002>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0003>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0004>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0005>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0006>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0007>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0008>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0009>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0010>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0011>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0012>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0013>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0014>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0015>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0016>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0017>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0018>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0019>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0020>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0021>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0022>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0023>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0024>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0025>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0026>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:failed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0027>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0028>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0029>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0030>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0031>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0032>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0033>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0034>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0035>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0036>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0037>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0038>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0039>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0040>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0041>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0042>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0043>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0044>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0045>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0046>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0047>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0048>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0049>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0050>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0051>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0052>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0053>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0054>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0055>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0056>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0057>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0058>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0059>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0060>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0061>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0062>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0063>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0064>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0065>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0066>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0067>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0068>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0069>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0070>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0071>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:failed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0072>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0073>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0074>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0075>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0076>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0077>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0078>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0079>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0080>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0081>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0082>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0083>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0084>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0085>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0086>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0087>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0088>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0089>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0090>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0091>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0092>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0093>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0094>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0095>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0096>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0097>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0098>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0099>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0100>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0101>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0102>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0103>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0104>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0105>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0106>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0107>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0108>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0109>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0110>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0111>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0112>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0113>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0114>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0115>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:failed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0116>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:failed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0117>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0118>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0119>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0120>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0121>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0122>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:failed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0123>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0124>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0125>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0126>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0127>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0128>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0129>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#t0130>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc001>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc002>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc003>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc004>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc005>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc006>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc007>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc008>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc009>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc010>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc011>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc012>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc013>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc014>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc015>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc016>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc017>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc018>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc019>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc020>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc021>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc022>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc023>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc024>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc025>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc026>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc027>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc028>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc029>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc030>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc031>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc032>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc033>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc034>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc035>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tc036>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tdi01>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:36Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tdi02>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tdi03>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tdi04>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tdi05>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tdi06>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tdi07>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tdi08>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tdi09>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tec01>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tec02>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tem01>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ten01>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ten02>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ten03>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ten04>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ten05>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ten06>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tep02>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tep03>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter01>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter02>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:failed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter03>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:failed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter04>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter05>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter06>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter07>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter08>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter09>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter10>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter11>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter12>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter13>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter14>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter15>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter17>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter18>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter19>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter20>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter21>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter22>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter23>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter24>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:failed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter25>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter26>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter27>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter28>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter29>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter30>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter31>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter32>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:failed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter33>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter34>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter35>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter36>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter37>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter38>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter39>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter40>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter41>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter42>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter43>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter44>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter48>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter49>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter50>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter51>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter52>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter53>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter54>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ter55>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tes01>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tes02>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tin01>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tin02>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tin03>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tin04>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tin05>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tin06>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tin07>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tin08>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tin09>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tjs01>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tjs02>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tjs03>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tjs04>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tjs05>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tjs06>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tjs07>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tjs08>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tjs09>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tjs10>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tjs11>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tjs12>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tjs13>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tjs14>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tjs15>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tjs16>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tjs17>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tjs18>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tjs19>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tjs20>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tjs21>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tjs22>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tjs23>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tl001>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tli01>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tli02>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tli03>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tli04>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tli05>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tli06>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tli07>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tli08>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tli09>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tli10>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tm001>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tm002>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tm003>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tm004>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tm005>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tm006>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tm007>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tm008>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tm009>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tm010>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tm011>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tm012>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tm013>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tm014>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tm015>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tm016>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tm017>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tm018>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tm019>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tm020>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tn001>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tn002>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tn003>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tn004>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tn005>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tn006>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tn007>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tn008>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tp001>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tp002>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tp003>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tp004>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpi01>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpi02>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpi03>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpi04>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpi05>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpi06>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpi07>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpi08>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpi09>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpi10>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpi11>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr01>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr02>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr03>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr04>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr05>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr06>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr08>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr09>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr10>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr11>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr12>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr13>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr14>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr15>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr16>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr17>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr18>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr19>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr20>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr21>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr22>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr23>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr24>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr25>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr26>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr27>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr28>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr29>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr30>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr31>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr32>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr33>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr34>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr35>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr36>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr37>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr38>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr39>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tpr40>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tso01>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tso02>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tso03>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tso05>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tso06>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tso07>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tso08>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tso09>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tso10>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tso11>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tso12>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#tso13>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ttn01>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/expand-manifest.jsonld#ttn02>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0001>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0002>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0003>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0004>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0005>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0006>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0007>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0008>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0009>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0010>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0011>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0012>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0013>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0014>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0015>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0016>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0017>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0018>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0019>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0020>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0021>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0022>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0023>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0024>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0025>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0026>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0027>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0028>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0029>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0030>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0031>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0032>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0033>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0034>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0035>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0036>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0037>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0038>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:failed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#ta038>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0039>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0040>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0041>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0042>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0043>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0044>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0045>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0046>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0047>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0048>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0049>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0050>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0051>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0052>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0053>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0054>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0055>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0056>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0057>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0058>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0059>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0060>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0061>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0062>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0063>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0064>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0065>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0066>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0067>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0068>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0069>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0070>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0071>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0072>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0073>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0074>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0075>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0076>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0077>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0078>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0079>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0080>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0081>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0082>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0083>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0084>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0085>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0086>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0087>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0088>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0089>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0090>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0091>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0092>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0093>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0094>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0095>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0096>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0097>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0098>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0099>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0100>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0101>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0102>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0103>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0104>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0105>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0106>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0107>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0108>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0109>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#t0110>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc001>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc002>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc003>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc004>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc005>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc006>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc007>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc008>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc009>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc010>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc011>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc012>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc013>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc014>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc015>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc016>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc017>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc018>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc019>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc020>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc021>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc022>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc023>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc024>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc025>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc026>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc027>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tc028>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tdi01>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tdi02>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tdi03>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tdi04>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tdi05>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tdi06>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tdi07>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#te001>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:failed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#te002>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#ten01>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tep05>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tep06>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tep07>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tep08>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tep09>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tep10>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tep11>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tep12>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tep13>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tep14>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tep15>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tin01>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tin02>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tin03>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tin04>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tin05>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tjs01>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tjs02>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tjs03>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tjs04>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tjs05>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tjs06>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tjs07>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tjs08>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tjs09>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tjs10>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tjs11>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tla01>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tli01>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tli02>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tli03>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tli04>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tli05>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tm001>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tm002>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tm003>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tm004>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tm005>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tm006>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tm007>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tm008>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tm009>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tm010>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tm011>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tm012>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tm013>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tm014>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tm015>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tm016>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tm017>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tm018>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tm019>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tm020>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tm021>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tm022>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tn001>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tn002>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tn003>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tn004>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tn005>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tn006>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tn007>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tn008>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tn009>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tn010>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tn011>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tp001>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tp002>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tp003>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tp004>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tp005>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tp006>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tp007>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tp008>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tpi01>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tpi02>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tpi03>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tpi04>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tpi05>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tpi06>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tpr01>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tpr02>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tpr03>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tpr04>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tpr05>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tr001>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#tr002>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#ts001>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#ts002>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#ttn01>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#ttn02>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://github.com/filip26>;
+  earl:subject <https://github.com/filip26/jsonp-ld>;
+  earl:test <https://w3c.github.io/json-ld-api/tests/compact-manifest.jsonld#ttn03>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-05-30T19:06:37Z"^^xsd:dateTime
+  ];
+  earl:mode earl:automatic;
+] .


### PR DESCRIPTION
Please add the test report. JSONP-LD is an open source implementation in Java aiming to fully support the specification. Version 0.2.2. supports expansion and compaction. Thank you.

https://github.com/filip26/jsonp-ld