### PR TITLE
Tests t0112 and t0113 use 1.1-specific features

### DIFF
--- a/tests/compact-manifest.html
+++ b/tests/compact-manifest.html
@@ -3160,6 +3160,13 @@
             <dd>
               <a href='compact/0112-out.jsonld'>compact/0112-out.jsonld</a>
             </dd>
+            <dt>Options</dt>
+            <dd>
+              <dl class='options'>
+                <dt>specVersion</dt>
+                <dd>json-ld-1.1</dd>
+              </dl>
+            </dd>
           </dl>
         </dd>
         <dt id='t0113'>
@@ -3184,6 +3191,13 @@
             <dt>expect</dt>
             <dd>
               <a href='compact/0113-out.jsonld'>compact/0113-out.jsonld</a>
+            </dd>
+            <dt>Options</dt>
+            <dd>
+              <dl class='options'>
+                <dt>specVersion</dt>
+                <dd>json-ld-1.1</dd>
+              </dl>
             </dd>
           </dl>
         </dd>

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -946,7 +946,8 @@
       "purpose": "With @container: @index and @index a compact IRI, ensure round-tripping of compacted representation",
       "input": "compact/0112-in.jsonld",
       "context": "compact/0112-context.jsonld",
-      "expect": "compact/0112-out.jsonld"
+      "expect": "compact/0112-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
     }, {
       "@id": "#t0113",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -954,7 +955,8 @@
       "purpose": "With @container: @index and @index an absolute IRI, ensure round-tripping of compacted representation",
       "input": "compact/0113-in.jsonld",
       "context": "compact/0113-context.jsonld",
-      "expect": "compact/0113-out.jsonld"
+      "expect": "compact/0113-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
     }, {
       "@id": "#t0114",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],

--- a/tests/fromRdf-manifest.html
+++ b/tests/fromRdf-manifest.html
@@ -1421,11 +1421,11 @@
             <dd>List of lists</dd>
             <dt>input</dt>
             <dd>
-              <a href='fromRdf/li02-in.nq'>fromRdf/li02-in.nq</a>
+              <a href='fromRdf/li03-in.nq'>fromRdf/li03-in.nq</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='fromRdf/li02-out.jsonld'>fromRdf/li02-out.jsonld</a>
+              <a href='fromRdf/li03-out.jsonld'>fromRdf/li03-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>


### PR DESCRIPTION
and should have `specVersion: 1.1` to not interfer with 1.0 development.

Fixes #649.