### PR TITLE
`LoadDocumentOptions` default value syntax is invalid

### DIFF
--- a/index.html
+++ b/index.html
@@ -6572,7 +6572,7 @@
       <pre class="idl">
         callback LoadDocumentCallback = Promise&lt;RemoteDocument> (
           USVString url,
-          optional LoadDocumentOptions? options
+          optional LoadDocumentOptions options = {}
         );
       </pre>
 


### PR DESCRIPTION
It would seem the spec won't build on `main`. I think there is a small fix to make it build.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/680.html" title="Last updated on Feb 22, 2026, 7:57 PM UTC (3f9a1ed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/680/590f78d...3f9a1ed.html" title="Last updated on Feb 22, 2026, 7:57 PM UTC (3f9a1ed)">Diff</a>