### PR TITLE
Add test for `@context` redefinition.

### DIFF
--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -1820,6 +1820,13 @@
       "input": "expand/er55-in.jsonld",
       "expectErrorCode": "invalid type mapping"
     }, {
+      "@id": "#ter56",
+      "@type": [ "jld:NegativeEvaluationTest", "jld:ExpandTest" ],
+      "name": "Invalid redefinition of @context keyword.",
+      "purpose": "Verifies that an exception is raise when attempting to redefine @context.",
+      "input": "expand/er56-in.jsonld",
+      "expectErrorCode": "keyword redefinition"
+    }, {
       "@id": "#tes01",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "Using an array value for @context is illegal in JSON-LD 1.0",

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -1823,7 +1823,7 @@
       "@id": "#ter56",
       "@type": [ "jld:NegativeEvaluationTest", "jld:ExpandTest" ],
       "name": "Invalid redefinition of @context keyword.",
-      "purpose": "Verifies that an exception is raise when attempting to redefine @context.",
+      "purpose": "Verifies that an exception is raised when attempting to redefine @context.",
       "input": "expand/er56-in.jsonld",
       "expectErrorCode": "keyword redefinition"
     }, {

--- a/tests/expand/er56-in.jsonld
+++ b/tests/expand/er56-in.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@context": {
+      "p": "ex:p"
+    }
+  },
+  "@id": "ex:1",
+  "p": "value"
+}
+

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -2248,7 +2248,7 @@
       "@id": "#ter56",
       "@type": [ "jld:NegativeEvaluationTest", "jld:ToRDFTest" ],
       "name": "Invalid redefinition of @context keyword.",
-      "purpose": "Verifies that an exception is raise when attempting to redefine @context.",
+      "purpose": "Verifies that an exception is raised when attempting to redefine @context.",
       "input": "expand/er56-in.jsonld",
       "expectErrorCode": "keyword redefinition"
     }, {

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -2231,19 +2231,19 @@
       "expectErrorCode": "invalid @prefix value",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
-     "@id": "#ter54",
-     "@type": [ "jld:NegativeEvaluationTest", "jld:ToRDFTest" ],
-     "name": "Invalid value object, multiple values for @type.",
-     "purpose": "The value of @type in a value object MUST be a string or null.",
-     "input": "toRdf/er54-in.jsonld",
-     "expectErrorCode": "invalid typed value"
+      "@id": "#ter54",
+      "@type": [ "jld:NegativeEvaluationTest", "jld:ToRDFTest" ],
+      "name": "Invalid value object, multiple values for @type.",
+      "purpose": "The value of @type in a value object MUST be a string or null.",
+      "input": "toRdf/er54-in.jsonld",
+      "expectErrorCode": "invalid typed value"
     }, {
-     "@id": "#ter55",
-     "@type": [ "jld:NegativeEvaluationTest", "jld:ToRDFTest" ],
-     "name": "Invalid term definition, multiple values for @type.",
-     "purpose": "The value of @type in an expanded term definition object MUST be a string or null.",
-     "input": "toRdf/er55-in.jsonld",
-     "expectErrorCode": "invalid type mapping"
+      "@id": "#ter55",
+      "@type": [ "jld:NegativeEvaluationTest", "jld:ToRDFTest" ],
+      "name": "Invalid term definition, multiple values for @type.",
+      "purpose": "The value of @type in an expanded term definition object MUST be a string or null.",
+      "input": "toRdf/er55-in.jsonld",
+      "expectErrorCode": "invalid type mapping"
     }, {
       "@id": "#ter56",
       "@type": [ "jld:NegativeEvaluationTest", "jld:ToRDFTest" ],

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -2245,6 +2245,13 @@
      "input": "toRdf/er55-in.jsonld",
      "expectErrorCode": "invalid type mapping"
     }, {
+      "@id": "#ter56",
+      "@type": [ "jld:NegativeEvaluationTest", "jld:ToRDFTest" ],
+      "name": "Invalid redefinition of @context keyword.",
+      "purpose": "Verifies that an exception is raise when attempting to redefine @context.",
+      "input": "expand/er56-in.jsonld",
+      "expectErrorCode": "keyword redefinition"
+    }, {
       "@id": "#tin01",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
       "name": "Basic Included array",

--- a/tests/toRdf/er56-in.jsonld
+++ b/tests/toRdf/er56-in.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@context": {
+      "p": "ex:p"
+    }
+  },
+  "@id": "ex:1",
+  "p": "value"
+}
+


### PR DESCRIPTION
See https://github.com/w3c/json-ld-api/issues/590.

- Please double check this is the correct error code.
- The test naming is still confusing, I think erNN is ok?