### PR TITLE
Improve test fromRdf#t0027.

### DIFF
--- a/tests/fromRdf/0027-in.nq
+++ b/tests/fromRdf/0027-in.nq
@@ -6,6 +6,7 @@
 
 <http://example.com/boolean-object> <http://example.com/example> "True"^^<http://www.w3.org/2001/XMLSchema#boolean> .
 <http://example.com/boolean-object> <http://example.com/example> "False"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+# NB: the two values above ("True" and "False") are *not* in the lexical space of xsd:bool, so they should be treated as any other invalid lexical form (like "notnative" below)
 <http://example.com/boolean-object> <http://example.com/example> "notnative"^^<http://www.w3.org/2001/XMLSchema#boolean> .
 
 <http://example.com/number-native> <http://example.com/example> "1"^^<http://www.w3.org/2001/XMLSchema#integer> .

--- a/tests/fromRdf/0027-in.nq
+++ b/tests/fromRdf/0027-in.nq
@@ -4,6 +4,8 @@
 <http://example.com/boolean-number> <http://example.com/example> "1"^^<http://www.w3.org/2001/XMLSchema#boolean> .
 <http://example.com/boolean-number> <http://example.com/example> "0"^^<http://www.w3.org/2001/XMLSchema#boolean> .
 
+<http://example.com/boolean-object> <http://example.com/example> "True"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+<http://example.com/boolean-object> <http://example.com/example> "False"^^<http://www.w3.org/2001/XMLSchema#boolean> .
 <http://example.com/boolean-object> <http://example.com/example> "notnative"^^<http://www.w3.org/2001/XMLSchema#boolean> .
 
 <http://example.com/number-native> <http://example.com/example> "1"^^<http://www.w3.org/2001/XMLSchema#integer> .

--- a/tests/fromRdf/0027-in.nq
+++ b/tests/fromRdf/0027-in.nq
@@ -4,11 +4,13 @@
 <http://example.com/boolean-number> <http://example.com/example> "1"^^<http://www.w3.org/2001/XMLSchema#boolean> .
 <http://example.com/boolean-number> <http://example.com/example> "0"^^<http://www.w3.org/2001/XMLSchema#boolean> .
 
-<http://example.com/boolean-object> <http://example.com/example> "True"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-<http://example.com/boolean-object> <http://example.com/example> "False"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+<http://example.com/boolean-object> <http://example.com/example> "notnative"^^<http://www.w3.org/2001/XMLSchema#boolean> .
 
 <http://example.com/number-native> <http://example.com/example> "1"^^<http://www.w3.org/2001/XMLSchema#integer> .
 
 <http://example.com/number-object> <http://example.com/example> "0.1e999999999999999"^^<http://www.w3.org/2001/XMLSchema#double> .
 <http://example.com/number-object> <http://example.com/example> "+INF"^^<http://www.w3.org/2001/XMLSchema#double> .
 <http://example.com/number-object> <http://example.com/example> "-INF"^^<http://www.w3.org/2001/XMLSchema#double> .
+
+<http://example.com/number-object> <http://example.com/example> "notnative"^^<http://www.w3.org/2001/XMLSchema#integer> .
+<http://example.com/number-object> <http://example.com/example> "notnative"^^<http://www.w3.org/2001/XMLSchema#double> .

--- a/tests/fromRdf/0027-out.jsonld
+++ b/tests/fromRdf/0027-out.jsonld
@@ -18,6 +18,14 @@
     "http://example.com/example": [
       {
         "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+        "@value": "True"
+      },
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#boolean",
+        "@value": "False"
+      },
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#boolean",
         "@value": "notnative"
       }
     ]

--- a/tests/fromRdf/0027-out.jsonld
+++ b/tests/fromRdf/0027-out.jsonld
@@ -18,11 +18,7 @@
     "http://example.com/example": [
       {
         "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-        "@value": "True"
-      },
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#boolean",
-        "@value": "False"
+        "@value": "notnative"
       }
     ]
   },
@@ -46,6 +42,14 @@
       {
         "@type": "http://www.w3.org/2001/XMLSchema#double",
         "@value": "-INF"
+      },
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#integer",
+        "@value": "notnative"
+      },
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#double",
+        "@value": "notnative"
       }
     ]
   }


### PR DESCRIPTION
- Improving the test coverage for use useNativeTypes algorithm in 8.5.2 2.4.
- Remove the "True" and "False" boolean tests that can cause confusion that those words are special values.
- Add tests using a value of "notnative" typed to boolean, integer, and double. These test that the type will be preserved when a native conversion does not happen.

I was fixing jsonld.js for fromRdf#t0027 and thought the tests could use some work to increase covearge.

https://github.com/w3c/json-ld-api/blob/main/tests/fromRdf/0027-in.nq
https://github.com/w3c/json-ld-api/blob/main/tests/fromRdf/0027-out.jsonld

I initially mistakenly tried to add specific support for the "True"/"False" tests:
```nq
<http://example.com/boolean-object> <http://example.com/example> "True"^^<http://www.w3.org/2001/XMLSchema#boolean> .
<http://example.com/boolean-object> <http://example.com/example> "False"^^<http://www.w3.org/2001/XMLSchema#boolean> .
```
But those are, I think, just testing that any not-native value is passed through even though it may not match semantics of the type.  I think some other value text should be used to avoid confusion.  For consistency, it probably makes sense to have similar tests for integers and doubles.  jsonld.js was dropping the type for non-integers typed as integers.

There might be other edge cases that should be tested here too. This does seem like an incremental improvement.

Possible relevant references:
https://w3c.github.io/json-ld-api/#algorithm-16
https://github.com/w3c/json-ld-api/issues/555
https://github.com/w3c/json-ld-api/issues/656
https://github.com/w3c/json-ld-api/pull/619
https://github.com/w3c/json-ld-api/pull/625
https://github.com/w3c/json-ld-api/pull/662
