### PR TITLE
(closes #656) convert `"1"^^xsd:boolean` and `"0"^^xsd:boolean` to native values

### DIFF
--- a/index.html
+++ b/index.html
@@ -5503,8 +5503,11 @@
                   of <var>value</var> equals <code>xsd:boolean</code>, set
                   <var>converted value</var> to <code>true</code> if the
                   <a>lexical form</a>
-                  of <var>value</var> matches <code>true</code>, or <code>false</code>
-                  if it matches <code>false</code>. If it matches neither,
+                  <ins cite="#change_5">
+                    of <var>value</var> matches <code>"true"</code> or <code>"1"</code>, or <code>false</code>
+                    if it matches <code>"false"</code> or <code>"0"</code>.
+                  </ins>
+                  If it matches neither,
                   set <var>type</var> to <code>xsd:boolean</code>.</li>
                 <li>Otherwise, if the
                   <a>datatype IRI</a>

--- a/index.html
+++ b/index.html
@@ -5503,9 +5503,9 @@
                   of <var>value</var> equals <code>xsd:boolean</code>, set
                   <var>converted value</var> to <code>true</code> if the
                   <a>lexical form</a>
-                  <ins cite="#change_5">
-                    of <var>value</var> matches <code>"true"</code> or <code>"1"</code>, or <code>false</code>
-                    if it matches <code>"false"</code> or <code>"0"</code>.
+                  
+                    of <var>value</var> matches <code>"true"</code><ins cite="#change_5"> or <code>"1"</code></ins>, or <code>false</code>
+                    if it matches <code>"false"</code><ins cite="#change_5"> or <code>"0"</code></ins>.
                   </ins>
                   If it matches neither,
                   set <var>type</var> to <code>xsd:boolean</code>.</li>

--- a/tests/fromRdf/0027-in.nq
+++ b/tests/fromRdf/0027-in.nq
@@ -1,6 +1,9 @@
 <http://example.com/boolean-native> <http://example.com/example> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
 <http://example.com/boolean-native> <http://example.com/example> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
 
+<http://example.com/boolean-number> <http://example.com/example> "1"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+<http://example.com/boolean-number> <http://example.com/example> "0"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+
 <http://example.com/boolean-object> <http://example.com/example> "True"^^<http://www.w3.org/2001/XMLSchema#boolean> .
 <http://example.com/boolean-object> <http://example.com/example> "False"^^<http://www.w3.org/2001/XMLSchema#boolean> .
 

--- a/tests/fromRdf/0027-out.jsonld
+++ b/tests/fromRdf/0027-out.jsonld
@@ -7,6 +7,13 @@
     ]
   },
   {
+    "@id": "http://example.com/boolean-number",
+    "http://example.com/example": [
+      {"@value": true},
+      {"@value": false}
+    ]
+  },
+  {
     "@id": "http://example.com/boolean-object",
     "http://example.com/example": [
       {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7843fb65-61fb-4bfe-ab2f-45620dca4654)

- **#656 Specify 0 and 1 as valid Boolean literals in RDF to Object conversion algorithm**
- **#656 Update fromRdf test 0027 to reflect 0 and 1 as valid Boolean values**


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/662.html" title="Last updated on Jun 20, 2025, 6:32 PM UTC (754c657)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/662/f32a438...754c657.html" title="Last updated on Jun 20, 2025, 6:32 PM UTC (754c657)">Diff</a>