### PR TITLE
(closes #555) Fall back to default logic in `useNativeTypes` mode for RDF numbers which are not JSON numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
-# Support JetBrains IDEs
-.idea
+# JetBrains IDEs
+.idea/
+
+# pyenv version file
+.python-version

--- a/index.html
+++ b/index.html
@@ -5487,13 +5487,16 @@
                     </li>
                     <li>
                       If the conversion is successful, set <var>converted value</var>
-                      to its result.
+                      to its result;
+                    </li>
+                    <li>
+                      Otherwise, set <var>type</var> to <a>datatype IRI</a> of <var>value</var>.
                     </li>
                   </ol>
                 </li>
               </ol>
             </li>
-            <li class="changed">If <a>processing mode</a> is not `json-ld-1.0`,
+            <li class="changed">Otherwise, if <a>processing mode</a> is not `json-ld-1.0`,
               and <var>value</var> is a <a>JSON literal</a>,
               set <var>converted value</var> to the result of
               turning the lexical value of <var>value</var>

--- a/index.html
+++ b/index.html
@@ -5477,13 +5477,23 @@
                   <code>xsd:double</code> and its
                   <a>lexical form</a>
                   is a valid <code>xsd:integer</code> or <code>xsd:double</code>
-                  according [[XMLSCHEMA11-2]], set <var>converted value</var>
-                  to the result of converting the
-                  <a>lexical form</a>
-                  to a JSON <a>number</a>.</li>
+                  according to [[XMLSCHEMA11-2]],
+                  <ol>
+                    <li>attempt to convert the <a>lexical form</a> to a <a>JSON number</a>
+                      according to
+                      [[RFC8785]] <a data-cite="RFC8785#name-serialization-of-numbers">
+                        JSON Serialization Scheme (JCS) 3.2.2.3 Serialization of Numbers
+                      </a> procedure;
+                    </li>
+                    <li>
+                      If the conversion is successful, set <var>converted value</var>
+                      to its result.
+                    </li>
+                  </ol>
+                </li>
               </ol>
             </li>
-            <li class="changed">Otherwise, if <a>processing mode</a> is not `json-ld-1.0`,
+            <li class="changed">If <a>processing mode</a> is not `json-ld-1.0`,
               and <var>value</var> is a <a>JSON literal</a>,
               set <var>converted value</var> to the result of
               turning the lexical value of <var>value</var>

--- a/index.html
+++ b/index.html
@@ -5477,17 +5477,17 @@
                   <code>xsd:double</code> and its
                   <a>lexical form</a>
                   is a valid <code>xsd:integer</code> or <code>xsd:double</code>
-                  according to [[XMLSCHEMA11-2]],
+                  according to [[XMLSCHEMA11-2]]:
                   <ol>
-                    <li>attempt to convert the <a>lexical form</a> to a <a>JSON number</a>
+                    <li>Attempt to convert the <a>lexical form</a> to a <a>JSON number</a>
                       according to
                       [[RFC8785]] <a data-cite="RFC8785#name-serialization-of-numbers">
                         JSON Serialization Scheme (JCS) 3.2.2.3 Serialization of Numbers
-                      </a> procedure;
+                      </a> procedure.
                     </li>
                     <li>
                       If the conversion is successful, set <var>converted value</var>
-                      to its result;
+                      to its result.
                     </li>
                     <li>
                       Otherwise, set <var>type</var> to <a>datatype IRI</a> of <var>value</var>.

--- a/index.html
+++ b/index.html
@@ -5458,7 +5458,7 @@
             <li>If <a data-link-for="JsonLdOptions">useNativeTypes</a> is <code>true</code>
               <div class="candidate correction" id="change_5">
                 <span class="marker">Candidate Correction 5</span>
-                <p>This changes the behavior of using native numbers when <a data-link-for="JsonLdOptions">useNativeTypes</a> is `true`.
+                <p>This changes behavior when using native numbers where <a data-link-for="JsonLdOptions">useNativeTypes</a> is `true`.
                   For more information, refer to <a href="https://github.com/w3c/json-ld-api/issues/555">issue 555</a>.
                 </p>
               </div>
@@ -5492,7 +5492,7 @@
                     <ol>
                       <li>
                         Attempt to convert the <a>lexical form</a> to a <a>JSON number</a>
-                        according to
+                        according to the
                         [[RFC8785]] <a data-cite="RFC8785#name-serialization-of-numbers">
                           JSON Serialization Scheme (JCS) 3.2.2.3 Serialization of Numbers
                         </a> procedure.

--- a/index.html
+++ b/index.html
@@ -5479,18 +5479,26 @@
                   is a valid <code>xsd:integer</code> or <code>xsd:double</code>
                   according to [[XMLSCHEMA11-2]]:
                   <ol>
-                    <li>Attempt to convert the <a>lexical form</a> to a <a>JSON number</a>
-                      according to
-                      [[RFC8785]] <a data-cite="RFC8785#name-serialization-of-numbers">
-                        JSON Serialization Scheme (JCS) 3.2.2.3 Serialization of Numbers
-                      </a> procedure.
+                    <li>
+                      <ins>
+                        Attempt to convert the <a>lexical form</a> to a <a>JSON number</a>
+                        according to
+                        [[RFC8785]] <a data-cite="RFC8785#name-serialization-of-numbers">
+                          JSON Serialization Scheme (JCS) 3.2.2.3 Serialization of Numbers
+                        </a> procedure.
+                      </ins>
                     </li>
                     <li>
-                      If the conversion is successful, set <var>converted value</var>
-                      to its result.
+                      <ins>
+                        If the conversion is successful, set <var>converted value</var>
+                        to its result.
+                      </ins>
                     </li>
                     <li>
-                      Otherwise, set <var>type</var> to <a>datatype IRI</a> of <var>value</var>.
+                      <ins>
+                        Otherwise, set <var>type</var> to <a>datatype IRI</a>
+                        of <var>value</var>.
+                      </ins>
                     </li>
                   </ol>
                 </li>

--- a/index.html
+++ b/index.html
@@ -5456,6 +5456,12 @@
             <li>Initialize <var>converted value</var> to <var>value</var>.</li>
             <li>Initialize <var>type</var> to <code>null</code></li>
             <li>If <a data-link-for="JsonLdOptions">useNativeTypes</a> is <code>true</code>
+              <div class="candidate correction" id="change_5">
+                <span class="marker">Candidate Correction 5</span>
+                <p>This changes the behavior of using native numbers when <a data-link-for="JsonLdOptions">useNativeTypes</a> is `true`.
+                  For more information, refer to <a href="https://github.com/w3c/json-ld-api/issues/555">issue 555</a>.
+                </p>
+              </div>
               <ol>
                 <li>If the
                   <a>datatype IRI</a>
@@ -5477,30 +5483,30 @@
                   <code>xsd:double</code> and its
                   <a>lexical form</a>
                   is a valid <code>xsd:integer</code> or <code>xsd:double</code>
-                  according to [[XMLSCHEMA11-2]]:
-                  <ol>
-                    <li>
-                      <ins>
+                  according to [[XMLSCHEMA11-2]]<del cite="#change_5">,
+                    set <var>converted value</var>
+                    to the result of converting the
+                    <a>lexical form</a>
+                    to a JSON <a>number</a>.
+                  </del><ins cite="#change_5">:
+                    <ol>
+                      <li>
                         Attempt to convert the <a>lexical form</a> to a <a>JSON number</a>
                         according to
                         [[RFC8785]] <a data-cite="RFC8785#name-serialization-of-numbers">
                           JSON Serialization Scheme (JCS) 3.2.2.3 Serialization of Numbers
                         </a> procedure.
-                      </ins>
-                    </li>
-                    <li>
-                      <ins>
+                      </li>
+                      <li>
                         If the conversion is successful, set <var>converted value</var>
                         to its result.
-                      </ins>
-                    </li>
-                    <li>
-                      <ins>
+                      </li>
+                      <li>
                         Otherwise, set <var>type</var> to <a>datatype IRI</a>
                         of <var>value</var>.
-                      </ins>
-                    </li>
-                  </ol>
+                      </li>
+                    </ol>
+                  </ins>
                 </li>
               </ol>
             </li>
@@ -7077,6 +7083,9 @@
       <a data-cite="JSON-LD11#embedding-json-ld-in-html-documents">Embedding JSON-LD in HTML Documents</a> [[JSON-LD11]]
       for treating script elements as a single document,
       as described in <a href="#change_4">Candidate Correction 4</a>.</li>
+    <li>2025-01-25: Correct some corner cases in transforming RDF Number Literals
+      to JSON numbers when <a data-link-for="JsonLdOptions">useNativeTypes</a> is `true`,
+      as described in <a href="#change_5">Candidate Correction 5</a>.</li>
     <li>2024-01-25: Change processing step for <a>LoadDocumentCallback</a>
       to not presume that the content type is for JSON,
       as described in <a href="#change_6">Candidate Correction 6</a></li>

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -941,7 +941,7 @@
           </dl>
         </dd>
         <dt id='t0041'>
-          Test t0041 @language: null resets the default language
+          Test t0041 @language: null
         </dt>
         <dd>
           <dl class='entry'>
@@ -950,7 +950,7 @@
             <dt>Type</dt>
             <dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
             <dt>Purpose</dt>
-            <dd></dd>
+            <dd>@language: null resets the default language</dd>
             <dt>input</dt>
             <dd>
               <a href='expand/0041-in.jsonld'>expand/0041-in.jsonld</a>

--- a/tests/fromRdf-manifest.html
+++ b/tests/fromRdf-manifest.html
@@ -648,6 +648,34 @@
             </dd>
           </dl>
         </dd>
+        <dt id='t0027'>
+          Test t0027 use native types flag with values that cannot be serialized to JSON
+        </dt>
+        <dd>
+          <dl class='entry'>
+            <dt>id</dt>
+            <dd>#t0027</dd>
+            <dt>Type</dt>
+            <dd>jld:PositiveEvaluationTest, jld:FromRDFTest</dd>
+            <dt>Purpose</dt>
+            <dd>useNativeTypes flag being true is disregarded for a value that cannot be serialized into a native JSON value.</dd>
+            <dt>input</dt>
+            <dd>
+              <a href='fromRdf/0027-in.nq'>fromRdf/0027-in.nq</a>
+            </dd>
+            <dt>expect</dt>
+            <dd>
+              <a href='fromRdf/0027-out.jsonld'>fromRdf/0027-out.jsonld</a>
+            </dd>
+            <dt>Options</dt>
+            <dd>
+              <dl class='options'>
+                <dt>useNativeTypes</dt>
+                <dd>true</dd>
+              </dl>
+            </dd>
+          </dl>
+        </dd>
         <dt id='tdi01'>
           Test tdi01 rdfDirection: null with i18n literal with direction and no language
         </dt>

--- a/tests/fromRdf-manifest.jsonld
+++ b/tests/fromRdf-manifest.jsonld
@@ -196,6 +196,16 @@
       "input": "fromRdf/0026-in.nq",
       "expect": "fromRdf/0026-out.jsonld"
     }, {
+      "@id": "#t0027",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FromRDFTest"],
+      "name": "use native types flag with values that cannot be serialized to JSON",
+      "purpose": "useNativeTypes flag being true is disregarded for a value that cannot be serialized into a native JSON value.",
+      "option": {
+        "useNativeTypes": true
+      },
+      "input": "fromRdf/0027-in.nq",
+      "expect": "fromRdf/0027-out.jsonld"
+    }, {
       "@id": "#tdi01",
       "@type": [ "jld:PositiveEvaluationTest", "jld:FromRDFTest" ],
       "name": "rdfDirection: null with i18n literal with direction and no language",

--- a/tests/fromRdf/0027-in.nq
+++ b/tests/fromRdf/0027-in.nq
@@ -5,7 +5,6 @@
 <http://example.com/boolean-object> <http://example.com/example> "False"^^<http://www.w3.org/2001/XMLSchema#boolean> .
 
 <http://example.com/number-native> <http://example.com/example> "1"^^<http://www.w3.org/2001/XMLSchema#integer> .
-<http://example.com/number-native> <http://example.com/example> "1.1"^^<http://www.w3.org/2001/XMLSchema#decimal> .
 
 <http://example.com/number-object> <http://example.com/example> "0.1e999999999999999"^^<http://www.w3.org/2001/XMLSchema#double> .
 <http://example.com/number-object> <http://example.com/example> "+INF"^^<http://www.w3.org/2001/XMLSchema#double> .

--- a/tests/fromRdf/0027-in.nq
+++ b/tests/fromRdf/0027-in.nq
@@ -1,0 +1,12 @@
+<http://example.com/boolean-native> <http://example.com/example> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+<http://example.com/boolean-native> <http://example.com/example> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+
+<http://example.com/boolean-object> <http://example.com/example> "True"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+<http://example.com/boolean-object> <http://example.com/example> "False"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+
+<http://example.com/number-native> <http://example.com/example> "1"^^<http://www.w3.org/2001/XMLSchema#integer> .
+<http://example.com/number-native> <http://example.com/example> "1.1"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+
+<http://example.com/number-object> <http://example.com/example> "0.1e999999999999999"^^<http://www.w3.org/2001/XMLSchema#double> .
+<http://example.com/number-object> <http://example.com/example> "+INF"^^<http://www.w3.org/2001/XMLSchema#double> .
+<http://example.com/number-object> <http://example.com/example> "-INF"^^<http://www.w3.org/2001/XMLSchema#double> .

--- a/tests/fromRdf/0027-out.jsonld
+++ b/tests/fromRdf/0027-out.jsonld
@@ -32,10 +32,6 @@
         {
           "@type": "http://www.w3.org/2001/XMLSchema#integer",
           "@value": 1
-        },
-        {
-          "@type": "http://www.w3.org/2001/XMLSchema#decimal",
-          "@value": 1.1
         }
       ]
     },

