### PR TITLE
improve 'term definition' definition

### DIFF
--- a/common/terms.html
+++ b/common/terms.html
@@ -383,7 +383,7 @@
     Its value is either a string (<dfn data-cite="JSON-LD11#dfn-simple-term-definition" data-lt="simple term definition|simple term" data-lt-noDefault>simple term definition</dfn>),
     expanding to an <a>IRI</a>,
     or a map (<a>expanded term definition</a>).<br/>
-    For <a data-cite="JSON-LD11-API#context-processing-algorithms">context processing</a>, <a>term definitions</a>' values are converted internally to a dedicated data structure that is easier to process.
+    For <a data-cite="JSON-LD11-API#context-processing-algorithms">context processing</a>, <a>term definition</a> values are converted internally to a dedicated data structure that is easier to process.
   </dd>
   <dt class="changed"><dfn data-cite="JSON-LD11#dfn-type-map">type map</dfn></dt><dd class="changed">
     A <a>type map</a> is a <a>map</a> value of a <a>term</a>

--- a/common/terms.html
+++ b/common/terms.html
@@ -382,8 +382,9 @@
     as a key, type, or elsewhere that a string is interpreted as a vocabulary item.
     Its value is either a string (<dfn data-cite="JSON-LD11#dfn-simple-term-definition" data-lt="simple term definition|simple term" data-lt-noDefault>simple term definition</dfn>),
     expanding to an <a>IRI</a>,
-    or a map (<a>expanded term definition</a>).<br/>
-    For <a data-cite="JSON-LD11-API#context-processing-algorithms">context processing</a>, <a>term definition</a> values are converted internally to a dedicated data structure that is easier to process.
+    or a map (<a>expanded term definition</a>).
+    <ins cite="#change_api_638"><br/>
+    For <a data-cite="JSON-LD11-API#context-processing-algorithms">context processing</a>, <a>term definition</a> values are converted internally to a dedicated data structure that is easier to process.</ins>
   </dd>
   <dt class="changed"><dfn data-cite="JSON-LD11#dfn-type-map">type map</dfn></dt><dd class="changed">
     A <a>type map</a> is a <a>map</a> value of a <a>term</a>

--- a/common/terms.html
+++ b/common/terms.html
@@ -383,7 +383,7 @@
     Its value is either a string (<dfn data-cite="JSON-LD11#dfn-simple-term-definition" data-lt="simple term definition|simple term" data-lt-noDefault>simple term definition</dfn>),
     expanding to an <a>IRI</a>,
     or a map (<a>expanded term definition</a>).<br/>
-    <span class="change">For <a data-cite="JSON-LD11-API#context-processing-algorithms">context processing</a>, <a>term definitions</a>' values are converted internally to a dedicated data structure</span> that is easier to process.
+    For <a data-cite="JSON-LD11-API#context-processing-algorithms">context processing</a>, <a>term definitions</a>' values are converted internally to a dedicated data structure that is easier to process.
   </dd>
   <dt class="changed"><dfn data-cite="JSON-LD11#dfn-type-map">type map</dfn></dt><dd class="changed">
     A <a>type map</a> is a <a>map</a> value of a <a>term</a>

--- a/common/terms.html
+++ b/common/terms.html
@@ -382,7 +382,8 @@
     as a key, type, or elsewhere that a string is interpreted as a vocabulary item.
     Its value is either a string (<dfn data-cite="JSON-LD11#dfn-simple-term-definition" data-lt="simple term definition|simple term" data-lt-noDefault>simple term definition</dfn>),
     expanding to an <a>IRI</a>,
-    or a map (<a>expanded term definition</a>).
+    or a map (<a>expanded term definition</a>).<br/>
+    <span class="change">For <a data-cite="JSON-LD11-API#context-processing-algorithms">context processing</a>, <a>term definitions</a>' values are converted internally to a dedicated data structure</span> that is easier to process.
   </dd>
   <dt class="changed"><dfn data-cite="JSON-LD11#dfn-type-map">type map</dfn></dt><dd class="changed">
     A <a>type map</a> is a <a>map</a> value of a <a>term</a>

--- a/index.html
+++ b/index.html
@@ -1074,7 +1074,7 @@
     <p>The <a>active context</a> consists of:</p>
     <ul>
       <li>the active <a>term definitions</a> which specify how
-        keys and values have to be interpreted (<a>array</a> of <a>term definitions</a>),</li>
+        keys and values have to be interpreted (<a class="change">map</a> of <a>term definitions</a>),</li>
       <li>the current <dfn data-lt="context-base-iri" data-lt-noDefault>base IRI</dfn> (<a>IRI</a>),</li>
       <li class="changed">the <dfn>original base URL</dfn> (<a>IRI</a>),</li>
       <li class="changed">an <dfn data-lt="context-inverse" data-lt-noDefault>inverse context</dfn> (<a>inverse context</a>),</li>
@@ -1085,7 +1085,7 @@
         used when a non-propagated <a>context</a> is defined.</li>
     </ul>
 
