### PR TITLE
Fix compacting property-based indexes.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3861,8 +3861,8 @@
                     <li id="alg-compact-12_8_9_6" class="changed">Otherwise, if <var>container</var> includes <code>@index</code>
                       and <var>index key</var> is not <code>@index</code>:
                       <ol>
-                        <li>Reinitialize <var>container key</var> by <a>IRI compacting</a>
-                          <var>index key</var>.</li>
+                        <li id="alg-compact-12_8_9_6_1">Reinitialize <var>container key</var> by <a>IRI compacting</a>
+                          <var>index key</var> after first <a>IRI expanding</a> it.</li>
                         <li>Set <var>map key</var> to the first value of <var>container key</var> in <var>compacted item</var>, if any.</li>
                         <li id="alg-compact-12_8_9_6_3">If there are remaining values in <var>compacted item</var>
                           for <var>container key</var>, use <a>add value</a> to
@@ -7105,6 +7105,10 @@
     <li>Changed obsolete use of `void` in WebIDL to `undefined`.</li>
     <li>Added some clarifications to the algorithm of <a href="#node-map-generation"></a>.</li>
     <li>Added some clarifications to the algorithm of <a href="#iri-compaction"></a>.</li>
+    <li>Added additional language to the
+      <a href="#compaction-algorithm">Compaction Algorithm</a>
+      step <a href="#alg-compact-12_8_9_6_1 ">12.8.9.6.1</a> to first expand
+      <var>container key</var> before compacting it.</li>
   </ul>
 </section>
 <section id="ack"

--- a/index.html
+++ b/index.html
@@ -1281,7 +1281,7 @@
                   to the {{RemoteDocument}} obtained
                   by dereferencing <var>context</var> using
                   the <a>LoadDocumentCallback</a>, passing <var>context</var>
-                  for <a data-link-for="LoadDocumentCallback">url</a>,
+                  for {{LoadDocumentCallback/url}},
                   and <code>http://www.w3.org/ns/json-ld#context</code> for <a data-link-for="LoadDocumentOptions">profile</a>
                   and for <a data-link-for="LoadDocumentOptions">requestProfile</a>.
                   <ol>
@@ -1350,7 +1350,7 @@
                   <var>base URL</var>.</li>
                 <li>Dereference <var>import</var> using
                   the <a>LoadDocumentCallback</a>, passing <var>import</var>
-                  for <a data-link-for="LoadDocumentCallback">url</a>,
+                  for {{LoadDocumentCallback/url}},
                   and <code>http://www.w3.org/ns/json-ld#context</code> for <a data-link-for="LoadDocumentOptions">profile</a>
                   and for <a data-link-for="LoadDocumentOptions">requestProfile</a>.</li>
                 <li>If <var>import</var> cannot be dereferenced,
@@ -5737,7 +5737,7 @@
           <li>Otherwise, if the provided <a data-lt="jsonldprocessor-compact-input">input</a>
             is a <a>string</a> representing the <a>IRI</a> of a remote document, await and dereference it as <var>remote document</var>
             using <a>LoadDocumentCallback</a>, passing <a data-lt="jsonldprocessor-compact-input">input</a>
-            for <a data-link-for="LoadDocumentCallback">url</a>,
+            for {{LoadDocumentCallback/url}},
             and the {{JsonLdOptions/extractAllScripts}} option from <a data-lt="jsonldprocessor-compact-options">options</a>
             for <a data-link-for="LoadDocumentOptions">extractAllScripts</a>.</li>
           <li>Set <var>expanded input</var> to the result of
@@ -5822,7 +5822,7 @@
           <li>Otherwise, if the provided <a data-lt="jsonldprocessor-expand-input">input</a>
             is a <a>string</a> representing the <a>IRI</a> of a remote document, await and dereference it as <var>remote document</var>
             using <a>LoadDocumentCallback</a>, passing <a data-lt="jsonldprocessor-expand-input">input</a>
-            for <a data-link-for="LoadDocumentCallback">url</a>,
+            for {{LoadDocumentCallback/url}},
             the {{JsonLdOptions/extractAllScripts}} option from <a data-lt="jsonldprocessor-expand-options">options</a>
             for <a data-link-for="LoadDocumentOptions">extractAllScripts</a>.</li>
           <li class="changed">If {{RemoteDocument/document}}
@@ -5903,7 +5903,7 @@
           <li>Otherwise, if the provided <a data-lt="jsonldprocessor-flatten-input">input</a>
             is a <a>string</a> representing the <a>IRI</a> of a remote document, await and dereference it as <var>remote document</var>
             using <a>LoadDocumentCallback</a>, passing <a data-lt="jsonldprocessor-flatten-input">input</a>
