### PR TITLE
Remove `<ins>` and `<del>` markup in preparation for 1.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -5479,7 +5479,7 @@
                   
                     of <var>value</var> matches <code>"true"</code> or <code>"1"</code>, or <code>false</code>
                     if it matches <code>"false"</code> or <code>"0"</code>.
-                  </ins>
+                  
                   If it matches neither,
                   set <var>type</var> to <code>xsd:boolean</code>.</li>
                 <li>Otherwise, if the

--- a/index.html
+++ b/index.html
@@ -1083,7 +1083,7 @@
     <p>The <a>active context</a> consists of:</p>
     <ul>
       <li>the active <a>term definitions</a> which specify how
-        keys and values have to be interpreted (<del cite="#change_api_638"><a>array</a></del><ins cite="#change_api_638"><a>map</a></ins> of <a>term definitions</a>),</li>
+        keys and values have to be interpreted (<a>map</a> of <a>term definitions</a>),</li>
       <li>the current <dfn data-lt="context-base-iri" data-lt-noDefault>base IRI</dfn> (<a>IRI</a>),</li>
       <li class="changed">the <dfn>original base URL</dfn> (<a>IRI</a>),</li>
       <li class="changed">an <dfn data-lt="context-inverse" data-lt-noDefault>inverse context</dfn> (<a>inverse context</a>),</li>
@@ -1094,7 +1094,7 @@
         used when a non-propagated <a>context</a> is defined.</li>
     </ul>
 
-    <p>Each <a>term definition</a><ins cite="#change_api_638">'s value</ins> consists of:</p>
+    <p>Each <a>term definition</a>'s value consists of:</p>
     <ul>
       <li>an <dfn>IRI mapping</dfn> (<a>IRI</a>),</li>
       <li class="changed">a <dfn>prefix flag</dfn> (<a>boolean</a>),</li>
@@ -1681,10 +1681,10 @@
             <li>Set the <a>term definition</a> of <var>term</var> in
               <var>active context</var> to <var>definition</var> and the
               value associated with <var>defined</var>'s <a>entry</a> <var>term</var> to
-              <code>true</code><del cite="#change_3"> and return</del>.</li>
+              <code>true</code>.</li>
           </ol>
         </li>
-        <li><ins cite="#change_3">Otherwise, if</ins><del cite="#change_3">If</del> <var>value</var> contains the <a>entry</a> <code>@id</code> and its value
+        <li>Otherwise, if <var>value</var> contains the <a>entry</a> <code>@id</code> and its value
           does not equal <var>term</var>:
           <ol>
             <li id="ctd-id-null">If the <code>@id</code> <a>entry</a> of <var>value</var>
@@ -2016,11 +2016,9 @@
           If the <var>active context</var> has a <a>default language</a>,
           set <var>default language</var> to the <a>default language</a> from the <var>active context</var>
           <span class="changed">normalized to lower case</span>.
-          <ins cite="#change_pr639">
-            If the <var>active context</var> has a <a>default base direction</a>,
-            concatenate its value to <var>default language</var>,
-            separated by an underscore (`"_"`).
-          </ins>
+          If the <var>active context</var> has a <a>default base direction</a>,
+          concatenate its value to <var>default language</var>,
+          separated by an underscore (`"_"`).
         </li>
         <li>For each key <a>term</a> and value <a>term definition</a> in
           the <var>active context</var>, ordered by shortest <a>term</a>
@@ -2133,32 +2131,11 @@
               </ol>
             </li>
             <li id="alg-inv-defaul-base-dir" class="changed">
-              <ins cite="#change_pr639"><em>(this step was removed by a <a href="#change_pr639">candidate correction</a>)</em></ins>
-              <del cite="#change_pr639">
-              Otherwise, if <var>active context</var> has a
-              <a>default base direction</a>:
-              <ol>
-                <li>Initialize a variable <var>lang dir</var>
-                  with the concatenation of <var>default language</var> and <a>default base direction</a>,
-                  separate by an underscore (`"_"`),
-                  normalized to lower case.</li>
-                <li>If <var>language map</var> does not have a <var>lang dir</var> <a>entry</a>,
-                  create one and set its value to the <a>term</a>
-                  being processed.</li>
-                <li>If <var>language map</var> does not have an `@none` <a>entry</a>,
-                  create one and set its value to the <a>term</a>
-                  being processed.</li>
-                <li>If <var>type map</var> does not have an `@none` <a>entry</a>,
-                  create one and set its value to the <a>term</a>
-                  being processed.</li>
-              </ol>
-              </del>
+              <em>(this step was removed by a <a href="#change_pr639">candidate correction</a>)</em>
             </li>
             <li>Otherwise:
               <ol>
