### PR TITLE
Rename name to purpose and add name for t0041

### DIFF
--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -291,7 +291,8 @@
     }, {
       "@id": "#t0041",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "@language: null resets the default language",
+      "name": "Language nullification",
+      "purpose": "@language: null resets the default language",
       "input": "expand/0041-in.jsonld",
       "expect": "expand/0041-out.jsonld"
     }, {

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -291,7 +291,7 @@
     }, {
       "@id": "#t0041",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "Language nullification",
+      "name": "@language: null",
       "purpose": "@language: null resets the default language",
       "input": "expand/0041-in.jsonld",
       "expect": "expand/0041-out.jsonld"


### PR DESCRIPTION
`purpose` was missing from `t0041`. Some prior discussion here: https://github.com/json-ld/json-ld.org/pull/852.