### PR TITLE
Fix nullable LoadDocumentOptions callback argument

### DIFF
--- a/index.html
+++ b/index.html
@@ -6572,7 +6572,7 @@
       <pre class="idl">
         callback LoadDocumentCallback = Promise&lt;RemoteDocument> (
           USVString url,
-          optional LoadDocumentOptions? options
+          optional LoadDocumentOptions options = {}
         );
       </pre>
 


### PR DESCRIPTION
## Summary
- make the `LoadDocumentCallback` options argument a non-nullable dictionary with an explicit empty default
- align the IDL with ReSpec WebIDL validation
- fix the CI failure in the `Build and Validate` job

## Testing
- `python3 -m http.server 3000`
- `npx --yes respec -s "http://localhost:3000/index.html?gitRevision=HEAD" -o /tmp/json-ld-api-built.html --verbose -t 20 -e`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/684.html" title="Last updated on Apr 4, 2026, 6:01 PM UTC (77d7605)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/684/590f78d...77d7605.html" title="Last updated on Apr 4, 2026, 6:01 PM UTC (77d7605)">Diff</a>