### PR TITLE
Updates to accommodate ReSpec changes and subsequent issues found post-REC.

### DIFF
--- a/common/algorithm-terms.html
+++ b/common/algorithm-terms.html
@@ -9,7 +9,7 @@
     which is used for finding coercion mappings in the <a>active context</a>.</dd>
   <dt><dfn data-cite="JSON-LD11-API#dfn-active-subject">active subject</dfn></dt><dd>
     The currently active subject that the processor should use when processing.</dd>
-  <dt class="changed"><dfn data-cite="JSON-LD11-API#add-value">add value</dfn></dt>
+  <dt class="changed"><dfn data-cite="JSON-LD11-API#dfn-add-value">add value</dfn></dt>
   <dd class="algorithm changed">
     Used as a macro within various algorithms as a way to add a <var>value</var>
     to an <a>entry</a> in a <a>map</a> (<var>object</var>) using a specified <var>key</var>.
@@ -38,7 +38,7 @@
       </li>
     </ol>
   </dd>
-  <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-expicit-inclusion-flag">explicit inclusion flag</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-explicit-inclusion-flag">explicit inclusion flag</dfn></dt><dd>
     A flag specifying that for <a>properties</a> to be included in the output,
     they must be explicitly declared in the matching <a>frame</a>.</dd>
   <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-framing-state">framing state</dfn></dt><dd>
@@ -78,7 +78,7 @@
     the <var>document relative</var> flag defaults to `false`,
     and the <var>vocab</var> flag defaults to `true`.
     <ol>
-      <li>Return the result of using the <a href="#iri-expansion">IRI Expansion algorithm</a>,
+      <li>Return the result of using the <a data-cite="JSON-LD11-API#iri-expansion">IRI Expansion algorithm</a>,
         passing <var>active context</var>,
         <var>value</var>,
         <var>local context</var> (if supplied),

--- a/common/terms.html
+++ b/common/terms.html
@@ -188,7 +188,7 @@
     An embedded <a>context</a> is a context which appears
     as the <code>@context</code> <a>entry</a> of one of the following:
     a <a>node object</a>, a <a>value object</a>, a <a>graph object</a>, a <a>list object</a>,
-    a <a>set object</a>, the value of a <a>nested properties</a>,
+    a <a>set object</a>, the value of a <a>nested property</a>,
     or the value of an <a>expanded term definition</a>.
     Its value may be a <a>map</a> for a <a data-cite="JSON-LD11#dfn-context-definition">context definition</a>,
     as an <a>IRI</a>, or as an <a>array</a> combining either of the above.
@@ -230,7 +230,7 @@
     Note that <a>node objects</a> may have a <code>@graph</code> <a>entry</a>,
     but are not considered <a>graph objects</a> if they include any other <a>entries</a>.
     A top-level object consisting of <code>@graph</code> is also not a <a>graph object</a>.
-    Note that a <a>node object</a> may also represent a <a>named graph</a> it it includes other properties.
+    Note that a <a>node object</a> may also represent a <a>named graph</a> if it includes other properties.
     See the <a data-cite="JSON-LD11#graph-objects">Graph Objects</a> section of JSON-LD 1.1 for a normative description.
   </dd>
   <dt class="changed"><dfn data-cite="JSON-LD11#dfn-id-map">id map</dfn></dt><dd class="changed">
@@ -302,7 +302,7 @@
     and normatively specified in the <a data-cite="JSON-LD11#keywords">Keywords</a> section of JSON-LD 1.1,
   </dd>
   <dt><dfn data-cite="JSON-LD11#dfn-language-map">language map</dfn></dt><dd>
-    An <a>language map</a> is a <a>map</a> value of a <a>term</a>
+    A <a>language map</a> is a <a>map</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@language</code>,
     whose keys must be <a>strings</a> representing [[BCP47]] language codes
     and the values must be any of the following types:

--- a/common/typographical-conventions.html
+++ b/common/typographical-conventions.html
@@ -15,7 +15,7 @@
     A reference to a definition <em>in this document</em>
     is underlined and is also an active link to the definition itself. </dd>
   <dt><a data-lt="definition"><code>markup definition reference</code></a></dt><dd>
-    A references to a definition <em>in this document</em>,
+    References to a definition <em>in this document</em>,
     when the reference itself is also a markup, is underlined,
     red-orange monospace font, and is also an active link to the definition itself.</dd>
   <dt><a class="externalDFN">external definition reference</a></dt><dd>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <title>JSON-LD 1.1 Processing Algorithms and API</title>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
-<script type="text/javascript" src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+<script type="text/javascript" src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 <script type="text/javascript" src="common/common.js" class="remove" defer></script>
 <script type="text/javascript" src="common/jsonld.js" class="remove"></script>
 <script type="text/javascript" class="remove">
@@ -117,22 +117,9 @@
           note:       "v1.0" }
       ],
 
