### PR TITLE
Fix context processing for reverse terms

### DIFF
--- a/index.html
+++ b/index.html
@@ -1664,10 +1664,10 @@
             <li>Set the <a>term definition</a> of <var>term</var> in
               <var>active context</var> to <var>definition</var> and the
               value associated with <var>defined</var>'s <a>entry</a> <var>term</var> to
-              <code>true</code> and return.</li>
+              <code>true</code>.</li>
           </ol>
         </li>
-        <li>If <var>value</var> contains the <a>entry</a> <code>@id</code> and its value
+        <li>Otherwise if <var>value</var> contains the <a>entry</a> <code>@id</code> and its value
           does not equal <var>term</var>:
           <ol>
             <li id="ctd-id-null">If the <code>@id</code> <a>entry</a> of <var>value</var>

--- a/tests/compact-manifest.html
+++ b/tests/compact-manifest.html
@@ -3212,6 +3212,40 @@ Test t0113 Compact property index using Absolute IRI index
 </dd>
 </dl>
 </dd>
+<dt id='t0114'>
+Test t0114 Reverse term with property based indexed container
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#t0114</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:CompactTest</dd>
+<dt>Purpose</dt>
+<dd>With reverse term using @container: @index and @index set to a property, ensure round-tripping from expaned form</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/0131-out.jsonld'>expand/0131-out.jsonld</a>
+</dd>
+<dt>context</dt>
+<dd>
+<a href='expand/0131-in.jsonld'>expand/0131-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='expand/0131-in.jsonld'>expand/0131-in.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>base</dt>
+<dd>https://example.org/</dd>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
 <dt id='tc001'>
 Test tc001 adding new term
 </dt>

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -958,6 +958,15 @@
       "context": "compact/0113-context.jsonld",
       "expect": "compact/0113-out.jsonld"
     }, {
+      "@id": "#t0114",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Reverse term with property based indexed container",
+      "purpose": "With reverse term using @container: @index and @index set to a property, ensure round-tripping from expaned form",
+      "input": "expand/0131-out.jsonld",
+      "context": "expand/0131-in.jsonld",
+      "expect": "expand/0131-in.jsonld",
+      "option": {"base": "https://example.org/", "specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tc001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "adding new term",

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -3215,6 +3215,34 @@ Test t0130 Base without trailing slash, with path
 </dd>
 </dl>
 </dd>
+<dt id='t0131'>
+Test t0131 Reverse term with property based indexed container
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#t0131</dd>
+<dt>Type</dt>
+<dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+<dt>Purpose</dt>
+<dd>Expanding a reverse term using @container: @index and @index set to a property</dd>
+<dt>input</dt>
+<dd>
+<a href='expand/0131-in.jsonld'>expand/0131-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+<a href='expand/0131-out.jsonld'>expand/0131-out.jsonld</a>
+</dd>
+<dt>Options</dt>
+<dd>
+<dl class='options'>
+<dt>specVersion</dt>
+<dd>json-ld-1.1</dd>
+</dl>
+</dd>
+</dl>
+</dd>
 <dt id='tc001'>
 Test tc001 adding new term
 </dt>

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -979,6 +979,14 @@
       "input": "expand/0130-in.jsonld",
       "expect": "expand/0130-out.jsonld"
     }, {
+      "@id": "#t0131",
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
+      "name": "Reverse term with property based indexed container",
+      "purpose": "Expanding a reverse term using @container: @index and @index set to a property",
+      "input": "expand/0131-in.jsonld",
+      "expect": "expand/0131-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tc001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "adding new term",

--- a/tests/expand/0131-in.jsonld
+++ b/tests/expand/0131-in.jsonld
@@ -1,0 +1,16 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@base": "https://example.org/",
+    "@vocab": "https://example.net/ns#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "statement": {"@reverse": "rdf:subject", "@container": "@index", "@index": "predicate"},
+    "predicate": {"@id": "rdf:predicate", "@type": "@vocab"},
+    "term": {"@id": "rdf:object", "@type": "@vocab"},
+    "addedIn": {"@type": "@id"}
+  },
+  "@id": "item/1",
+  "statement": {
+    "rdf:type": {"term": "A", "addedIn": "v1"}
+  }
+}

--- a/tests/expand/0131-out.jsonld
+++ b/tests/expand/0131-out.jsonld
@@ -1,0 +1,26 @@
+[
+  {
+    "@id": "https://example.org/item/1",
+    "@reverse": {
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#subject": [
+        {
+          "https://example.net/ns#addedIn": [
+            {
+              "@id": "https://example.org/v1"
+            }
+          ],
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#object": [
+            {
+              "@id": "https://example.net/ns#A"
+            }
+          ],
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate": [
+            {
+              "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+            }
+          ]
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
This changes the algorithm for processing a reverse term so that it doesn't return early. Fixes #565.

Includes one test for expansion using a reverse term with `@container: @index` and `@index` set to a property, and a roundtripping compaction test based on the former.

(Note: the round-tripping compaction test _reuses_ the expand test data. That does not seem to be the practise; is there any rationale against that?)