-            for <a data-link-for="LoadDocumentCallback">url</a>,
+            for {{LoadDocumentCallback/url}},
             and the {{JsonLdOptions/extractAllScripts}} option from <a data-lt="jsonldprocessor-flatten-options">options</a>
             for <a data-link-for="LoadDocumentOptions">extractAllScripts</a>.
           </li>
@@ -6355,8 +6355,8 @@
         <li>Create a new {{Promise}} <var>promise</var> and return it.
           The following steps are then deferred.</li>
         <li id="LoadDocumentCallback-step-2">Set <var>document</var> to the body retrieved from
-          the resource identified by <a data-link-for="LoadDocumentCallback">url</a>,
-          or by otherwise locating a resource associated with <a data-link-for="LoadDocumentCallback">url</a>.
+          the resource identified by {{LoadDocumentCallback/url}},
+          or by otherwise locating a resource associated with {{LoadDocumentCallback/url}}.
           When requesting remote documents the request MUST prefer <a>Content-Type</a> <code>application/ld+json</code>
           followed by <code>application/json</code>.
 
@@ -6502,10 +6502,10 @@
         or <code>application/xhtml+xml</code>:</p>
       <ol>
         <li>Set <var>documentUrl</var> to the <a data-cite="HTML/urls-and-fetching.html#document-base-url">Document Base URL</a>
-          of <a data-link-for="LoadDocumentCallback">url</a>, as defined in [[HTML]],
+          of {{LoadDocumentCallback/url}}, as defined in [[HTML]],
           using the existing <var>documentUrl</var> as the document's URL.
         </li>
-        <li>If the <a data-link-for="LoadDocumentCallback">url</a> parameter
+        <li>If the {{LoadDocumentCallback/url}} parameter
           contains a <a data-cite="RFC3986#section-3.5">fragment identifier</a>,
           set <var>source</var> to the <a data-cite="DOM#dom-node-textcontent">textContent</a>
           of the <a data-cite="HTML/scripting.html#the-script-element">script element</a> in <var>document</var>

--- a/index.html
+++ b/index.html
@@ -533,7 +533,7 @@
         <button data-selects="expanded">Expanded (Result)</button>
         <button data-selects="statements">Statements</button>
         <button data-selects="turtle">Turtle</button>
-        <a class="playground" target="_blank" href="#">PG</a>
+        <a class="playground" target="_blank" href="">PG</a>
       </div>
       <pre class="compacted selected" data-transform="updateExample">
       <!--
@@ -599,7 +599,7 @@
         <button data-selects="expanded">Expanded (Result)</button>
         <button data-selects="statements">Statements</button>
         <button data-selects="turtle">Turtle</button>
-        <a class="playground" target="_blank" href="#">PG</a>
+        <a class="playground" target="_blank" href="">PG</a>
       </div>
       <pre class="compacted input selected nohighlight" data-transform="updateExample">
       <!--
@@ -774,7 +774,7 @@
            data-context="#sample-document-context"
            data-compact
            target="_blank"
-           href="#">PG</a>
+           href="">PG</a>
       </div>
       <pre class="result compacted selected nohighlight" data-transform="updateExample"
            data-result-for="Expanded sample document"
@@ -857,7 +857,7 @@
            data-result-for="#json-ld-document-in-compact-form"
            data-flatten
            target="_blank"
-           href="#">PG</a>
+           href="">PG</a>
       </div>
       <pre class="original result selected nohighlight" data-transform="updateExample"
            data-result-for="JSON-LD document in compact form"
@@ -903,7 +903,7 @@
            data-context="#json-ld-document-in-compact-form"
            data-flatten
            target="_blank"
-            href="#">PG</a>
+            href="">PG</a>
       </div>
       <pre class="result selected nohighlight" data-transform="updateExample"
            data-result-for="JSON-LD document in compact form"

--- a/index.html
+++ b/index.html
@@ -7107,7 +7107,7 @@
     <li>Added some clarifications to the algorithm of <a href="#iri-compaction"></a>.</li>
     <li>Added additional language to the
       <a href="#compaction-algorithm">Compaction Algorithm</a>
-      step <a href="#alg-compact-12_8_9_6_1 ">12.8.9.6.1</a> to first expand
+      step <a href="#alg-compact-12_8_9_6_1">12.8.9.6.1</a> to first expand
       <var>container key</var> before compacting it.</li>
   </ul>
 </section>

--- a/tests/compact-manifest.html
+++ b/tests/compact-manifest.html
@@ -3162,6 +3162,56 @@ Test t0111 Keyword-like relative IRIs
 </dd>
 </dl>
 </dd>
