### PR TITLE
Add protected graph container null context test.

### DIFF
--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -9643,6 +9643,34 @@
             </dd>
           </dl>
         </dd>
+        <dt id='tpr43'>
+          Test tpr43 Clear protection in @graph @container with null context.
+        </dt>
+        <dd>
+          <dl class='entry'>
+            <dt>id</dt>
+            <dd>#tpr43</dd>
+            <dt>Type</dt>
+            <dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+            <dt>Purpose</dt>
+            <dd>Clear protection in @graph @container with null context.</dd>
+            <dt>input</dt>
+            <dd>
+              <a href='expand/pr43-in.jsonld'>expand/pr43-in.jsonld</a>
+            </dd>
+            <dt>expect</dt>
+            <dd>
+              <a href='expand/pr43-out.jsonld'>expand/pr43-out.jsonld</a>
+            </dd>
+            <dt>Options</dt>
+            <dd>
+              <dl class='options'>
+                <dt>specVersion</dt>
+                <dd>json-ld-1.1</dd>
+              </dl>
+            </dd>
+          </dl>
+        </dd>
         <dt id='tso01'>
           Test tso01 @import is invalid in 1.0.
         </dt>

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -2859,6 +2859,14 @@
       "input": "expand/pr42-in.jsonld",
       "expectErrorCode": "protected term redefinition"
     }, {
+      "@id": "#tpr43",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Clear protection in @graph @container with null context.",
+      "purpose": "Clear protection in @graph @container with null context.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/pr43-in.jsonld",
+      "expect": "expand/pr43-out.jsonld"
+    }, {
       "@id": "#tso01",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "@import is invalid in 1.0.",

--- a/tests/expand/pr43-in.jsonld
+++ b/tests/expand/pr43-in.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@protected": true,
+    "protected": {
+      "@id": "ex:protected1",
+      "@type": "@id"
+    },
+    "unprotected": {
+      "@id": "ex:unprotected",
+      "@type": "@id",
+      "@container": "@graph",
+      "@context": null
+    }
+  },
+  "@id": "ex:outer",
+  "unprotected": {
+    "@context": {
+      "protected": "ex:protected2"
+    },
+    "@id": "ex:inner",
+    "protected": "p === ex:protected2"
+  }
+}

--- a/tests/expand/pr43-out.jsonld
+++ b/tests/expand/pr43-out.jsonld
@@ -1,0 +1,19 @@
+[
+  {
+    "@id": "ex:outer",
+    "ex:unprotected": [
+      {
+        "@graph": [
+          {
+            "@id": "ex:inner",
+            "ex:protected2": [
+              {
+                "@value": "p === ex:protected2"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/tests/toRdf-manifest.html
+++ b/tests/toRdf-manifest.html
@@ -11342,6 +11342,34 @@
             </dd>
           </dl>
         </dd>
+        <dt id='tpr43'>
+          Test tpr43 Clear protection in @graph @container with null context.
+        </dt>
+        <dd>
+          <dl class='entry'>
+            <dt>id</dt>
+            <dd>#tpr43</dd>
+            <dt>Type</dt>
+            <dd>jld:PositiveEvaluationTest, jld:ToRDFTest</dd>
+            <dt>Purpose</dt>
+            <dd>Clear protection in @graph @container with null context.</dd>
+            <dt>input</dt>
+            <dd>
+              <a href='toRdf/pr43-in.jsonld'>toRdf/pr43-in.jsonld</a>
+            </dd>
+            <dt>expect</dt>
+            <dd>
+              <a href='toRdf/pr43-out.nq'>toRdf/pr43-out.nq</a>
+            </dd>
+            <dt>Options</dt>
+            <dd>
+              <dl class='options'>
+                <dt>specVersion</dt>
+                <dd>json-ld-1.1</dd>
+              </dl>
+            </dd>
+          </dl>
+        </dd>
         <dt id='trt01'>
           Test trt01 Representing numbers &gt;= 1e21
         </dt>

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -3388,6 +3388,14 @@
       "input": "toRdf/pr42-in.jsonld",
       "expectErrorCode": "protected term redefinition"
     }, {
+      "@id": "#tpr43",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+      "name": "Clear protection in @graph @container with null context.",
+      "purpose": "Clear protection in @graph @container with null context.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "toRdf/pr43-in.jsonld",
+      "expect": "toRdf/pr43-out.nq"
+    }, {
       "@id": "#trt01",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
       "name": "Representing numbers >= 1e21",

--- a/tests/toRdf/pr43-in.jsonld
+++ b/tests/toRdf/pr43-in.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": {
+    "@protected": true,
+    "protected": {
+      "@id": "ex:protected1",
+      "@type": "@id"
+    },
+    "unprotected": {
+      "@id": "ex:unprotected",
+      "@type": "@id",
+      "@container": "@graph",
+      "@context": null
+    }
+  },
+  "@id": "ex:outer",
+  "unprotected": {
+    "@context": {
+      "protected": "ex:protected2"
+    },
+    "@id": "ex:inner",
+    "protected": "p === ex:protected2"
+  }
+}

--- a/tests/toRdf/pr43-out.nq
+++ b/tests/toRdf/pr43-out.nq
@@ -1,0 +1,2 @@
+<ex:outer> <ex:unprotected> _:b0 .
+<ex:inner> <ex:protected2> "p === ex:protected2" _:b0 .


### PR DESCRIPTION
Adds a test for a protected `@graph` `@container` property that nullifies it's `@context`.  This is similar to a pattern found in the VC Data Model 2.0 context.  There are other test variations of context nullification, graph properties, and protection rules, etc, but there doesn't seem to be one with this combination.  jsonld.js was failing this test but other implementations pass.

Are other variations of this test needed?  It looks like most base features are covered, but perhaps tricky combinations of features might expose edge case issues.  Help needed.

See:
https://github.com/w3c/vc-data-model/issues/1373