### PR TITLE
Remove atrisk notes.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4778,14 +4778,6 @@
     <p class="changed">If the {{JsonLdOptions/rdfDirection}} option is not `null`, then special processing is used to
       convert from an `i18n-datatype` or `compound-literal` form.</p>
 
-    <p class="issue atrisk">The support for both `i18n-datatype` and `compound-literal`
-      algorithm steps are non-normative, and are AT RISK for JSON-LD 1.1.
-      They may be replaced with normative algorithm steps in a future version.
-      Either or both of these transformation methods may be removed prior to
-      JSON-LD 1.1 being finalized.
-      The JSON-LD Working Group solicits feedback from the community on the
-      usefulness of these transformations.</p>
-
     <p class="changed">Implementations MUST generate only <dfn>well-formed</dfn>
       <a>triples</a> and <a>graph names</a>:</p>
     <ul>
@@ -5156,14 +5148,6 @@
 
       <p class="changed">If the {{JsonLdOptions/rdfDirection}} option is not `null`, then special processing is used to
         convert from an `i18n-datatype` or `compound-literal` form.</p>
-
-      <p class="issue atrisk">The support for both `i18n-datatype` and `compound-literal`
-        algorithm steps are non-normative, and are AT RISK for JSON-LD 1.1.
-        They may be replaced with normative algorithm steps in a future version.
-        Either or both of these transformation methods may be removed prior to
-        JSON-LD 1.1 being finalized.
-        The JSON-LD Working Group solicits feedback from the community on the
-        usefulness of these transformations.</p>
     </section>
 
     <section>


### PR DESCRIPTION
For w3c/json-ld-wg#150.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/493.html" title="Last updated on Jun 8, 2020, 12:43 AM UTC (f64d727)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/493/691ca67...f64d727.html" title="Last updated on Jun 8, 2020, 12:43 AM UTC (f64d727)">Diff</a>