### PR TITLE
Fix IDL definition of `LoadDocumentCallback`

### DIFF
--- a/index.html
+++ b/index.html
@@ -6572,7 +6572,7 @@
       <pre class="idl">
         callback LoadDocumentCallback = Promise&lt;RemoteDocument> (
           USVString url,
-          optional LoadDocumentOptions? options
+          optional LoadDocumentOptions options = {}
         );
       </pre>
 


### PR DESCRIPTION
Dictionary arguments cannot be nullable in Web IDL:

> "Although dictionary types can in general be nullable, they cannot when
used as the type of an operation argument or a dictionary member."
> https://webidl.spec.whatwg.org/#dfn-nullable-type

Note: this was missed before because the webidl2 checker did not validate arguments in callback definitions. It now does.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/json-ld-api/pull/664.html" title="Last updated on Jul 24, 2025, 8:02 AM UTC (b11a734)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/664/590f78d...tidoust:b11a734.html" title="Last updated on Jul 24, 2025, 8:02 AM UTC (b11a734)">Diff</a>