-                <li>If <var>language map</var> does not have a <var>default language</var> <a>entry</a>,<del cite="#change_pr639">
-                  <span class="changed">(after being normalized to lower case)</span>,
-                  </del>
+                <li>If <var>language map</var> does not have a <var>default language</var> <a>entry</a>,
                   create one and set its value to the <a>term</a>
                   being processed.</li>
                 <li>If <var>language map</var> does not have an <code>@none</code>
@@ -3113,15 +3090,11 @@
                       For more information, refer to <a href="https://github.com/w3c/json-ld-api/issues/380">issue 380</a>.</p>
                   </div>
                   Recursively repeat steps
-                  <ins cite="#change_1">
-                    <a href="#alg-expand-property-scoped-context">3</a>,
-                    <a href="#alg-expand-property-scoped-context2">8</a>,
-                  </ins>
+                  <a href="#alg-expand-property-scoped-context">3</a>,
+                  <a href="#alg-expand-property-scoped-context2">8</a>,
                   <a href="#alg-expand-each-key-value">13</a>,
                   and <a href="#alg-expand-resolve-nest">14</a> using
-                  <ins cite="#change_1">
-                    <var>nesting-key</var> for <var>active property</var>, and
-                  </ins>
+                  <var>nesting-key</var> for <var>active property</var>, and
                   <var>nested value</var> for <var>element</var>.
                   <div class="note">Steps <a href="#alg-expand-property-scoped-context">3</a>
                     and <a href="#alg-expand-property-scoped-context2">8</a>
@@ -3918,7 +3891,7 @@
                       </div>
                       <ol>
                         <li id="alg-compact-12_8_9_6_1">Reinitialize <var>container key</var> by <a>IRI compacting</a>
-                          <var>index key</var><ins cite="#change_2"> after first <a>IRI expanding</a> it</ins>.</li>
+                          <var>index key</var> after first <a>IRI expanding</a> it.</li>
                         <li>Set <var>map key</var> to the first value of <var>container key</var> in <var>compacted item</var>, if any.</li>
                         <li id="alg-compact-12_8_9_6_3">If there are remaining values in <var>compacted item</var>
                           for <var>container key</var>, use <a>add value</a> to
@@ -5504,8 +5477,8 @@
                   <var>converted value</var> to <code>true</code> if the
                   <a>lexical form</a>
                   
-                    of <var>value</var> matches <code>"true"</code><ins cite="#change_5"> or <code>"1"</code></ins>, or <code>false</code>
-                    if it matches <code>"false"</code><ins cite="#change_5"> or <code>"0"</code></ins>.
+                    of <var>value</var> matches <code>"true"</code> or <code>"1"</code>, or <code>false</code>
+                    if it matches <code>"false"</code> or <code>"0"</code>.
                   </ins>
                   If it matches neither,
                   set <var>type</var> to <code>xsd:boolean</code>.</li>
@@ -5515,30 +5488,30 @@
                   <code>xsd:double</code> and its
                   <a>lexical form</a>
                   is a valid <code>xsd:integer</code> or <code>xsd:double</code>
-                  according to [[XMLSCHEMA11-2]]<del cite="#change_5">,
-                    set <var>converted value</var>
-                    to the result of converting the
-                    <a>lexical form</a>
-                    to a JSON <a>number</a>.
-                  </del><ins cite="#change_5">:
-                    <ol>
-                      <li>
-                        Attempt to convert the <a>lexical form</a> to a <a>JSON number</a>
-                        according to the
-                        [[RFC8785]] <a data-cite="RFC8785#name-serialization-of-numbers">
-                          JSON Serialization Scheme (JCS) 3.2.2.3 Serialization of Numbers
-                        </a> procedure.
-                      </li>
-                      <li>
-                        If the conversion is successful, set <var>converted value</var>
-                        to its result.
-                      </li>
-                      <li>
-                        Otherwise, set <var>type</var> to <a>datatype IRI</a>
-                        of <var>value</var>.
-                      </li>
-                    </ol>
-                  </ins>
+                  according to [[XMLSCHEMA11-2]],
+                  set <var>converted value</var>
+                  to the result of converting the
+                  <a>lexical form</a>
+                  to a JSON <a>number</a>.
+                  :
+                  <ol>
+                    <li>
+                      Attempt to convert the <a>lexical form</a> to a <a>JSON number</a>
+                      according to the
+                      [[RFC8785]] <a data-cite="RFC8785#name-serialization-of-numbers">
+                        JSON Serialization Scheme (JCS) 3.2.2.3 Serialization of Numbers
+                      </a> procedure.
+                    </li>
+                    <li>
+                      If the conversion is successful, set <var>converted value</var>
+                      to its result.
+                    </li>
+                    <li>
+                      Otherwise, set <var>type</var> to <a>datatype IRI</a>
+                      of <var>value</var>.
+                    </li>
+                  </ol>
+
                 </li>
               </ol>
             </li>
