### PR TITLE
fix #633, in a better way

### DIFF
--- a/index.html
+++ b/index.html
@@ -2007,7 +2007,7 @@
           <div id="change_pr639" class="candidate correction">
             <span class="marker">Candidate Correction 8</span>
             <p>Simplify the algorithm by handling the <a>default base direction</a>
-              once and for all in this step, rather than in each iteration at the end of the next step.
+              once and for all in this step, rather than <a href="#alg-inv-defaul-base-dir">in each iteration</a>.
               For more information, refer to <a href="https://github.com/w3c/json-ld-api/issues/633">issue 633</a>. 
             </p>
           </div>
@@ -2132,7 +2132,7 @@
                   being processed.</li>
               </ol>
             </li>
-            <li class="changed">
+            <li id="alg-inv-defaul-base-dir" class="changed">
               <ins cite="#change_pr639"><em>(this step was removed by a <a href="#change_pr639">candidate correction</a>)</em></ins>
               <del cite="#change_pr639">
               Otherwise, if <var>active context</var> has a

--- a/index.html
+++ b/index.html
@@ -2003,10 +2003,25 @@
 
       <ol>
         <li>Initialize <var>result</var> to an empty <a class="changed">map</a>.</li>
-        <li>Initialize <var>default language</var> to <code>@none</code>.
+        <li>
+          <div id="change_pr639" class="candidate correction">
+            <span class="marker">Candidate Correction 8</span>
+            <p>Simplify the algorithm by handling the <a>default base direction</a>
+              once and for all in this step, rather than in each iteration at the end of the next step.
+              For more information, refer to <a href="https://github.com/w3c/json-ld-api/issues/633">issue 633</a>. 
+            </p>
+          </div>
+
+          Initialize <var>default language</var> to <code>@none</code>.
           If the <var>active context</var> has a <a>default language</a>,
           set <var>default language</var> to the <a>default language</a> from the <var>active context</var>
-          <span class="changed">normalized to lower case</span>.</li>
+          <span class="changed">normalized to lower case</span>.
+          <ins cite="#change_pr639">
+            If the <var>active context</var> has a <a>default base direction</a>,
+            concatenate its value to <var>default language</var>,
+            separated by an underscore (`"_"`).
+          </ins>
+        </li>
         <li>For each key <a>term</a> and value <a>term definition</a> in
           the <var>active context</var>, ordered by shortest <a>term</a>
           first (breaking ties by choosing the lexicographically least
@@ -2117,6 +2132,7 @@
                   being processed.</li>
               </ol>
             </li>
+            <del cite="#change_pr639">
             <li class="changed">Otherwise, if <var>active context</var> has a
               <a>default base direction</a>:
               <ol>
@@ -2135,10 +2151,12 @@
                   being processed.</li>
               </ol>
             </li>
+            </del>
             <li>Otherwise:
               <ol>
-                <li>If <var>language map</var> does not have a <var>default language</var> <a>entry</a>
+                <li>If <var>language map</var> does not have a <var>default language</var> <a>entry</a>,<del cite="#change_pr639">
                   <span class="changed">(after being normalized to lower case)</span>,
+                  </del>
                   create one and set its value to the <a>term</a>
                   being processed.</li>
                 <li>If <var>language map</var> does not have an <code>@none</code>
@@ -7103,6 +7121,8 @@
       as described in <a href="#change_7">Candidate Correction 7</a></li>
      <li>2025-02-28: Clarifiy language about <a>term definitions</a>,
       as described in <a href="#change_api_638">Candidate Correction 8</a></li>
+    <li>2025-02-28: Simplify the <a href="#algorithm-1">Inverse Context Creation algorithm</a>
+      as described in <a href="#change_pr639">Candidate Correction 8</a></li>
  </ul>
   </details>
 

--- a/index.html
+++ b/index.html
@@ -2132,8 +2132,10 @@
                   being processed.</li>
               </ol>
             </li>
-            <del cite="#change_pr639">
-            <li class="changed">Otherwise, if <var>active context</var> has a
+            <li class="changed">
+              <ins cite="#change_pr639"><em>(this step was removed by a <a href="#change_pr639">candidate correction</a>)</em></ins>
+              <del cite="#change_pr639">
+              Otherwise, if <var>active context</var> has a
               <a>default base direction</a>:
               <ol>
                 <li>Initialize a variable <var>lang dir</var>
@@ -2150,8 +2152,8 @@
                   create one and set its value to the <a>term</a>
                   being processed.</li>
               </ol>
+              </del>
             </li>
-            </del>
             <li>Otherwise:
               <ol>
                 <li>If <var>language map</var> does not have a <var>default language</var> <a>entry</a>,<del cite="#change_pr639">


### PR DESCRIPTION
and using the markup for candidate corrections

This PR deprecates the old PR #637 because
- the old PR did not use candidate correction markup
- the old PR accidentally removed a part of the algorithm that should stay (that's what you get for writing PRs at 1am...)
- the old PR introduced a behavior change in the edge case where default language was undefined, but default base direction was, on the assumption that the old behavior was a bug. On second thought, I'd rather keep this for a separate issue if this is really a bug (if it is, it might also affect other algorithms, e.g. compaction).
- the changes in this PR are simpler, while achieving the same result


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/639.html" title="Last updated on Jun 15, 2025, 8:22 PM UTC (a04703d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/639/525f503...a04703d.html" title="Last updated on Jun 15, 2025, 8:22 PM UTC (a04703d)">Diff</a>