--- a/tests/fromRdf/0027-out.jsonld
+++ b/tests/fromRdf/0027-out.jsonld
@@ -1,0 +1,60 @@
+{
+  "@graph": [
+    {
+      "@id": "http://example.com/boolean-native",
+      "http://example.com/example": [
+        {
+          "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+          "@value": true
+        },
+        {
+          "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+          "@value": false
+        }
+      ]
+    },
+    {
+      "@id": "http://example.com/boolean-object",
+      "http://example.com/example": [
+        {
+          "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+          "@value": "True"
+        },
+        {
+          "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+          "@value": "False"
+        }
+      ]
+    },
+    {
+      "@id": "http://example.com/number-native",
+      "http://example.com/example": [
+        {
+          "@type": "http://www.w3.org/2001/XMLSchema#integer",
+          "@value": 1
+        },
+        {
+          "@type": "http://www.w3.org/2001/XMLSchema#decimal",
+          "@value": 1.1
+        }
+      ]
+    },
+    {
+      "@id": "http://example.com/number-object",
+      "http://example.com/example": [
+        {
+          "@type": "http://www.w3.org/2001/XMLSchema#double",
+          "@value": "0.1e999999999999999"
+        },
+        {
+          "@type": "http://www.w3.org/2001/XMLSchema#double",
+          "@value": "+INF"
+        },
+        {
+          "@type": "http://www.w3.org/2001/XMLSchema#double",
+          "@value": "-INF"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This is my second attempt to fix this issue after https://github.com/w3c/json-ld-api/pull/619.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/625.html" title="Last updated on Jan 27, 2025, 10:44 PM UTC (33a652b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/625/f004001...33a652b.html" title="Last updated on Jan 27, 2025, 10:44 PM UTC (33a652b)">Diff</a>