### PR TITLE
Add similar id protected term redefinition test.

### DIFF
--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -2828,6 +2828,14 @@
       "input": "expand/pr40-in.jsonld",
       "expect": "expand/pr40-out.jsonld"
     }, {
+      "@id": "#tpr41",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Allows protected redefinition of equivalent id terms",
+      "purpose": "Check protected redefinition of equivalent id terms in different forms.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/pr41-in.jsonld",
+      "expect": "expand/pr41-out.jsonld"
+    }, {
       "@id": "#tso01",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "@import is invalid in 1.0.",

--- a/tests/expand/pr41-in.jsonld
+++ b/tests/expand/pr41-in.jsonld
@@ -1,0 +1,16 @@
+{
+  "@context": {
+    "@protected": true,
+    "foo": {
+      "@id": "ex:foo"
+    }
+  },
+  "@id": "ex:outer",
+  "foo": {
+    "@context": {
+      "@protected": true,
+      "foo": "ex:foo"
+    },
+    "@id": "ex:inner"
+  }
+}

--- a/tests/expand/pr41-out.jsonld
+++ b/tests/expand/pr41-out.jsonld
@@ -1,0 +1,6 @@
+[{
+  "@id": "ex:outer",
+  "ex:foo": [{
+    "@id": "ex:inner"
+  }]
+}]

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -3358,6 +3358,14 @@
       "input": "toRdf/pr40-in.jsonld",
       "expect": "toRdf/pr40-out.nq"
     }, {
+      "@id": "#tpr41",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Allows protected redefinition of equivalent id terms",
+      "purpose": "Check protected redefinition of equivalent id terms in different forms.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "toRdf/pr41-in.jsonld",
+      "expect": "toRdf/pr41-out.nq"
+    }, {
       "@id": "#trt01",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
       "name": "Representing numbers >= 1e21",

--- a/tests/toRdf/pr41-in.jsonld
+++ b/tests/toRdf/pr41-in.jsonld
@@ -1,0 +1,16 @@
+{
+  "@context": {
+    "@protected": true,
+    "foo": {
+      "@id": "ex:foo"
+    }
+  },
+  "@id": "ex:outer",
+  "foo": {
+    "@context": {
+      "@protected": true,
+      "foo": "ex:foo"
+    },
+    "@id": "ex:inner"
+  }
+}

--- a/tests/toRdf/pr41-out.nq
+++ b/tests/toRdf/pr41-out.nq
@@ -1,0 +1,1 @@
+<ex:outer> <ex:foo> <ex:inner> .


### PR DESCRIPTION
- Add test of redefining equivalent protected id terms in different forms:
  - `"foo": {"@id": "ex:foo"}`
  - `"foo": "ex:foo"`

This currently fails in jsonld.js and with the distiller.  Should implementations be considering these forms equivalent as far as protected redefinition checks are concerned?