### PR TITLE
Make a global JsonLd interface.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5662,7 +5662,7 @@
       as long as they generally use the same methods, arguments, and options
       and return the same results.</span></p>
 
-  <p class="note">Interfaces are marked `[Exposed=Endpoint]`,
+  <p class="note">Interfaces are marked `[Exposed=JsonLd]`,
     which creates a global interface.
     The use of WebIDL in JSON-LD, while appropriate for use within browsers,
     is not limited to such use.</p>
@@ -5688,12 +5688,12 @@
 
     <pre class="idl">
       /*
-       * The Endpoint interface is created to expose the JsonLdProcessor interface.
+       * The JsonLd interface is created to expose the JsonLdProcessor interface.
        */
-      [Global=Endpoint, Exposed=Endpoint]
-      interface Endpoint {};
+      [Global=JsonLd, Exposed=JsonLd]
+      interface JsonLd {};
 
-      [Exposed=Endpoint]
+      [Exposed=JsonLd]
       interface JsonLdProcessor {
         constructor();
         static Promise&lt;JsonLdRecord> compact(
@@ -6092,7 +6092,7 @@
       which has a <a>default graph</a> accessible via the <a data-link-for="RdfDataset">defaultGraph</a> attribute.</p>
 
     <pre class="idl changed">
-      [Exposed=Endpoint]
+      [Exposed=JsonLd]
       interface RdfDataset {
         constructor();
         readonly attribute RdfGraph defaultGraph;
@@ -6136,7 +6136,7 @@
       which is composed of zero or more <a>RdfTriple</a> instances.</p>
 
     <pre class="idl changed">
-      [Exposed=Endpoint]
+      [Exposed=JsonLd]
       interface RdfGraph {
         constructor();
         void add(RdfTriple triple);
@@ -6165,7 +6165,7 @@
     <p>The <dfn>RdfTriple</dfn> interface describes an <a>triple</a>.</p>
 
     <pre class="idl changed">
-      [Exposed=Endpoint]
+      [Exposed=JsonLd]
       interface RdfTriple {
         constructor();
         readonly attribute USVString subject;
@@ -6193,7 +6193,7 @@
     <p>The <dfn>RdfLiteral</dfn> interface describes an <a>RDF Literal</a>.</p>
 
     <pre class="idl changed">
-      [Exposed=Endpoint]
+      [Exposed=JsonLd]
       interface RdfLiteral {
         constructor();
         readonly attribute USVString value;
@@ -6447,7 +6447,7 @@
         to return information about a remote document or context.</p>
 
       <pre class="idl">
-        [Exposed=Endpoint]
+        [Exposed=JsonLd]
         interface RemoteDocument {
           constructor();
           readonly attribute USVString contentType;
@@ -7089,7 +7089,7 @@
       to update <var>cl reference</var> and not <var>node</var>.</li>
     <li>Added <a href="#api-keywords" class="sectionRef"></a> to describe
       the `preserve` keyword, which is only used for framing.</li>
-    <li>Changed `[Exposed=(Window,Worker)]` to `[Exposed=Endpoint]`,
+    <li>Changed `[Exposed=(Window,Worker)]` to `[Exposed=JsonLd]`,
       which is declared as a global interface in order to expose the {{JsonLdProcessor}} interface
       for non-browser usage to address review suggestions.</li>
   </ul>

--- a/index.html
+++ b/index.html
@@ -5662,9 +5662,8 @@
       as long as they generally use the same methods, arguments, and options
       and return the same results.</span></p>
 
-  <p class="note">Interfaces are not marked with the `[Exposed]`
-    <a data-cite="WEBIDL#dfn-extended-attribute">extended attribute</a>,
-    as this is currently quite browser specific.
+  <p class="note">Interfaces are marked `[Exposed=JsonLdProcessor]`,
+    which creates a global interface.
     The use of WebIDL in JSON-LD, while appropriate for use within browsers,
     is not limited to such use.</p>
 
@@ -5688,8 +5687,8 @@
       in this document mention this directly.</p>
 
     <pre class="idl">
+      [Global=JsonLdProcessor, Exposed=JsonLdProcessor]
       interface JsonLdProcessor {
-        constructor();
         static Promise&lt;JsonLdRecord> compact(
           JsonLdInput input,
           optional JsonLdContext context = null,
@@ -6086,6 +6085,7 @@
       which has a <a>default graph</a> accessible via the <a data-link-for="RdfDataset">defaultGraph</a> attribute.</p>
 
     <pre class="idl changed">
+      [Exposed=JsonLdProcessor]
       interface RdfDataset {
         constructor();
         readonly attribute RdfGraph defaultGraph;
@@ -6129,6 +6129,7 @@
       which is composed of zero or more <a>RdfTriple</a> instances.</p>
 
     <pre class="idl changed">
+      [Exposed=JsonLdProcessor]
       interface RdfGraph {
         constructor();
         void add(RdfTriple triple);
@@ -6157,6 +6158,7 @@
     <p>The <dfn>RdfTriple</dfn> interface describes an <a>triple</a>.</p>
 
     <pre class="idl changed">
+      [Exposed=JsonLdProcessor]
       interface RdfTriple {
         constructor();
         readonly attribute USVString subject;
@@ -6184,6 +6186,7 @@
     <p>The <dfn>RdfLiteral</dfn> interface describes an <a>RDF Literal</a>.</p>
 
     <pre class="idl changed">
+      [Exposed=JsonLdProcessor]
       interface RdfLiteral {
         constructor();
         readonly attribute USVString value;
@@ -6437,6 +6440,7 @@
         to return information about a remote document or context.</p>
 
       <pre class="idl">
+        [Exposed=JsonLdProcessor]
         interface RemoteDocument {
           constructor();
           readonly attribute USVString contentType;

--- a/index.html
+++ b/index.html
@@ -5662,7 +5662,7 @@
       as long as they generally use the same methods, arguments, and options
       and return the same results.</span></p>
 
-  <p class="note">Interfaces are marked `[Exposed=JsonLdProcessor]`,
+  <p class="note">Interfaces are marked `[Exposed=Endpoint]`,
     which creates a global interface.
     The use of WebIDL in JSON-LD, while appropriate for use within browsers,
     is not limited to such use.</p>
@@ -5687,8 +5687,15 @@
       in this document mention this directly.</p>
 
     <pre class="idl">
-      [Global=JsonLdProcessor, Exposed=JsonLdProcessor]
+      /*
+       * The Endpoint interface is created to expose the JsonLdProcessor interface.
+       */
+      [Global=Endpoint, Exposed=Endpoint]
+      interface Endpoint {};
+
+      [Exposed=Endpoint]
       interface JsonLdProcessor {
+        constructor();
         static Promise&lt;JsonLdRecord> compact(
           JsonLdInput input,
           optional JsonLdContext context = null,
@@ -6085,7 +6092,7 @@
       which has a <a>default graph</a> accessible via the <a data-link-for="RdfDataset">defaultGraph</a> attribute.</p>
 
     <pre class="idl changed">
-      [Exposed=JsonLdProcessor]
+      [Exposed=Endpoint]
       interface RdfDataset {
         constructor();
         readonly attribute RdfGraph defaultGraph;
@@ -6129,7 +6136,7 @@
       which is composed of zero or more <a>RdfTriple</a> instances.</p>
 
     <pre class="idl changed">
-      [Exposed=JsonLdProcessor]
+      [Exposed=Endpoint]
       interface RdfGraph {
         constructor();
         void add(RdfTriple triple);
@@ -6158,7 +6165,7 @@
     <p>The <dfn>RdfTriple</dfn> interface describes an <a>triple</a>.</p>
 
     <pre class="idl changed">
-      [Exposed=JsonLdProcessor]
+      [Exposed=Endpoint]
       interface RdfTriple {
         constructor();
         readonly attribute USVString subject;
@@ -6186,7 +6193,7 @@
     <p>The <dfn>RdfLiteral</dfn> interface describes an <a>RDF Literal</a>.</p>
 
     <pre class="idl changed">
-      [Exposed=JsonLdProcessor]
+      [Exposed=Endpoint]
       interface RdfLiteral {
         constructor();
         readonly attribute USVString value;
@@ -6440,7 +6447,7 @@
         to return information about a remote document or context.</p>
 
       <pre class="idl">
-        [Exposed=JsonLdProcessor]
+        [Exposed=Endpoint]
         interface RemoteDocument {
           constructor();
           readonly attribute USVString contentType;
@@ -7082,9 +7089,9 @@
       to update <var>cl reference</var> and not <var>node</var>.</li>
     <li>Added <a href="#api-keywords" class="sectionRef"></a> to describe
       the `preserve` keyword, which is only used for framing.</li>
-    <li>Removed the `[Exposed=(Window,Worker)]`
-      <a data-cite="WEBIDL#dfn-extended-attribute">extended attribute</a>
-      from <a href="#the-application-programming-interface" class="sectionRef"></a> to address review suggestions.</li>
+    <li>Changed `[Exposed=(Window,Worker)]` to `[Exposed=Endpoint]`,
+      which is declared as a global interface in order to expose the {{JsonLdProcessor}} interface
+      for non-browser usage to address review suggestions.</li>
   </ul>
 </section>
 <section id="ack"


### PR DESCRIPTION
This silences ReSpec, and is probably better than just removing [Exposed] altogether.

Thanks to @hober for the advice.

If acceptable, a similar change will be required for JSON-LD Framing.

CC/ @swickr @iherman


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/500.html" title="Last updated on Jun 26, 2020, 6:57 PM UTC (95a5df8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/500/e4e8dc5...95a5df8.html" title="Last updated on Jun 26, 2020, 6:57 PM UTC (95a5df8)">Diff</a>