### PR TITLE
The default for extractAllScripts in toRdf() should be true.

### DIFF
--- a/index.html
+++ b/index.html
@@ -7119,7 +7119,7 @@
       14 to begin with <q>Otherwise</q>.</li>
     <li>Use <a>code point order</a> as a better definition for the more vague "lexicographical order".</li>
     <li>Remove spurious paragraph in the description of {{JsonLdOptions/frameExpansion}}</li>
-    <li>Specify that the default value of <a data-link-for="LoadDocumentOptions">extractAllScripts</a>
+    <li>Specify that the value of <a data-link-for="LoadDocumentOptions">extractAllScripts</a>
       in <a data-link-for="JsonLdProcessor">toRdf()</a>
       defaults to `true`, rather than `false`.
       This is consistent with wording in

--- a/index.html
+++ b/index.html
@@ -6008,7 +6008,8 @@
             <a data-link-for="JsonLdProcessor">expand()</a> method
             using <a data-lt="jsonldprocessor-toRdf-input">input</a>
             and <a data-lt="jsonldprocessor-toRdf-options">options</a>
-            <span class="changed">with {{JsonLdOptions/ordered}} set to <code>false</code></span>.</li>
+            <span class="changed">with {{JsonLdOptions/ordered}} set to <code>false</code>,
+              and {{JsonLdOptions/extractAllScripts}} defaulting to <code>true</code></span>.</li>
           <li>Create a new <a>RdfDataset</a> <var>dataset</var>.</li>
           <li>Create a new <a>map</a> <var>node map</var>.</li>
           <li>Invoke the <a href="#node-map-generation">Node Map Generation algorithm</a>,
@@ -7118,6 +7119,12 @@
       14 to begin with <q>Otherwise</q>.</li>
     <li>Use <a>code point order</a> as a better definition for the more vague "lexicographical order".</li>
     <li>Remove spurious paragraph in the description of {{JsonLdOptions/frameExpansion}}</li>
+    <li>Specify that the default value of <a data-link-for="LoadDocumentOptions">extractAllScripts</a>
+      in <a data-link-for="JsonLdProcessor">toRdf()</a>
+      defaults to `true`, rather than `false`.
+      This is consistent with wording in
+      <a data-cite="JSON-LD11#embedding-json-ld-in-html-documents">Embedding JSON-LD in HTML Documents</a> [[JSON-LD11]]
+      for teating script elements as a single document.</li>
   </ul>
 </section>
 <section id="ack"

--- a/index.html
+++ b/index.html
@@ -7124,7 +7124,7 @@
       defaults to `true`, rather than `false`.
       This is consistent with wording in
       <a data-cite="JSON-LD11#embedding-json-ld-in-html-documents">Embedding JSON-LD in HTML Documents</a> [[JSON-LD11]]
-      for teating script elements as a single document.</li>
+      for treating script elements as a single document.</li>
   </ul>
 </section>
 <section id="ack"


### PR DESCRIPTION
Tests are already consistent with this interpretation, although it was never documented in the API properly.

Fixes #603.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/606.html" title="Last updated on Jul 12, 2024, 2:21 PM UTC (b2ece69)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/606/30aa531...b2ece69.html" title="Last updated on Jul 12, 2024, 2:21 PM UTC (b2ece69)">Diff</a>