### PR TITLE
Test protected flag retained during redefinition.

### DIFF
--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -2844,6 +2844,14 @@
       "input": "expand/pr41-in.jsonld",
       "expect": "expand/pr41-out.jsonld"
     }, {
+      "@id": "#tpr42",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "Fail if protected flag not retained during redefinition",
+      "purpose": "Check protected redefinition retains protected flag.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/pr42-in.jsonld",
+      "expectErrorCode": "protected term redefinition"
+    }, {
       "@id": "#tso01",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "@import is invalid in 1.0.",

--- a/tests/expand/pr42-in.jsonld
+++ b/tests/expand/pr42-in.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": [
+    {
+      "@protected": true,
+      "protected": "ex:protected"
+    },
+    {
+      "protected": "ex:protected"
+    },
+    {
+      "protected": "ex:unprotected"
+    }
+  ],
+  "protected": "fail / should retain protection during redefinition"
+}

--- a/tests/toRdf-manifest.jsonld
+++ b/tests/toRdf-manifest.jsonld
@@ -3373,6 +3373,14 @@
       "input": "toRdf/pr41-in.jsonld",
       "expect": "toRdf/pr41-out.nq"
     }, {
+      "@id": "#tpr42",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
+      "name": "Fail if protected flag not retained during redefinition",
+      "purpose": "Check protected redefinition retains protected flag.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "toRdf/pr42-in.jsonld",
+      "expectErrorCode": "protected term redefinition"
+    }, {
       "@id": "#trt01",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
       "name": "Representing numbers >= 1e21",

--- a/tests/toRdf/pr42-in.jsonld
+++ b/tests/toRdf/pr42-in.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": [
+    {
+      "@protected": true,
+      "protected": "ex:protected"
+    },
+    {
+      "protected": "ex:protected"
+    },
+    {
+      "protected": "ex:unprotected"
+    }
+  ],
+  "protected": "fail / should retain protection during redefinition"
+}


### PR DESCRIPTION
- Add expand and toRdf tests to check protection flag is retained when a term is redefined the same as a protected term, and then redefined as something else, triggering a failure.
- See 4.1.11 https://www.w3.org/TR/json-ld11/#protected-term-definitions about similar overrides that don't change semantics of the protected term.
- See 4.2.2.27.2 https://www.w3.org/TR/json-ld-api/#algorithm-0 about retaining the value of protected flag.