+<dt id='t0113'>
+Test t0113 Compact property index using Absolute IRI index
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#t0113</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:CompactTest</dd>
+<dt>Purpose</dt>
+<dd>With @container: @index and @index an absolute IRI, ensure round-tripping of compacted representation</dd>
+<dt>input</dt>
+<dd>
+<a href='compact/0113-in.jsonld'>compact/0113-in.jsonld</a>
+</dd>
+<dt>context</dt>
+<dd>
+<a href='compact/0113-context.jsonld'>compact/0113-context.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='compact/0113-out.jsonld'>compact/0113-out.jsonld</a>
+</dd>
+</dl>
+</dd>
+<dt id='t0112'>
+Test t0112 Compact property index using Compact IRI index
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#t0112</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:CompactTest</dd>
+<dt>Purpose</dt>
+<dd>With @container: @index and @index a compact IRI, ensure round-tripping of compacted representation</dd>
+<dt>input</dt>
+<dd>
+<a href='compact/0112-in.jsonld'>compact/0112-in.jsonld</a>
+</dd>
+<dt>context</dt>
+<dd>
+<a href='compact/0112-context.jsonld'>compact/0112-context.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='compact/0112-out.jsonld'>compact/0112-out.jsonld</a>
+</dd>
+</dl>
+</dd>
 <dt id='tc001'>
 Test tc001 adding new term
 </dt>

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -942,6 +942,22 @@
       "expect": "compact/0111-out.jsonld",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#t0113",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Compact property index using Absolute IRI index",
+      "purpose": "With @container: @index and @index an absolute IRI, ensure round-tripping of compacted representation",
+      "input": "compact/0113-in.jsonld",
+      "context": "compact/0113-context.jsonld",
+      "expect": "compact/0113-out.jsonld"
+    }, {
+      "@id": "#t0112",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Compact property index using Compact IRI index",
+      "purpose": "With @container: @index and @index a compact IRI, ensure round-tripping of compacted representation",
+      "input": "compact/0112-in.jsonld",
+      "context": "compact/0112-context.jsonld",
+      "expect": "compact/0112-out.jsonld"
+    }, {
       "@id": "#tc001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "adding new term",

--- a/tests/compact/0112-context.jsonld
+++ b/tests/compact/0112-context.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "ex": "http://example.org/ns/",
+    "prop": {
+      "@id": "ex:prop",
+      "@container": "@index",
+      "@index": "ex:name"
+    }
+  }
+}

--- a/tests/compact/0112-in.jsonld
+++ b/tests/compact/0112-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "http://example.org/ns/prop": [{
+    "@id": "http://example.org/ns/bar",
+    "http://example.org/ns/name": "bar"
+  }, {
+      "@id": "http://example.org/ns/foo",
+    "http://example.org/ns/name": "foo"
+  }]
+}

--- a/tests/compact/0112-out.jsonld
+++ b/tests/compact/0112-out.jsonld
@@ -1,0 +1,14 @@
+{
+  "@context": {
+    "ex": "http://example.org/ns/",
+    "prop": {
+      "@id": "ex:prop",
+      "@container": "@index",
+      "@index": "ex:name"
+    }
+  },
+  "prop": {
+    "foo": { "@id": "ex:foo"},
+    "bar": { "@id": "ex:bar"}
+  }
+}

--- a/tests/compact/0113-context.jsonld
+++ b/tests/compact/0113-context.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "ex": "http://example.org/ns/",
+    "prop": {
+      "@id": "ex:prop",
+      "@container": "@index",
+      "@index": "http://example.org/ns/name"
+    }
+  }
+}

--- a/tests/compact/0113-in.jsonld
+++ b/tests/compact/0113-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "http://example.org/ns/prop": [{
+    "@id": "http://example.org/ns/bar",
+    "http://example.org/ns/name": "bar"
+  }, {
+      "@id": "http://example.org/ns/foo",
+    "http://example.org/ns/name": "foo"
+  }]
+}

--- a/tests/compact/0113-out.jsonld
+++ b/tests/compact/0113-out.jsonld
@@ -1,0 +1,14 @@
+{
+  "@context": {
+    "ex": "http://example.org/ns/",
+    "prop": {
+      "@id": "ex:prop",
+      "@container": "@index",
+      "@index": "http://example.org/ns/name"
+    }
+  },
+  "prop": {
+    "foo": { "@id": "ex:foo"},
+    "bar": { "@id": "ex:bar"}
+  }
+}


### PR DESCRIPTION
The value of `@index` on a property map can be a Compact IRI in addition to an IRI. The Compaction Algorithm is updated to first expand this value before re-compacting it. Added additional language to the Compaction Algorithm step 12.8.9.6.1 to first expand container key before compacting it.

Also fixed an emergent issue with WebIDL reference for LoadDocumentCallback/url.

Adds two new compaction tests.

Fixes #514.

CC/ @vcharpenay


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/528.html" title="Last updated on May 15, 2021, 7:07 PM UTC (45036dc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/528/b7df683...45036dc.html" title="Last updated on May 15, 2021, 7:07 PM UTC (45036dc)">Diff</a>