### PR TITLE
remove surious paragraph in the description of frameExpansion

### DIFF
--- a/index.html
+++ b/index.html
@@ -6290,8 +6290,6 @@
         or document location when <a>compacting</a>.</dd>
       <dt class="changed"><dfn data-dfn-for="JsonLdOptions">frameExpansion</dfn></dt>
       <dd class="changed">Enables special frame processing rules for the <a href="#expansion-algorithm">Expansion Algorithm</a>.</dd>
-      <dd class="changed">Enables special rules for the <a href="#serialize-rdf-as-json-ld-algorithm">Serialize RDF as JSON-LD Algorithm</a>
-        to use JSON-LD native types as values, where possible.</dd>
       <dt class="changed"><dfn data-dfn-for="JsonLdOptions">useNativeTypes</dfn></dt>
       <dd class="changed">Causes the <a href="#serialize-rdf-as-json-ld-algorithm">Serialize RDF as JSON-LD Algorithm</a>
         to use native JSON values in <a>value objects</a> avoiding the need for an explicitly <code>@type</code>.</dd>

--- a/index.html
+++ b/index.html
@@ -7117,6 +7117,7 @@
       was to remove <q>and return</q> from the end of step 13, and revise step
       14 to begin with <q>Otherwise</q>.</li>
     <li>Use <a>code point order</a> as a better definition for the more vague "lexicographical order".</li>
+    <li>Remove spurious paragraph in the description of {{JsonLdOptions/frameExpansion}}</li>
   </ul>
 </section>
 <section id="ack"


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/578.html" title="Last updated on Sep 15, 2023, 8:01 PM UTC (dd2ca3c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/578/6bf9ef4...dd2ca3c.html" title="Last updated on Sep 15, 2023, 8:01 PM UTC (dd2ca3c)">Diff</a>