@@ -5788,11 +5761,11 @@
       <p>For more information, refer to <a href="https://github.com/w3c/json-ld-api/issues/605">issue 605</a>.</p>
     </div>
 
-    <ins cite="#change_7"><p>Methods resolving a {{Promise}} with the <a>internal representation</a>
+    <p>Methods resolving a {{Promise}} with the <a>internal representation</a>
       MUST either
       map it to the datatype used by the implementation, as described in <a href="#internal-representation-in-implementations" class="sectionRef"></a>,
       or serialize it to JSON (or another appropriate serialization format)
-      as described in <a href="#serialization-and-deserialization" class="sectionRef"></a>.</p></ins>
+      as described in <a href="#serialization-and-deserialization" class="sectionRef"></a>.</p>
 
     <pre class="idl">
       /*
@@ -5898,9 +5871,7 @@
                 to the provided <var>context</var>.</li>
             </ol>
           </li>
-          <li id="idl-compact-step-10">Resolve the <var>promise</var> with <var>compacted output</var><del cite="#change_7">
-            transforming <var>compacted output</var> from the
-            <a>internal representation</a> to a JSON serialization</del>.</li>
+          <li id="idl-compact-step-10">Resolve the <var>promise</var> with <var>compacted output</var>.</li>
         </ol>
 
         <dl class="parameters">
@@ -5986,9 +5957,7 @@
                 set <var>expanded output</var> to an <a>array</a> containing only <var>expanded output</var>.</li>
             </ol>
           </li>
-          <li id="idl-expand-step-9">Resolve the <var>promise</var> with <var>expanded output</var><del cite="#change_7">
-            transforming <var>expanded output</var> from the
-            <a>internal representation</a> to a JSON serialization</del>.</li>
+          <li id="idl-expand-step-9">Resolve the <var>promise</var> with <var>expanded output</var>.</li>
         </ol>
 
         <dl class="parameters">
@@ -6050,9 +6019,7 @@
                 otherwise to <code>null</code>.</li>
             </ol>
           </li>
-          <li id="idl-flatten-step-7">Resolve the <var>promise</var> with <var>flattened output</var><del cite="#change_7">
-            transforming <var>flattened output</var> from the
-            <a>internal representation</a> to a JSON serialization</del>.</li>
+          <li id="idl-flatten-step-7">Resolve the <var>promise</var> with <var>flattened output</var>.</li>
         </ol>
 
         <dl class="parameters">
@@ -6090,9 +6057,7 @@
             <a href="#serialize-rdf-as-json-ld-algorithm">Serialize RDF as JSON-LD Algorithm</a> method
             using <a data-lt="jsonldprocessor-fromRdf-input">dataset</a>
             and <a data-lt="jsonldprocessor-fromRdf-options">options</a>.</li>
-          <li id="idl-fromRdf-step-3">Resolve the <var>promise</var> with <var>expanded result</var><del cite="#change_7">
-            transforming <var>expanded output</var> from the
-            <a>internal representation</a> to a JSON serialization</del>.</li>
+          <li id="idl-fromRdf-step-3">Resolve the <var>promise</var> with <var>expanded result</var>.</li>
         </ol>
 
         <dl class="parameters">
@@ -6127,8 +6092,8 @@
             <a data-link-for="JsonLdProcessor">expand()</a> method
             using <a data-lt="jsonldprocessor-toRdf-input">input</a>
             and <a data-lt="jsonldprocessor-toRdf-options">options</a>
-            <span class="changed">with {{JsonLdOptions/ordered}} set to <code>false</code><ins cite="#change_4">,
-              and {{JsonLdOptions/extractAllScripts}} defaulting to <code>true</code></ins></span>.</li>
+            <span class="changed">with {{JsonLdOptions/ordered}} set to <code>false</code>,
+              and {{JsonLdOptions/extractAllScripts}} defaulting to <code>true</code></span>.</li>
           <li>Create a new <a>RdfDataset</a> <var>dataset</var>.</li>
           <li>Create a new <a>map</a> <var>node map</var>.</li>
           <li>Invoke the <a href="#node-map-generation">Node Map Generation algorithm</a>,
@@ -6283,37 +6248,34 @@
 
     <section id="serialization-and-deserialization">
       <h4>Serialization and Deserialization</h4>
-    <ins cite="#change_7">
+    <p>This section defines the requirements for serializing and deserializing
+      JSON from and to the <a>internal representation</a>, as appropriate,
+      based on the provided or requested <a>Content-Type</a>.
+      A <a>Content-Type</a> of <code>application/json</code>,
+      or media type with a <code>+json</code> suffix as defined in [[RFC6839]]
+      MUST serialize or deserialize to a format consistent with the JSON Grammar
+      as specified in [[RFC8259]].</p>
 
-      <p>This section defines the requirements for serializing and deserializing
-        JSON from and to the <a>internal representation</a>, as appropriate,
-        based on the provided or requested <a>Content-Type</a>.
-        A <a>Content-Type</a> of <code>application/json</code>,
-        or media type with a <code>+json</code> suffix as defined in [[RFC6839]]
-        MUST serialize or deserialize to a format consistent with the JSON Grammar
-        as specified in [[RFC8259]].</p>
+    <p class="note">This specification does not define serializations of the <a>internal representation</a>
+      for other media types, which may be defined by other specifications.</p>
 
-      <p class="note">This specification does not define serializations of the <a>internal representation</a>
-        for other media types, which may be defined by other specifications.</p>
+    <p class="note">See <a href="#html-content-algorithms" class="sectionRef"></a>
+      for details on extracting JSON from HTML.</p>
 
-      <p class="note">See <a href="#html-content-algorithms" class="sectionRef"></a>
-        for details on extracting JSON from HTML.</p>
+    <dl>
+      <dt>To transform a JSON-conforming string [[RFC8259]],</dt>
+      <dd>
+        deserialize into the
+        <a>internal representation</a> as described in {{LoadDocumentCallback}};
+      </dd>
 
-      <dl>
-        <dt>To transform a JSON-conforming string [[RFC8259]],</dt>
-        <dd>
-          deserialize into the
-          <a>internal representation</a> as described in {{LoadDocumentCallback}};
-        </dd>
-
-        <dt>To transform the <a>internal representation</a> to a JSON-LD document
-        </dt>
-        <dd>
-          serialize to JSON [[RFC8259]] using an appropriate serializer (e.g.,
-          [[ECMASCRIPT]] <code>[=ToString=]</code>);
-        </dd>
-      </dl>
-    </ins>
+      <dt>To transform the <a>internal representation</a> to a JSON-LD document
+      </dt>
+      <dd>
+        serialize to JSON [[RFC8259]] using an appropriate serializer (e.g.,
+        [[ECMASCRIPT]] <code>[=ToString=]</code>);
+      </dd>
+    </dl>
   </section>
   </section>
 
@@ -6623,12 +6585,11 @@
           <p class="note">The HTTP Link Header is ignored for documents served as <code>application/ld+json</code>,
             <code>text/html</code>, or <code>application/xhtml+xml</code>.</p>
         </li>
-        <li>Otherwise, <ins cite="#change_6">if</ins> the retrieved document's <a>Content-Type</a> is neither
+        <li>Otherwise, if the retrieved document's <a>Content-Type</a> is neither
           <code>application/json</code>,
           <code>application/ld+json</code>,
           nor any other media type using a
-          <code>+json</code> suffix as defined in [[RFC6839]]<del cite="#change_6">.
-            Reject</del><ins cite="#change_6">, then reject</ins>
+          <code>+json</code> suffix as defined in [[RFC6839]], then reject
           the <var>promise</var> passing a <a data-link-for="JsonLdErrorCode">loading document failed</a> error.
           <div class="candidate correction" id="change_6">
             <span class="marker">Candidate Correction 6</span>

--- a/index.html
+++ b/index.html
@@ -5488,12 +5488,7 @@
                   <code>xsd:double</code> and its
                   <a>lexical form</a>
                   is a valid <code>xsd:integer</code> or <code>xsd:double</code>
-                  according to [[XMLSCHEMA11-2]],
-                  set <var>converted value</var>
-                  to the result of converting the
-                  <a>lexical form</a>
-                  to a JSON <a>number</a>.
-                  :
+                  according to [[XMLSCHEMA11-2]]:
                   <ol>
                     <li>
                       Attempt to convert the <a>lexical form</a> to a <a>JSON number</a>


### PR DESCRIPTION
This removes all `<ins>` and `<del>` markup in the document. There may still be artefacts left that relate to these, so we may need to think about the scope of this PR (see comments).

If I got it right, we want this in preparation for JSON-LD 1.2 working drafts, along with other important changes (title, correct "What's new in 1.2", change use of `class="changed"`...). Do we want these other changes in separate PR:s, or a bigger branch for all the prep work?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/niklasl/json-ld-api/pull/676.html" title="Last updated on Jun 3, 2026, 4:49 PM UTC (c18662d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/676/590f78d...niklasl:c18662d.html" title="Last updated on Jun 3, 2026, 4:49 PM UTC (c18662d)">Diff</a>