### PR TITLE
Change JCS bibref to RFC8785, as it's now published.

### DIFF
--- a/common/jsonld.js
+++ b/common/jsonld.js
@@ -59,11 +59,11 @@ const jsonld = {
       status: 'unofficial',
       date: '29 May 2015'
     },
-    "JCS": {
+    "RFC8785": {
       title: "JSON Canonicalization Scheme (JCS)",
-      href: 'https://tools.ietf.org/html/draft-rundgren-json-canonicalization-scheme-17',
+      href: 'https://www.rfc-editor.org/rfc/rfc8785',
       authors: ['A. Rundgren', 'B. Jordan', 'S. Erdtman'],
-      publisher: 'Network Working Group',
+      publisher: 'Informational',
       status: 'Internet-Draft',
       date: '20 January 2020'
     },

--- a/common/jsonld.js
+++ b/common/jsonld.js
@@ -63,9 +63,9 @@ const jsonld = {
       title: "JSON Canonicalization Scheme (JCS)",
       href: 'https://www.rfc-editor.org/rfc/rfc8785',
       authors: ['A. Rundgren', 'B. Jordan', 'S. Erdtman'],
-      publisher: 'Informational',
-      status: 'Internet-Draft',
-      date: '20 January 2020'
+      publisher: 'Network Working Group',
+      status: 'Informational',
+      date: 'June 2020'
     },
     // These necessary as specref uses the wrong URLs
     "RFC7231": {

--- a/index.html
+++ b/index.html
@@ -4973,9 +4973,8 @@
           convert <var>value</var> to the <a>canonical lexical form</a>
           using the result of transforming the <a>internal representation</a> of <var>value</var>
           to JSON and set <var>datatype</var> to <code>rdf:JSON</code>.
-          <div class="issue">The JSON Canonicalization Scheme [[?JCS]]
-            is an emerging standard for JSON canonicalization
-            not yet ready to be referenced.
+          <div class="issue">The JSON Canonicalization Scheme (JCS) [[?RFC8785]]
+            is a standard for JSON canonicalization.
             When a JSON canonicalization standard becomes available,
             this specification will likely be updated to require such a canonical representation.
             Users are cautioned from depending on the

--- a/index.html
+++ b/index.html
@@ -4975,8 +4975,7 @@
           to JSON and set <var>datatype</var> to <code>rdf:JSON</code>.
           <div class="issue">The JSON Canonicalization Scheme (JCS) [[?RFC8785]]
             is a standard for JSON canonicalization.
-            When a JSON canonicalization standard becomes available,
-            this specification will likely be updated to require such a canonical representation.
+            This specification will likely be updated to require such a canonical representation.
             Users are cautioned from depending on the
             <a>JSON literal</a> lexical representation as an <a>RDF literal</a>,
             as the specifics of serialization may change in a future revision of this document.</div></li>
@@ -7091,6 +7090,7 @@
     <li>Changed `[Exposed=(Window,Worker)]` to `[Exposed=JsonLd]`,
       which is declared as a global interface in order to expose the {{JsonLdProcessor}} interface
       for non-browser usage to address review suggestions.</li>
+    <li>Update bibliographic reference for JCS to [[RFC8785]].</li>
   </ul>
 </section>
 <section id="ack"


### PR DESCRIPTION
Note that we discuss changing our canonicalization requirements to JCS when it becomes available, which it is now. Perhaps something to take up post-publication.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/501.html" title="Last updated on Jun 30, 2020, 10:25 PM UTC (c22aaa5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/501/a150a99...c22aaa5.html" title="Last updated on Jun 30, 2020, 10:25 PM UTC (c22aaa5)">Diff</a>