-    <p>Each <a>term definition</a> consists of:</p>
+    <p>Each <a>term definition</a><span class="change">'s value</span> consists of:</p>
     <ul>
       <li>an <dfn>IRI mapping</dfn> (<a>IRI</a>),</li>
       <li class="changed">a <dfn>prefix flag</dfn> (<a>boolean</a>),</li>

--- a/index.html
+++ b/index.html
@@ -1074,7 +1074,7 @@
     <p>The <a>active context</a> consists of:</p>
     <ul>
       <li>the active <a>term definitions</a> which specify how
-        keys and values have to be interpreted (<a class="change">map</a> of <a>term definitions</a>),</li>
+        keys and values have to be interpreted (<a class="changed">map</a> of <a>term definitions</a>),</li>
       <li>the current <dfn data-lt="context-base-iri" data-lt-noDefault>base IRI</dfn> (<a>IRI</a>),</li>
       <li class="changed">the <dfn>original base URL</dfn> (<a>IRI</a>),</li>
       <li class="changed">an <dfn data-lt="context-inverse" data-lt-noDefault>inverse context</dfn> (<a>inverse context</a>),</li>
@@ -1085,7 +1085,7 @@
         used when a non-propagated <a>context</a> is defined.</li>
     </ul>
 
-    <p>Each <a>term definition</a><span class="change">'s value</span> consists of:</p>
+    <p>Each <a>term definition</a><span class="changed">'s value</span> consists of:</p>
     <ul>
       <li>an <dfn>IRI mapping</dfn> (<a>IRI</a>),</li>
       <li class="changed">a <dfn>prefix flag</dfn> (<a>boolean</a>),</li>

--- a/index.html
+++ b/index.html
@@ -1075,7 +1075,7 @@
       <span class="marker">Candidate Correction 8</span>
       <p>Change the type of <a>term definition</a> from <a>array</a> to <a>map</a> in <a>active context</a>,
         to be consistent with the way it is used in the algorithms.
-        Clarify the notion <a>term definition</a>.
+        Clarify the notion of "<a>term definition</a>".
         For more information, refer to <a href="https://github.com/w3c/json-ld-api/issues/630">issue 630</a>.
       </p>
     </div>

--- a/index.html
+++ b/index.html
@@ -1071,10 +1071,19 @@
       using information provided by the <a>active context</a>. This
       section describes how to produce an <a>active context</a>.</p>
 
+    <div id="change_api_638" class="candidate correction">
+      <span class="marker">Candidate Correction 8</span>
+      <p>Change the type of <a>term definition</a> from <a>array</a> to <a>map</a> in <a>active context</a>,
+        to be consistent with the way it is used in the algorithms.
+        Clarify the notion <a>term definition</a>.
+        For more information, refer to <a href="https://github.com/w3c/json-ld-api/issues/630">issue 630</a>.
+      </p>
+    </div>
+
     <p>The <a>active context</a> consists of:</p>
     <ul>
       <li>the active <a>term definitions</a> which specify how
-        keys and values have to be interpreted (<a class="changed">map</a> of <a>term definitions</a>),</li>
+        keys and values have to be interpreted (<del cite="#change_api_638"><a>array</a></del><ins cite="#change_api_638"><a>map</a></ins> of <a>term definitions</a>),</li>
       <li>the current <dfn data-lt="context-base-iri" data-lt-noDefault>base IRI</dfn> (<a>IRI</a>),</li>
       <li class="changed">the <dfn>original base URL</dfn> (<a>IRI</a>),</li>
       <li class="changed">an <dfn data-lt="context-inverse" data-lt-noDefault>inverse context</dfn> (<a>inverse context</a>),</li>
@@ -1085,7 +1094,7 @@
         used when a non-propagated <a>context</a> is defined.</li>
     </ul>
 
-    <p>Each <a>term definition</a><span class="changed">'s value</span> consists of:</p>
+    <p>Each <a>term definition</a><ins cite="#change_api_638">'s value</ins> consists of:</p>
     <ul>
       <li>an <dfn>IRI mapping</dfn> (<a>IRI</a>),</li>
       <li class="changed">a <dfn>prefix flag</dfn> (<a>boolean</a>),</li>
@@ -7092,6 +7101,8 @@
      <li>2024-10-31: Abstract JSON serialization from WebIDL interfaces to allow
       for alternative formats,
       as described in <a href="#change_7">Candidate Correction 7</a></li>
+     <li>2025-02-28: Clarifiy language about <a>term definitions</a>,
+      as described in <a href="#change_api_638">Candidate Correction 8</a></li>
  </ul>
   </details>
 


### PR DESCRIPTION
I'm not entirely satisfied with the addition in common/terms.html, as it seems too detailed for the terminology section. But...

...as pointed out in the comment of #630,
the API spec references to this definition in multiple places, and many of those links are actually for instances of the internal representation, *not* for instances of the strings or maps that represent term definition in JSON.

So the alternative would be to introduce a new name for those "internal term definition" and patch all the algorithms... which seems laborious and error-prone.

@gkellogg I don't remember what's the process for synchronizing the files in common with other specs.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/638.html" title="Last updated on Jun 4, 2025, 5:02 PM UTC (b037802)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/638/55504a9...b037802.html" title="Last updated on Jun 4, 2025, 5:02 PM UTC (b037802)">Diff</a>