### PR TITLE
Add compaction to @type map when the compacted item is not already a map.

### DIFF
--- a/tests/compact-manifest.html
+++ b/tests/compact-manifest.html
@@ -6206,6 +6206,38 @@
             </dd>
           </dl>
         </dd>
+        <dt id='tm023'>
+          Test tm023 compact IRI with container: @type
+        </dt>
+        <dd>
+          <dl class='entry'>
+            <dt>id</dt>
+            <dd>#tm023</dd>
+            <dt>Type</dt>
+            <dd>jld:PositiveEvaluationTest, jld:CompactTest</dd>
+            <dt>Purpose</dt>
+            <dd>Uses @none when compacted item is an IRI string</dd>
+            <dt>input</dt>
+            <dd>
+              <a href='compact/m023-in.jsonld'>compact/m023-in.jsonld</a>
+            </dd>
+            <dt>context</dt>
+            <dd>
+              <a href='compact/m023-context.jsonld'>compact/m023-context.jsonld</a>
+            </dd>
+            <dt>expect</dt>
+            <dd>
+              <a href='compact/m023-out.jsonld'>compact/m023-out.jsonld</a>
+            </dd>
+            <dt>Options</dt>
+            <dd>
+              <dl class='options'>
+                <dt>specVersion</dt>
+                <dd>json-ld-1.1</dd>
+              </dl>
+            </dd>
+          </dl>
+        </dd>
         <dt id='tn001'>
           Test tn001 Indexes to @nest for property with @nest
         </dt>

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -1801,6 +1801,15 @@
       "expect": "compact/m022-out.jsonld",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#tm023",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "compact IRI with container: @type",
+      "purpose": "Uses @none when compacted item is an IRI string",
+      "input": "compact/m023-in.jsonld",
+      "context": "compact/m023-context.jsonld",
+      "expect": "compact/m023-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tn001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Indexes to @nest for property with @nest",

--- a/tests/compact/m023-context.jsonld
+++ b/tests/compact/m023-context.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@vocab": "http://schema.org/",
+    "location": {
+      "@type": "@id",
+      "@container": "@type"
+    }
+  }
+}

--- a/tests/compact/m023-in.jsonld
+++ b/tests/compact/m023-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@vocab": "http://schema.org/"
+  },
+  "@type": "Event",
+  "location": {
+    "@id": "http://kg.artsdata.ca/resource/K11-200"
+  }
+}

--- a/tests/compact/m023-out.jsonld
+++ b/tests/compact/m023-out.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "@vocab": "http://schema.org/",
+    "location": {
+      "@type": "@id",
+      "@container": "@type"
+    }
+  },
+  "@type": "Event",
+  "location": {
+    "@none": "http://kg.artsdata.ca/resource/K11-200"
+  }
+}


### PR DESCRIPTION
The algorithm inspects `compacted item` to see if it has value for `container key` when `compacted item` is not a **map**.

From ruby-rdf/json-ld#62.