-      // name of the WG
-      wg:                     "JSON-LD Working Group",
-
-      // URI of the public WG page
-      wgURI:                  "https://www.w3.org/2018/json-ld-wg/",
-
-      // name (with the @w3c.org) of the public mailing to which comments are due
+      group: "wg/json-ld",
       wgPublicList:           "public-json-ld-wg",
 
-      // URI of the patent status for this WG, for Rec-track documents
-      // !!!! IMPORTANT !!!!
-      // This is important for Rec-track documents, do not copy a patent URI from a random
-      // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
-      // Team Contact.
-      wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/107714/status",
-      processVersion: 2018,
       maxTocLevel:            2,
       alternateFormats: [ {uri: "json-ld11-api.epub", label: "EPUB"} ]
   };
@@ -417,18 +404,14 @@
     <p>This document uses the following terms as defined in external specifications
       and defines terms specific to JSON-LD.</p>
 
-    <div data-include="common/terms.html"
-         data-oninclude="restrictReferences">
-    </div>
+    <div data-include="common/terms.html"></div>
 
   <section>
     <h4>Algorithm Terms</h4>
 
     <p>The Following terms are used within specific algorithms.</p>
 
-    <div data-include="common/algorithm-terms.html"
-         data-oninclude="restrictReferences">
-    </div>
+    <div data-include="common/algorithm-terms.html"></div>
   </section>
   <section id="api-keywords">
     <h2>Syntax Tokens and Keywords</h2>
@@ -553,7 +536,7 @@
         <button data-selects="expanded">Expanded (Result)</button>
         <button data-selects="statements">Statements</button>
         <button data-selects="turtle">Turtle</button>
-        <a class="playground" target="_blank"></a>
+        <a class="playground" target="_blank" href="#">PG</a>
       </div>
       <pre class="compacted selected" data-transform="updateExample">
       <!--
@@ -619,7 +602,7 @@
         <button data-selects="expanded">Expanded (Result)</button>
         <button data-selects="statements">Statements</button>
         <button data-selects="turtle">Turtle</button>
-        <a class="playground" target="_blank"></a>
+        <a class="playground" target="_blank" href="#">PG</a>
       </div>
       <pre class="compacted input selected nohighlight" data-transform="updateExample">
       <!--
@@ -793,7 +776,8 @@
            data-result-for="#sample-document"
            data-context="#sample-document-context"
            data-compact
-           target="_blank"></a>
+           target="_blank"
+           href="#">PG</a>
       </div>
       <pre class="result compacted selected nohighlight" data-transform="updateExample"
            data-result-for="Expanded sample document"
@@ -875,7 +859,8 @@
         <a class="playground"
            data-result-for="#json-ld-document-in-compact-form"
            data-flatten
-           target="_blank"></a>
+           target="_blank"
+           href="#">PG</a>
       </div>
       <pre class="original result selected nohighlight" data-transform="updateExample"
            data-result-for="JSON-LD document in compact form"
@@ -920,7 +905,8 @@
            data-result-for="#json-ld-document-in-compact-form"
            data-context="#json-ld-document-in-compact-form"
            data-flatten
-           target="_blank"></a>
+           target="_blank"
+            href="#">PG</a>
       </div>
       <pre class="result selected nohighlight" data-transform="updateExample"
            data-result-for="JSON-LD document in compact form"
@@ -6095,7 +6081,7 @@
       interface RdfDataset {
         constructor();
         readonly attribute RdfGraph defaultGraph;
-        void add(USVString graphName, RdfGraph graph);
+        undefined add(USVString graphName, RdfGraph graph);
         iterable&lt;USVString?, RdfGraph>;
       };
     </pre>
@@ -6138,7 +6124,7 @@
       [Exposed=JsonLd]
       interface RdfGraph {
         constructor();
-        void add(RdfTriple triple);
+        undefined add(RdfTriple triple);
         iterable&lt;RdfTriple>;
       };
     </pre>
@@ -7098,6 +7084,13 @@
     <li>Changed `[Exposed=(Window,Worker)]` to `[Exposed=JsonLd]`,
       which is declared as a global interface in order to expose the {{JsonLdProcessor}} interface
       for non-browser usage to address review suggestions.</li>
+  </ul>
+</section>
+<section class="appendix informative" id="changes-from-rec1">
+  <h2>Changes since Recommendation of 16 July 2020</h2>
+  <ul>
+    <li>Regenerated definition list, which does not attempt to filter out unused definitions.</li>
+    <li>Changed obsolete use of `void` in WebIDL to `undefined`.</li>
   </ul>
 </section>
 <section id="ack"


### PR DESCRIPTION
* Use respec-w3c instead of respec-w3c-comman.
* Update ReSpec configuration to use group: "wg/json-ld" instead of separate wg* attributes.
* Update playground links to not be flagged by ReSpec.
* Other changes to common files.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/515.html" title="Last updated on Nov 13, 2020, 10:45 PM UTC (353feda)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/515/bd409b8...353feda.html" title="Last updated on Nov 13, 2020, 10:45 PM UTC (353feda)">Diff</a>