### PR TITLE
fix #633

### DIFF
--- a/index.html
+++ b/index.html
@@ -1998,7 +1998,7 @@
           <li>If the <var>active context</var> has a <a>default language</a> and a <a>default base direction</a>,
             set <var>default lang dir</var> to
             the concatenation of those <a>default language</a> and <a>default base direction</a>,
-            separated by an underscore (`"_"`),
+            separated by an underscore (`"_"`), and
             normalized to lower case.</li>
           <li>Otherwise, if the <var>active context</var> has a <a>default language</a>,
             set <var>default lang dir</var> to that <a>default language</a>

--- a/index.html
+++ b/index.html
@@ -1996,7 +1996,7 @@
         <li>Initialize <var>result</var> to an empty <a class="changed">map</a>.</li>
         <li>Initialize <var>default language</var> to <code>@none</code>.
           If the <var>active context</var> has a <a>default language</a>,
-          set <var>default language</var> to the <a>default language</a> from the <a>active context</a>
+          set <var>default language</var> to the <a>default language</a> from the <var>active context</var>
           <span class="changed">normalized to lower case</span>.</li>
         <li>For each key <a>term</a> and value <a>term definition</a> in
           the <var>active context</var>, ordered by shortest <a>term</a>
@@ -2112,7 +2112,7 @@
               <a>default base direction</a>:
               <ol>
                 <li>Initialize a variable <var>lang dir</var>
-                  with the concatenation of <a>default language</a> and <a>default base direction</a>,
+                  with the concatenation of <var>default language</var> and <a>default base direction</a>,
                   separate by an underscore (`"_"`),
                   normalized to lower case.</li>
                 <li>If <var>language map</var> does not have a <var>lang dir</var> <a>entry</a>,

--- a/index.html
+++ b/index.html
@@ -1994,10 +1994,20 @@
 
       <ol>
         <li>Initialize <var>result</var> to an empty <a class="changed">map</a>.</li>
-        <li>Initialize <var>default language</var> to <code>@none</code>.
-          If the <var>active context</var> has a <a>default language</a>,
-          set <var>default language</var> to the <a>default language</a> from the <var>active context</var>
-          <span class="changed">normalized to lower case</span>.</li>
+        <li class="changed">Initialize <var>default lang dir</var> as follows:<ul>
+          <li>If the <var>active context</var> has a <a>default language</a> and a <a>default base direction</a>,
+            set <var>default lang dir</var> to
+            the concatenation of those <a>default language</a> and <a>default base direction</a>,
+            separated by an underscore (`"_"`),
+            normalized to lower case.</li>
+          <li>Otherwise, if the <var>active context</var> has a <a>default language</a>,
+            set <var>default lang dir</var> to that <a>default language</a>
+            normalized to lower case.</li>
+          <li>Otherwise, if the <var>active context</var> has a <a>default base direction</a>,
+            set <var>default lang dir</var> to the <a>default base direction</a> from the <var>active context</var>
+            preceded by an underscore (`"_"`).</li>
+          <li>Otherwise, set <var>default lang dir</var> to <code>@none</code>.</li>
+        </ul></li>
         <li>For each key <a>term</a> and value <a>term definition</a> in
           the <var>active context</var>, ordered by shortest <a>term</a>
           first (breaking ties by choosing the lexicographically least
@@ -2097,39 +2107,9 @@
                   being processed.</li>
               </ol>
             </li>
-            <li class="changed">Otherwise, if <a>term definition</a> has a
-              <a>direction mapping</a> (might be <code>null</code>):
-              <ol>
-                <li>If the <a>direction mapping</a> equals <code>null</code>,
-                  set <var>direction</var> to <code>@none</code>; otherwise
-                  to <a>direction mapping</a> preceded by an underscore (`"_"`).</li>
-                <li>If <var>language map</var> does not have a <var>direction</var> <a>entry</a>,
-                  create one and set its value to the <a>term</a>
-                  being processed.</li>
-              </ol>
-            </li>
-            <li class="changed">Otherwise, if <var>active context</var> has a
-              <a>default base direction</a>:
-              <ol>
-                <li>Initialize a variable <var>lang dir</var>
-                  with the concatenation of <var>default language</var> and <a>default base direction</a>,
-                  separate by an underscore (`"_"`),
-                  normalized to lower case.</li>
-                <li>If <var>language map</var> does not have a <var>lang dir</var> <a>entry</a>,
-                  create one and set its value to the <a>term</a>
-                  being processed.</li>
-                <li>If <var>language map</var> does not have an `@none` <a>entry</a>,
-                  create one and set its value to the <a>term</a>
-                  being processed.</li>
-                <li>If <var>type map</var> does not have an `@none` <a>entry</a>,
-                  create one and set its value to the <a>term</a>
-                  being processed.</li>
-              </ol>
-            </li>
             <li>Otherwise:
               <ol>
-                <li>If <var>language map</var> does not have a <var>default language</var> <a>entry</a>
-                  <span class="changed">(after being normalized to lower case)</span>,
+                <li>If <var>language map</var> does not have a <var>default lang dir</var> <a>entry</a>,
                   create one and set its value to the <a>term</a>
                   being processed.</li>
                 <li>If <var>language map</var> does not have an <code>@none</code>


### PR DESCRIPTION
This reorders and factorizes some parts of the 'Inverse Content Creation' algorithm.
It does not change the behaviour of the algorithm,
except for one corner case:
if the active context has no default language but has a default base direction,
the default combined tag is now _{dir}.
In the previous version, it was @none_{dir}.
I find this more consistent with steps 3.13.4 and 3.15.1,
and I suspect that this former discrepency was actually a bug.

NB: I put this PR on top of #636 because they affect the same part of the spec,
and because I don't expect #636 to be controversial anyway.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/637.html" title="Last updated on Feb 28, 2025, 8:22 AM UTC (fbd89a5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/637/55504a9...fbd89a5.html" title="Last updated on Feb 28, 2025, 8:22 AM UTC (fbd89a5)">Diff</a>