### PR TITLE
tests: add expand #t0132 (@base vs property keys)

### DIFF
--- a/index.html
+++ b/index.html
@@ -6572,7 +6572,7 @@
       <pre class="idl">
         callback LoadDocumentCallback = Promise&lt;RemoteDocument> (
           USVString url,
-          optional LoadDocumentOptions? options
+          optional LoadDocumentOptions options = {}
         );
       </pre>
 

--- a/index.html
+++ b/index.html
@@ -6572,7 +6572,7 @@
       <pre class="idl">
         callback LoadDocumentCallback = Promise&lt;RemoteDocument> (
           USVString url,
-          optional LoadDocumentOptions options = {}
+          optional LoadDocumentOptions? options
         );
       </pre>
 

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -1,17 +1,17 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
     <title>
       Expansion
     </title>
-    <link href='expand-manifest.jsonld' rel='alternate'>
-    <link href='https://www.w3.org/StyleSheets/TR/base' rel='stylesheet'>
+    <link href="expand-manifest.jsonld" rel="alternate">
+    <link href="https://www.w3.org/StyleSheets/TR/base" rel="stylesheet">
   </head>
   <body>
     <p>
-      <a href='http://www.w3.org/'>
-        <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
+      <a href="http://www.w3.org/">
+        <img alt="W3C" height="48" src="http://www.w3.org/Icons/w3c_home" width="72">
       </a>
     </p>
     <h1>Expansion</h1>
@@ -69,13 +69,13 @@
         that you will be creating a new test or fix and the purpose of the
         change.</li>
       <li>Clone the git repository: git://github.com/w3c/json-ld-api.git</li>
-      <li>Make your changes and submit them via github, or via a &#39;git format-patch&#39;
+      <li>Make your changes and submit them via github, or via a 'git format-patch'
         to the <a href="mailto:json-ld-wg@w3.org">JSON-LD Working Group mailing list</a>.</li>
     </ol>
     <h2>Distribution</h2>
-    <p>Distributed under the <a href="http://www.w3.org/Consortium/Legal/2008/04-testsuite-license">W3C Test Suite License</a>. To contribute to a W3C Test Suite, see the <a href="http://www.w3.org/2004/10/27-testcases">policies and contribution forms</a>.</p>
+    <p>  Distributed under the <a href="http://www.w3.org/Consortium/Legal/2008/04-testsuite-license">W3C Test Suite License</a>. To contribute to a W3C Test Suite, see the <a href="http://www.w3.org/2004/10/27-testcases">policies and contribution forms</a>.</p>
     <h2>Disclaimer</h2>
-    <p>UNDER THE EXCLUSIVE LICENSE, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED &quot;AS IS,&quot; AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+    <p>  UNDER THE EXCLUSIVE LICENSE, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
       COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
     <dl>
       <dt>baseIri</dt>
@@ -85,12 +85,12 @@
       <h2>
         Test sequence:
       </h2>
-      <dl class='entries'>
-        <dt id='t0001'>
+      <dl class="entries">
+        <dt id="t0001">
           Test t0001 drop free-floating nodes
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0001</dd>
             <dt>Type</dt>
@@ -99,19 +99,19 @@
             <dd>Expand drops unreferenced nodes having only @id</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0001-in.jsonld'>expand/0001-in.jsonld</a>
+              <a href="expand/0001-in.jsonld">expand/0001-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0001-out.jsonld'>expand/0001-out.jsonld</a>
+              <a href="expand/0001-out.jsonld">expand/0001-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0002'>
+        <dt id="t0002">
           Test t0002 basic
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0002</dd>
             <dt>Type</dt>
@@ -120,19 +120,19 @@
             <dd>Expanding terms with different types of values</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0002-in.jsonld'>expand/0002-in.jsonld</a>
+              <a href="expand/0002-in.jsonld">expand/0002-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0002-out.jsonld'>expand/0002-out.jsonld</a>
+              <a href="expand/0002-out.jsonld">expand/0002-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0003'>
+        <dt id="t0003">
           Test t0003 drop null and unmapped properties
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0003</dd>
             <dt>Type</dt>
@@ -141,19 +141,19 @@
             <dd>Verifies that null values and unmapped properties are removed from expanded output</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0003-in.jsonld'>expand/0003-in.jsonld</a>
+              <a href="expand/0003-in.jsonld">expand/0003-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0003-out.jsonld'>expand/0003-out.jsonld</a>
+              <a href="expand/0003-out.jsonld">expand/0003-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0004'>
+        <dt id="t0004">
           Test t0004 optimize @set, keep empty arrays
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0004</dd>
             <dt>Type</dt>
@@ -162,19 +162,19 @@
             <dd>Uses of @set are removed in expansion; values of @set, or just plain values which are empty arrays are retained</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0004-in.jsonld'>expand/0004-in.jsonld</a>
+              <a href="expand/0004-in.jsonld">expand/0004-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0004-out.jsonld'>expand/0004-out.jsonld</a>
+              <a href="expand/0004-out.jsonld">expand/0004-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0005'>
+        <dt id="t0005">
           Test t0005 do not expand aliased @id/@type
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0005</dd>
             <dt>Type</dt>
@@ -183,19 +183,19 @@
             <dd>If a keyword is aliased, it is not used when expanding</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0005-in.jsonld'>expand/0005-in.jsonld</a>
+              <a href="expand/0005-in.jsonld">expand/0005-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0005-out.jsonld'>expand/0005-out.jsonld</a>
+              <a href="expand/0005-out.jsonld">expand/0005-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0006'>
+        <dt id="t0006">
           Test t0006 alias keywords
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0006</dd>
             <dt>Type</dt>
@@ -204,19 +204,19 @@
             <dd>Aliased keywords expand in resulting document</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0006-in.jsonld'>expand/0006-in.jsonld</a>
+              <a href="expand/0006-in.jsonld">expand/0006-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0006-out.jsonld'>expand/0006-out.jsonld</a>
+              <a href="expand/0006-out.jsonld">expand/0006-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0007'>
+        <dt id="t0007">
           Test t0007 date type-coercion
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0007</dd>
             <dt>Type</dt>
@@ -225,19 +225,19 @@
             <dd>Expand strings to expanded value with @type: xsd:dateTime</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0007-in.jsonld'>expand/0007-in.jsonld</a>
+              <a href="expand/0007-in.jsonld">expand/0007-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0007-out.jsonld'>expand/0007-out.jsonld</a>
+              <a href="expand/0007-out.jsonld">expand/0007-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0008'>
+        <dt id="t0008">
           Test t0008 @value with @language
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0008</dd>
             <dt>Type</dt>
@@ -246,19 +246,19 @@
             <dd>Keep expanded values with @language, drop non-conforming value objects containing just @language</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0008-in.jsonld'>expand/0008-in.jsonld</a>
+              <a href="expand/0008-in.jsonld">expand/0008-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0008-out.jsonld'>expand/0008-out.jsonld</a>
+              <a href="expand/0008-out.jsonld">expand/0008-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0009'>
+        <dt id="t0009">
           Test t0009 @graph with terms
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0009</dd>
             <dt>Type</dt>
@@ -267,19 +267,19 @@
             <dd>Use of @graph to contain multiple nodes within array</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0009-in.jsonld'>expand/0009-in.jsonld</a>
+              <a href="expand/0009-in.jsonld">expand/0009-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0009-out.jsonld'>expand/0009-out.jsonld</a>
+              <a href="expand/0009-out.jsonld">expand/0009-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0010'>
+        <dt id="t0010">
           Test t0010 native types
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0010</dd>
             <dt>Type</dt>
@@ -288,19 +288,19 @@
             <dd>Expanding native scalar retains native scalar within expanded value</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0010-in.jsonld'>expand/0010-in.jsonld</a>
+              <a href="expand/0010-in.jsonld">expand/0010-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0010-out.jsonld'>expand/0010-out.jsonld</a>
+              <a href="expand/0010-out.jsonld">expand/0010-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0011'>
+        <dt id="t0011">
           Test t0011 coerced @id
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0011</dd>
             <dt>Type</dt>
@@ -309,19 +309,19 @@
             <dd>A value of a property with @type: @id coercion expands to a node reference</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0011-in.jsonld'>expand/0011-in.jsonld</a>
+              <a href="expand/0011-in.jsonld">expand/0011-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0011-out.jsonld'>expand/0011-out.jsonld</a>
+              <a href="expand/0011-out.jsonld">expand/0011-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0012'>
+        <dt id="t0012">
           Test t0012 @graph with embed
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0012</dd>
             <dt>Type</dt>
@@ -330,19 +330,19 @@
             <dd>Use of @graph to contain multiple nodes within array</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0012-in.jsonld'>expand/0012-in.jsonld</a>
+              <a href="expand/0012-in.jsonld">expand/0012-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0012-out.jsonld'>expand/0012-out.jsonld</a>
+              <a href="expand/0012-out.jsonld">expand/0012-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0013'>
+        <dt id="t0013">
           Test t0013 expand already expanded
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0013</dd>
             <dt>Type</dt>
@@ -351,19 +351,19 @@
             <dd>Expand does not mess up already expanded document</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0013-in.jsonld'>expand/0013-in.jsonld</a>
+              <a href="expand/0013-in.jsonld">expand/0013-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0013-out.jsonld'>expand/0013-out.jsonld</a>
+              <a href="expand/0013-out.jsonld">expand/0013-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0014'>
+        <dt id="t0014">
           Test t0014 @set of @value objects with keyword aliases
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0014</dd>
             <dt>Type</dt>
@@ -372,19 +372,19 @@
             <dd>Expanding aliased @set and @value</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0014-in.jsonld'>expand/0014-in.jsonld</a>
+              <a href="expand/0014-in.jsonld">expand/0014-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0014-out.jsonld'>expand/0014-out.jsonld</a>
+              <a href="expand/0014-out.jsonld">expand/0014-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0015'>
+        <dt id="t0015">
           Test t0015 collapse set of sets, keep empty lists
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0015</dd>
             <dt>Type</dt>
@@ -393,19 +393,19 @@
             <dd>An array of multiple @set nodes are collapsed into a single array</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0015-in.jsonld'>expand/0015-in.jsonld</a>
+              <a href="expand/0015-in.jsonld">expand/0015-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0015-out.jsonld'>expand/0015-out.jsonld</a>
+              <a href="expand/0015-out.jsonld">expand/0015-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0016'>
+        <dt id="t0016">
           Test t0016 context reset
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0016</dd>
             <dt>Type</dt>
@@ -414,19 +414,19 @@
             <dd>Setting @context to null within an embedded object resets back to initial context state</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0016-in.jsonld'>expand/0016-in.jsonld</a>
+              <a href="expand/0016-in.jsonld">expand/0016-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0016-out.jsonld'>expand/0016-out.jsonld</a>
+              <a href="expand/0016-out.jsonld">expand/0016-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0017'>
+        <dt id="t0017">
           Test t0017 @graph and @id aliased
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0017</dd>
             <dt>Type</dt>
@@ -435,19 +435,19 @@
             <dd>Expanding with @graph and @id aliases</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0017-in.jsonld'>expand/0017-in.jsonld</a>
+              <a href="expand/0017-in.jsonld">expand/0017-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0017-out.jsonld'>expand/0017-out.jsonld</a>
+              <a href="expand/0017-out.jsonld">expand/0017-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0018'>
+        <dt id="t0018">
           Test t0018 override default @language
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0018</dd>
             <dt>Type</dt>
@@ -456,19 +456,19 @@
             <dd>override default @language in terms; only language-tag strings</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0018-in.jsonld'>expand/0018-in.jsonld</a>
+              <a href="expand/0018-in.jsonld">expand/0018-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0018-out.jsonld'>expand/0018-out.jsonld</a>
+              <a href="expand/0018-out.jsonld">expand/0018-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0019'>
+        <dt id="t0019">
           Test t0019 remove @value = null
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0019</dd>
             <dt>Type</dt>
@@ -477,19 +477,19 @@
             <dd>Expanding a value of null removes the value</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0019-in.jsonld'>expand/0019-in.jsonld</a>
+              <a href="expand/0019-in.jsonld">expand/0019-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0019-out.jsonld'>expand/0019-out.jsonld</a>
+              <a href="expand/0019-out.jsonld">expand/0019-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0020'>
+        <dt id="t0020">
           Test t0020 do not remove @graph if not at top-level
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0020</dd>
             <dt>Type</dt>
@@ -498,19 +498,19 @@
             <dd>@graph used under a node is retained</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0020-in.jsonld'>expand/0020-in.jsonld</a>
+              <a href="expand/0020-in.jsonld">expand/0020-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0020-out.jsonld'>expand/0020-out.jsonld</a>
+              <a href="expand/0020-out.jsonld">expand/0020-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0021'>
+        <dt id="t0021">
           Test t0021 do not remove @graph at top-level if not only property
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0021</dd>
             <dt>Type</dt>
@@ -519,19 +519,19 @@
             <dd>@graph used at the top level is retained if there are other properties</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0021-in.jsonld'>expand/0021-in.jsonld</a>
+              <a href="expand/0021-in.jsonld">expand/0021-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0021-out.jsonld'>expand/0021-out.jsonld</a>
+              <a href="expand/0021-out.jsonld">expand/0021-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0022'>
+        <dt id="t0022">
           Test t0022 expand value with default language
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0022</dd>
             <dt>Type</dt>
@@ -540,19 +540,19 @@
             <dd>Expanding with a default language applies that language to string values</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0022-in.jsonld'>expand/0022-in.jsonld</a>
+              <a href="expand/0022-in.jsonld">expand/0022-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0022-out.jsonld'>expand/0022-out.jsonld</a>
+              <a href="expand/0022-out.jsonld">expand/0022-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0023'>
+        <dt id="t0023">
           Test t0023 Expanding list/set with coercion
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0023</dd>
             <dt>Type</dt>
@@ -561,19 +561,19 @@
             <dd>Expanding lists and sets with properties having coercion coerces list/set values</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0023-in.jsonld'>expand/0023-in.jsonld</a>
+              <a href="expand/0023-in.jsonld">expand/0023-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0023-out.jsonld'>expand/0023-out.jsonld</a>
+              <a href="expand/0023-out.jsonld">expand/0023-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0024'>
+        <dt id="t0024">
           Test t0024 Multiple contexts
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0024</dd>
             <dt>Type</dt>
@@ -582,19 +582,19 @@
             <dd>Tests that contexts in an array are merged</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0024-in.jsonld'>expand/0024-in.jsonld</a>
+              <a href="expand/0024-in.jsonld">expand/0024-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0024-out.jsonld'>expand/0024-out.jsonld</a>
+              <a href="expand/0024-out.jsonld">expand/0024-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0025'>
+        <dt id="t0025">
           Test t0025 Problematic IRI expansion tests
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0025</dd>
             <dt>Type</dt>
@@ -603,19 +603,19 @@
             <dd>Expanding different kinds of terms and Compact IRIs</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0025-in.jsonld'>expand/0025-in.jsonld</a>
+              <a href="expand/0025-in.jsonld">expand/0025-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0025-out.jsonld'>expand/0025-out.jsonld</a>
+              <a href="expand/0025-out.jsonld">expand/0025-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0026'>
+        <dt id="t0026">
           Test t0026 Term definition with @id: @type
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0026</dd>
             <dt>Type</dt>
@@ -624,26 +624,26 @@
             <dd>Expanding term mapping to @type uses @type syntax</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0026-in.jsonld'>expand/0026-in.jsonld</a>
+              <a href="expand/0026-in.jsonld">expand/0026-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0026-out.jsonld'>expand/0026-out.jsonld</a>
+              <a href="expand/0026-out.jsonld">expand/0026-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.0</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0027'>
+        <dt id="t0027">
           Test t0027 Duplicate values in @list and @set
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0027</dd>
             <dt>Type</dt>
@@ -652,19 +652,19 @@
             <dd>Duplicate values in @list and @set are not merged</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0027-in.jsonld'>expand/0027-in.jsonld</a>
+              <a href="expand/0027-in.jsonld">expand/0027-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0027-out.jsonld'>expand/0027-out.jsonld</a>
+              <a href="expand/0027-out.jsonld">expand/0027-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0028'>
+        <dt id="t0028">
           Test t0028 Use @vocab in properties and @type but not in @id
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0028</dd>
             <dt>Type</dt>
@@ -673,19 +673,19 @@
             <dd>@vocab is used to compact properties and @type, but is not used for @id</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0028-in.jsonld'>expand/0028-in.jsonld</a>
+              <a href="expand/0028-in.jsonld">expand/0028-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0028-out.jsonld'>expand/0028-out.jsonld</a>
+              <a href="expand/0028-out.jsonld">expand/0028-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0029'>
+        <dt id="t0029">
           Test t0029 Relative IRIs
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0029</dd>
             <dt>Type</dt>
@@ -694,19 +694,19 @@
             <dd>@base is used to compact @id; test with different relative IRIs</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0029-in.jsonld'>expand/0029-in.jsonld</a>
+              <a href="expand/0029-in.jsonld">expand/0029-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0029-out.jsonld'>expand/0029-out.jsonld</a>
+              <a href="expand/0029-out.jsonld">expand/0029-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0030'>
+        <dt id="t0030">
           Test t0030 Language maps
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0030</dd>
             <dt>Type</dt>
@@ -715,19 +715,19 @@
             <dd>Language Maps expand values to include @language</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0030-in.jsonld'>expand/0030-in.jsonld</a>
+              <a href="expand/0030-in.jsonld">expand/0030-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0030-out.jsonld'>expand/0030-out.jsonld</a>
+              <a href="expand/0030-out.jsonld">expand/0030-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0031'>
+        <dt id="t0031">
           Test t0031 type-coercion of native types
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0031</dd>
             <dt>Type</dt>
@@ -736,19 +736,19 @@
             <dd>Expanding native types with type coercion adds the coerced type to an expanded value representation and retains the native value representation</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0031-in.jsonld'>expand/0031-in.jsonld</a>
+              <a href="expand/0031-in.jsonld">expand/0031-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0031-out.jsonld'>expand/0031-out.jsonld</a>
+              <a href="expand/0031-out.jsonld">expand/0031-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0032'>
+        <dt id="t0032">
           Test t0032 Null term and @vocab
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0032</dd>
             <dt>Type</dt>
@@ -757,19 +757,19 @@
             <dd>Mapping a term to null decouples it from @vocab</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0032-in.jsonld'>expand/0032-in.jsonld</a>
+              <a href="expand/0032-in.jsonld">expand/0032-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0032-out.jsonld'>expand/0032-out.jsonld</a>
+              <a href="expand/0032-out.jsonld">expand/0032-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0033'>
+        <dt id="t0033">
           Test t0033 Using @vocab with with type-coercion
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0033</dd>
             <dt>Type</dt>
@@ -778,19 +778,19 @@
             <dd>Verifies that terms can be defined using @vocab</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0033-in.jsonld'>expand/0033-in.jsonld</a>
+              <a href="expand/0033-in.jsonld">expand/0033-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0033-out.jsonld'>expand/0033-out.jsonld</a>
+              <a href="expand/0033-out.jsonld">expand/0033-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0034'>
+        <dt id="t0034">
           Test t0034 Multiple properties expanding to the same IRI
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0034</dd>
             <dt>Type</dt>
@@ -799,19 +799,19 @@
             <dd>Verifies multiple values from separate terms are deterministically made multiple values of the IRI associated with the terms</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0034-in.jsonld'>expand/0034-in.jsonld</a>
+              <a href="expand/0034-in.jsonld">expand/0034-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0034-out.jsonld'>expand/0034-out.jsonld</a>
+              <a href="expand/0034-out.jsonld">expand/0034-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0035'>
+        <dt id="t0035">
           Test t0035 Language maps with @vocab, default language, and colliding property
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0035</dd>
             <dt>Type</dt>
@@ -820,19 +820,19 @@
             <dd>Pathological tests of language maps</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0035-in.jsonld'>expand/0035-in.jsonld</a>
+              <a href="expand/0035-in.jsonld">expand/0035-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0035-out.jsonld'>expand/0035-out.jsonld</a>
+              <a href="expand/0035-out.jsonld">expand/0035-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0036'>
+        <dt id="t0036">
           Test t0036 Expanding @index
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0036</dd>
             <dt>Type</dt>
@@ -841,19 +841,19 @@
             <dd>Expanding index maps for terms defined with @container: @index</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0036-in.jsonld'>expand/0036-in.jsonld</a>
+              <a href="expand/0036-in.jsonld">expand/0036-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0036-out.jsonld'>expand/0036-out.jsonld</a>
+              <a href="expand/0036-out.jsonld">expand/0036-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0037'>
+        <dt id="t0037">
           Test t0037 Expanding @reverse
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0037</dd>
             <dt>Type</dt>
@@ -862,19 +862,19 @@
             <dd>Expanding @reverse keeps @reverse</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0037-in.jsonld'>expand/0037-in.jsonld</a>
+              <a href="expand/0037-in.jsonld">expand/0037-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0037-out.jsonld'>expand/0037-out.jsonld</a>
+              <a href="expand/0037-out.jsonld">expand/0037-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0038'>
+        <dt id="t0038">
           Test t0038 Expanding blank node labels
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0038</dd>
             <dt>Type</dt>
@@ -883,26 +883,26 @@
             <dd>Blank nodes are not relabeled during expansion</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0038-in.jsonld'>expand/0038-in.jsonld</a>
+              <a href="expand/0038-in.jsonld">expand/0038-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0038-out.jsonld'>expand/0038-out.jsonld</a>
+              <a href="expand/0038-out.jsonld">expand/0038-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.0</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0039'>
+        <dt id="t0039">
           Test t0039 Using terms in a reverse-maps
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0039</dd>
             <dt>Type</dt>
@@ -911,19 +911,19 @@
             <dd>Terms within @reverse are expanded</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0039-in.jsonld'>expand/0039-in.jsonld</a>
+              <a href="expand/0039-in.jsonld">expand/0039-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0039-out.jsonld'>expand/0039-out.jsonld</a>
+              <a href="expand/0039-out.jsonld">expand/0039-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0040'>
+        <dt id="t0040">
           Test t0040 language and index expansion on non-objects
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0040</dd>
             <dt>Type</dt>
@@ -932,19 +932,19 @@
             <dd>Only invoke language and index map expansion if the value is a JSON object</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0040-in.jsonld'>expand/0040-in.jsonld</a>
+              <a href="expand/0040-in.jsonld">expand/0040-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0040-out.jsonld'>expand/0040-out.jsonld</a>
+              <a href="expand/0040-out.jsonld">expand/0040-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0041'>
+        <dt id="t0041">
           Test t0041 @language: null
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0041</dd>
             <dt>Type</dt>
@@ -953,19 +953,19 @@
             <dd>@language: null resets the default language</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0041-in.jsonld'>expand/0041-in.jsonld</a>
+              <a href="expand/0041-in.jsonld">expand/0041-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0041-out.jsonld'>expand/0041-out.jsonld</a>
+              <a href="expand/0041-out.jsonld">expand/0041-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0042'>
+        <dt id="t0042">
           Test t0042 Reverse properties
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0042</dd>
             <dt>Type</dt>
@@ -974,19 +974,19 @@
             <dd>Expanding terms defined as reverse properties uses @reverse in expanded document</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0042-in.jsonld'>expand/0042-in.jsonld</a>
+              <a href="expand/0042-in.jsonld">expand/0042-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0042-out.jsonld'>expand/0042-out.jsonld</a>
+              <a href="expand/0042-out.jsonld">expand/0042-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0043'>
+        <dt id="t0043">
           Test t0043 Using reverse properties inside a @reverse-container
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0043</dd>
             <dt>Type</dt>
@@ -995,19 +995,19 @@
             <dd>Expanding a reverse property within a @reverse undoes both reversals</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0043-in.jsonld'>expand/0043-in.jsonld</a>
+              <a href="expand/0043-in.jsonld">expand/0043-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0043-out.jsonld'>expand/0043-out.jsonld</a>
+              <a href="expand/0043-out.jsonld">expand/0043-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0044'>
+        <dt id="t0044">
           Test t0044 Index maps with language mappings
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0044</dd>
             <dt>Type</dt>
@@ -1016,19 +1016,19 @@
             <dd>Ensure index maps use language mapping</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0044-in.jsonld'>expand/0044-in.jsonld</a>
+              <a href="expand/0044-in.jsonld">expand/0044-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0044-out.jsonld'>expand/0044-out.jsonld</a>
+              <a href="expand/0044-out.jsonld">expand/0044-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0045'>
+        <dt id="t0045">
           Test t0045 Top-level value objects
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0045</dd>
             <dt>Type</dt>
@@ -1037,19 +1037,19 @@
             <dd>Expanding top-level value objects causes them to be removed</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0045-in.jsonld'>expand/0045-in.jsonld</a>
+              <a href="expand/0045-in.jsonld">expand/0045-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0045-out.jsonld'>expand/0045-out.jsonld</a>
+              <a href="expand/0045-out.jsonld">expand/0045-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0046'>
+        <dt id="t0046">
           Test t0046 Free-floating nodes
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0046</dd>
             <dt>Type</dt>
@@ -1058,19 +1058,19 @@
             <dd>Expanding free-floating nodes causes them to be removed</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0046-in.jsonld'>expand/0046-in.jsonld</a>
+              <a href="expand/0046-in.jsonld">expand/0046-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0046-out.jsonld'>expand/0046-out.jsonld</a>
+              <a href="expand/0046-out.jsonld">expand/0046-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0047'>
+        <dt id="t0047">
           Test t0047 Free-floating values in sets and free-floating lists
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0047</dd>
             <dt>Type</dt>
@@ -1079,19 +1079,19 @@
             <dd>Free-floating values in sets are removed, free-floating lists are removed completely</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0047-in.jsonld'>expand/0047-in.jsonld</a>
+              <a href="expand/0047-in.jsonld">expand/0047-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0047-out.jsonld'>expand/0047-out.jsonld</a>
+              <a href="expand/0047-out.jsonld">expand/0047-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0048'>
+        <dt id="t0048">
           Test t0048 Terms are ignored in @id
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0048</dd>
             <dt>Type</dt>
@@ -1100,19 +1100,19 @@
             <dd>Values of @id are not expanded as terms</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0048-in.jsonld'>expand/0048-in.jsonld</a>
+              <a href="expand/0048-in.jsonld">expand/0048-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0048-out.jsonld'>expand/0048-out.jsonld</a>
+              <a href="expand/0048-out.jsonld">expand/0048-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0049'>
+        <dt id="t0049">
           Test t0049 String values of reverse properties
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0049</dd>
             <dt>Type</dt>
@@ -1121,19 +1121,19 @@
             <dd>String values of a reverse property with @type: @id are treated as IRIs</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0049-in.jsonld'>expand/0049-in.jsonld</a>
+              <a href="expand/0049-in.jsonld">expand/0049-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0049-out.jsonld'>expand/0049-out.jsonld</a>
+              <a href="expand/0049-out.jsonld">expand/0049-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0050'>
+        <dt id="t0050">
           Test t0050 Term definitions with prefix separate from prefix definitions
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0050</dd>
             <dt>Type</dt>
@@ -1142,19 +1142,19 @@
             <dd>Term definitions using compact IRIs don&#39;t inherit the definitions of the prefix</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0050-in.jsonld'>expand/0050-in.jsonld</a>
+              <a href="expand/0050-in.jsonld">expand/0050-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0050-out.jsonld'>expand/0050-out.jsonld</a>
+              <a href="expand/0050-out.jsonld">expand/0050-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0051'>
+        <dt id="t0051">
           Test t0051 Expansion of keyword aliases in term definitions
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0051</dd>
             <dt>Type</dt>
@@ -1163,19 +1163,19 @@
             <dd>Expanding terms which are keyword aliases</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0051-in.jsonld'>expand/0051-in.jsonld</a>
+              <a href="expand/0051-in.jsonld">expand/0051-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0051-out.jsonld'>expand/0051-out.jsonld</a>
+              <a href="expand/0051-out.jsonld">expand/0051-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0052'>
+        <dt id="t0052">
           Test t0052 @vocab-relative IRIs in term definitions
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0052</dd>
             <dt>Type</dt>
@@ -1184,19 +1184,19 @@
             <dd>If @vocab is defined, term definitions are expanded relative to @vocab</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0052-in.jsonld'>expand/0052-in.jsonld</a>
+              <a href="expand/0052-in.jsonld">expand/0052-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0052-out.jsonld'>expand/0052-out.jsonld</a>
+              <a href="expand/0052-out.jsonld">expand/0052-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0053'>
+        <dt id="t0053">
           Test t0053 Expand absolute IRI with @type: @vocab
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0053</dd>
             <dt>Type</dt>
@@ -1205,19 +1205,19 @@
             <dd>Expanding values of properties of @type: @vocab does not further expand absolute IRIs</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0053-in.jsonld'>expand/0053-in.jsonld</a>
+              <a href="expand/0053-in.jsonld">expand/0053-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0053-out.jsonld'>expand/0053-out.jsonld</a>
+              <a href="expand/0053-out.jsonld">expand/0053-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0054'>
+        <dt id="t0054">
           Test t0054 Expand term with @type: @vocab
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0054</dd>
             <dt>Type</dt>
@@ -1226,19 +1226,19 @@
             <dd>Expanding values of properties of @type: @vocab does not expand term values</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0054-in.jsonld'>expand/0054-in.jsonld</a>
+              <a href="expand/0054-in.jsonld">expand/0054-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0054-out.jsonld'>expand/0054-out.jsonld</a>
+              <a href="expand/0054-out.jsonld">expand/0054-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0055'>
+        <dt id="t0055">
           Test t0055 Expand @vocab-relative term with @type: @vocab
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0055</dd>
             <dt>Type</dt>
@@ -1247,19 +1247,19 @@
             <dd>Expanding values of properties of @type: @vocab expands relative IRIs using @vocab</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0055-in.jsonld'>expand/0055-in.jsonld</a>
+              <a href="expand/0055-in.jsonld">expand/0055-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0055-out.jsonld'>expand/0055-out.jsonld</a>
+              <a href="expand/0055-out.jsonld">expand/0055-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0056'>
+        <dt id="t0056">
           Test t0056 Use terms with @type: @vocab but not with @type: @id
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0056</dd>
             <dt>Type</dt>
@@ -1268,19 +1268,19 @@
             <dd>Checks that expansion uses appropriate base depending on term definition having @type @id or @vocab</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0056-in.jsonld'>expand/0056-in.jsonld</a>
+              <a href="expand/0056-in.jsonld">expand/0056-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0056-out.jsonld'>expand/0056-out.jsonld</a>
+              <a href="expand/0056-out.jsonld">expand/0056-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0057'>
+        <dt id="t0057">
           Test t0057 Expand relative IRI with @type: @vocab
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0057</dd>
             <dt>Type</dt>
@@ -1289,19 +1289,19 @@
             <dd>Relative values of terms with @type: @vocab expand relative to @vocab</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0057-in.jsonld'>expand/0057-in.jsonld</a>
+              <a href="expand/0057-in.jsonld">expand/0057-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0057-out.jsonld'>expand/0057-out.jsonld</a>
+              <a href="expand/0057-out.jsonld">expand/0057-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0058'>
+        <dt id="t0058">
           Test t0058 Expand compact IRI with @type: @vocab
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0058</dd>
             <dt>Type</dt>
@@ -1310,19 +1310,19 @@
             <dd>Compact IRIs are expanded normally even if term has @type: @vocab</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0058-in.jsonld'>expand/0058-in.jsonld</a>
+              <a href="expand/0058-in.jsonld">expand/0058-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0058-out.jsonld'>expand/0058-out.jsonld</a>
+              <a href="expand/0058-out.jsonld">expand/0058-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0059'>
+        <dt id="t0059">
           Test t0059 Reset @vocab by setting it to null
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0059</dd>
             <dt>Type</dt>
@@ -1331,19 +1331,19 @@
             <dd>Setting @vocab to null removes a previous definition</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0059-in.jsonld'>expand/0059-in.jsonld</a>
+              <a href="expand/0059-in.jsonld">expand/0059-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0059-out.jsonld'>expand/0059-out.jsonld</a>
+              <a href="expand/0059-out.jsonld">expand/0059-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0060'>
+        <dt id="t0060">
           Test t0060 Overwrite document base with @base and reset it again
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0060</dd>
             <dt>Type</dt>
@@ -1352,19 +1352,19 @@
             <dd>Setting @base to an IRI and then resetting it to nil</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0060-in.jsonld'>expand/0060-in.jsonld</a>
+              <a href="expand/0060-in.jsonld">expand/0060-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0060-out.jsonld'>expand/0060-out.jsonld</a>
+              <a href="expand/0060-out.jsonld">expand/0060-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0061'>
+        <dt id="t0061">
           Test t0061 Coercing native types to arbitrary datatypes
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0061</dd>
             <dt>Type</dt>
@@ -1373,19 +1373,19 @@
             <dd>Expanding native types when coercing to arbitrary datatypes</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0061-in.jsonld'>expand/0061-in.jsonld</a>
+              <a href="expand/0061-in.jsonld">expand/0061-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0061-out.jsonld'>expand/0061-out.jsonld</a>
+              <a href="expand/0061-out.jsonld">expand/0061-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0062'>
+        <dt id="t0062">
           Test t0062 Various relative IRIs with with @base
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0062</dd>
             <dt>Type</dt>
@@ -1394,19 +1394,19 @@
             <dd>Pathological relative IRIs</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0062-in.jsonld'>expand/0062-in.jsonld</a>
+              <a href="expand/0062-in.jsonld">expand/0062-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0062-out.jsonld'>expand/0062-out.jsonld</a>
+              <a href="expand/0062-out.jsonld">expand/0062-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0063'>
+        <dt id="t0063">
           Test t0063 Reverse property and index container
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0063</dd>
             <dt>Type</dt>
@@ -1415,19 +1415,19 @@
             <dd>Expaning reverse properties with an index-container</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0063-in.jsonld'>expand/0063-in.jsonld</a>
+              <a href="expand/0063-in.jsonld">expand/0063-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0063-out.jsonld'>expand/0063-out.jsonld</a>
+              <a href="expand/0063-out.jsonld">expand/0063-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0064'>
+        <dt id="t0064">
           Test t0064 bnode values of reverse properties
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0064</dd>
             <dt>Type</dt>
@@ -1436,19 +1436,19 @@
             <dd>Expand reverse property whose values are unlabeled blank nodes</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0064-in.jsonld'>expand/0064-in.jsonld</a>
+              <a href="expand/0064-in.jsonld">expand/0064-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0064-out.jsonld'>expand/0064-out.jsonld</a>
+              <a href="expand/0064-out.jsonld">expand/0064-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0065'>
+        <dt id="t0065">
           Test t0065 Drop unmapped keys in reverse map
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0065</dd>
             <dt>Type</dt>
@@ -1457,19 +1457,19 @@
             <dd>Keys that are not mapped to an IRI in a reverse-map are dropped</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0065-in.jsonld'>expand/0065-in.jsonld</a>
+              <a href="expand/0065-in.jsonld">expand/0065-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0065-out.jsonld'>expand/0065-out.jsonld</a>
+              <a href="expand/0065-out.jsonld">expand/0065-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0066'>
+        <dt id="t0066">
           Test t0066 Reverse-map keys with @vocab
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0066</dd>
             <dt>Type</dt>
@@ -1478,19 +1478,19 @@
             <dd>Expand uses @vocab to expand keys in reverse-maps</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0066-in.jsonld'>expand/0066-in.jsonld</a>
+              <a href="expand/0066-in.jsonld">expand/0066-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0066-out.jsonld'>expand/0066-out.jsonld</a>
+              <a href="expand/0066-out.jsonld">expand/0066-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0067'>
+        <dt id="t0067">
           Test t0067 prefix://suffix not a compact IRI
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0067</dd>
             <dt>Type</dt>
@@ -1499,19 +1499,19 @@
             <dd>prefix:suffix values are not interpreted as compact IRIs if suffix begins with two slashes</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0067-in.jsonld'>expand/0067-in.jsonld</a>
+              <a href="expand/0067-in.jsonld">expand/0067-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0067-out.jsonld'>expand/0067-out.jsonld</a>
+              <a href="expand/0067-out.jsonld">expand/0067-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0068'>
+        <dt id="t0068">
           Test t0068 _:suffix values are not a compact IRI
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0068</dd>
             <dt>Type</dt>
@@ -1520,19 +1520,19 @@
             <dd>prefix:suffix values are not interpreted as compact IRIs if prefix is an underscore</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0068-in.jsonld'>expand/0068-in.jsonld</a>
+              <a href="expand/0068-in.jsonld">expand/0068-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0068-out.jsonld'>expand/0068-out.jsonld</a>
+              <a href="expand/0068-out.jsonld">expand/0068-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0069'>
+        <dt id="t0069">
           Test t0069 Compact IRI as term with type mapping
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0069</dd>
             <dt>Type</dt>
@@ -1541,19 +1541,19 @@
             <dd>Redefine compact IRI to define type mapping using the compact IRI itself as value of @id</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0069-in.jsonld'>expand/0069-in.jsonld</a>
+              <a href="expand/0069-in.jsonld">expand/0069-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0069-out.jsonld'>expand/0069-out.jsonld</a>
+              <a href="expand/0069-out.jsonld">expand/0069-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0070'>
+        <dt id="t0070">
           Test t0070 Compact IRI as term defined using equivalent compact IRI
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0070</dd>
             <dt>Type</dt>
@@ -1562,19 +1562,19 @@
             <dd>Redefine compact IRI to define type mapping using the compact IRI itself as string value</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0070-in.jsonld'>expand/0070-in.jsonld</a>
+              <a href="expand/0070-in.jsonld">expand/0070-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0070-out.jsonld'>expand/0070-out.jsonld</a>
+              <a href="expand/0070-out.jsonld">expand/0070-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0071'>
+        <dt id="t0071">
           Test t0071 Redefine terms looking like compact IRIs
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0071</dd>
             <dt>Type</dt>
@@ -1583,26 +1583,26 @@
             <dd>Term definitions may look like compact IRIs</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0071-in.jsonld'>expand/0071-in.jsonld</a>
+              <a href="expand/0071-in.jsonld">expand/0071-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0071-out.jsonld'>expand/0071-out.jsonld</a>
+              <a href="expand/0071-out.jsonld">expand/0071-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.0</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0072'>
+        <dt id="t0072">
           Test t0072 Redefine term using @vocab, not itself
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0072</dd>
             <dt>Type</dt>
@@ -1611,19 +1611,19 @@
             <dd>Redefining a term as itself when @vocab is defined uses @vocab, not previous term definition</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0072-in.jsonld'>expand/0072-in.jsonld</a>
+              <a href="expand/0072-in.jsonld">expand/0072-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0072-out.jsonld'>expand/0072-out.jsonld</a>
+              <a href="expand/0072-out.jsonld">expand/0072-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0073'>
+        <dt id="t0073">
           Test t0073 @context not first property
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0073</dd>
             <dt>Type</dt>
@@ -1632,19 +1632,19 @@
             <dd>Objects are unordered, so serialized node definition containing @context may have @context at the end of the node definition</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0073-in.jsonld'>expand/0073-in.jsonld</a>
+              <a href="expand/0073-in.jsonld">expand/0073-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0073-out.jsonld'>expand/0073-out.jsonld</a>
+              <a href="expand/0073-out.jsonld">expand/0073-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0074'>
+        <dt id="t0074">
           Test t0074 @id not first property
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0074</dd>
             <dt>Type</dt>
@@ -1653,19 +1653,19 @@
             <dd>Objects are unordered, so serialized node definition containing @id may have @id at the end of the node definition</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0074-in.jsonld'>expand/0074-in.jsonld</a>
+              <a href="expand/0074-in.jsonld">expand/0074-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0074-out.jsonld'>expand/0074-out.jsonld</a>
+              <a href="expand/0074-out.jsonld">expand/0074-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0075'>
+        <dt id="t0075">
           Test t0075 @vocab as blank node identifier
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0075</dd>
             <dt>Type</dt>
@@ -1674,26 +1674,26 @@
             <dd>Use @vocab to map all properties to blank node identifiers</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0075-in.jsonld'>expand/0075-in.jsonld</a>
+              <a href="expand/0075-in.jsonld">expand/0075-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0075-out.jsonld'>expand/0075-out.jsonld</a>
+              <a href="expand/0075-out.jsonld">expand/0075-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>processingMode</dt>
                 <dd>json-ld-1.0</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0076'>
+        <dt id="t0076">
           Test t0076 base option overrides document location
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0076</dd>
             <dt>Type</dt>
@@ -1702,26 +1702,26 @@
             <dd>Use of the base option overrides the document location</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0076-in.jsonld'>expand/0076-in.jsonld</a>
+              <a href="expand/0076-in.jsonld">expand/0076-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0076-out.jsonld'>expand/0076-out.jsonld</a>
+              <a href="expand/0076-out.jsonld">expand/0076-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>base</dt>
                 <dd>http://example/base/</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0077'>
+        <dt id="t0077">
           Test t0077 expandContext option
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0077</dd>
             <dt>Type</dt>
@@ -1730,26 +1730,26 @@
             <dd>Use of the expandContext option to expand the input document</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0077-in.jsonld'>expand/0077-in.jsonld</a>
+              <a href="expand/0077-in.jsonld">expand/0077-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0077-out.jsonld'>expand/0077-out.jsonld</a>
+              <a href="expand/0077-out.jsonld">expand/0077-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>expandContext</dt>
                 <dd>expand/0077-context.jsonld</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0078'>
+        <dt id="t0078">
           Test t0078 multiple reverse properties
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0078</dd>
             <dt>Type</dt>
@@ -1758,19 +1758,19 @@
             <dd>Use of multiple reverse properties</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0078-in.jsonld'>expand/0078-in.jsonld</a>
+              <a href="expand/0078-in.jsonld">expand/0078-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0078-out.jsonld'>expand/0078-out.jsonld</a>
+              <a href="expand/0078-out.jsonld">expand/0078-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0079'>
+        <dt id="t0079">
           Test t0079 expand @graph container
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0079</dd>
             <dt>Type</dt>
@@ -1779,26 +1779,26 @@
             <dd>Use of @graph containers</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0079-in.jsonld'>expand/0079-in.jsonld</a>
+              <a href="expand/0079-in.jsonld">expand/0079-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0079-out.jsonld'>expand/0079-out.jsonld</a>
+              <a href="expand/0079-out.jsonld">expand/0079-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0080'>
+        <dt id="t0080">
           Test t0080 expand [@graph, @set] container
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0080</dd>
             <dt>Type</dt>
@@ -1807,26 +1807,26 @@
             <dd>Use of [@graph, @set] containers</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0080-in.jsonld'>expand/0080-in.jsonld</a>
+              <a href="expand/0080-in.jsonld">expand/0080-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0080-out.jsonld'>expand/0080-out.jsonld</a>
+              <a href="expand/0080-out.jsonld">expand/0080-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0081'>
+        <dt id="t0081">
           Test t0081 Creates an @graph container if value is a graph
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0081</dd>
             <dt>Type</dt>
@@ -1835,26 +1835,26 @@
             <dd>Don&#39;t double-expand an already expanded graph</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0081-in.jsonld'>expand/0081-in.jsonld</a>
+              <a href="expand/0081-in.jsonld">expand/0081-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0081-out.jsonld'>expand/0081-out.jsonld</a>
+              <a href="expand/0081-out.jsonld">expand/0081-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0082'>
+        <dt id="t0082">
           Test t0082 expand [@graph, @index] container
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0082</dd>
             <dt>Type</dt>
@@ -1863,26 +1863,26 @@
             <dd>Use of @graph containers with @index</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0082-in.jsonld'>expand/0082-in.jsonld</a>
+              <a href="expand/0082-in.jsonld">expand/0082-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0082-out.jsonld'>expand/0082-out.jsonld</a>
+              <a href="expand/0082-out.jsonld">expand/0082-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0083'>
+        <dt id="t0083">
           Test t0083 expand [@graph, @index, @set] container
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0083</dd>
             <dt>Type</dt>
@@ -1891,26 +1891,26 @@
             <dd>Use of @graph containers with @index and @set</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0083-in.jsonld'>expand/0083-in.jsonld</a>
+              <a href="expand/0083-in.jsonld">expand/0083-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0083-out.jsonld'>expand/0083-out.jsonld</a>
+              <a href="expand/0083-out.jsonld">expand/0083-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0084'>
+        <dt id="t0084">
           Test t0084 Do not expand [@graph, @index] container if value is a graph
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0084</dd>
             <dt>Type</dt>
@@ -1919,26 +1919,26 @@
             <dd>Does not create a new graph object if indexed value is already a graph object</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0084-in.jsonld'>expand/0084-in.jsonld</a>
+              <a href="expand/0084-in.jsonld">expand/0084-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0084-out.jsonld'>expand/0084-out.jsonld</a>
+              <a href="expand/0084-out.jsonld">expand/0084-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0085'>
+        <dt id="t0085">
           Test t0085 expand [@graph, @id] container
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0085</dd>
             <dt>Type</dt>
@@ -1947,26 +1947,26 @@
             <dd>Use of @graph containers with @id</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0085-in.jsonld'>expand/0085-in.jsonld</a>
+              <a href="expand/0085-in.jsonld">expand/0085-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0085-out.jsonld'>expand/0085-out.jsonld</a>
+              <a href="expand/0085-out.jsonld">expand/0085-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0086'>
+        <dt id="t0086">
           Test t0086 expand [@graph, @id, @set] container
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0086</dd>
             <dt>Type</dt>
@@ -1975,26 +1975,26 @@
             <dd>Use of @graph containers with @id and @set</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0086-in.jsonld'>expand/0086-in.jsonld</a>
+              <a href="expand/0086-in.jsonld">expand/0086-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0086-out.jsonld'>expand/0086-out.jsonld</a>
+              <a href="expand/0086-out.jsonld">expand/0086-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0087'>
+        <dt id="t0087">
           Test t0087 Do not expand [@graph, @id] container if value is a graph
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0087</dd>
             <dt>Type</dt>
@@ -2003,26 +2003,26 @@
             <dd>Does not create a new graph object if indexed value is already a graph object</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0087-in.jsonld'>expand/0087-in.jsonld</a>
+              <a href="expand/0087-in.jsonld">expand/0087-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0087-out.jsonld'>expand/0087-out.jsonld</a>
+              <a href="expand/0087-out.jsonld">expand/0087-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0088'>
+        <dt id="t0088">
           Test t0088 Do not expand native values to IRIs
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0088</dd>
             <dt>Type</dt>
@@ -2031,19 +2031,19 @@
             <dd>Value Expansion does not expand native values, such as booleans, to a node object</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0088-in.jsonld'>expand/0088-in.jsonld</a>
+              <a href="expand/0088-in.jsonld">expand/0088-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0088-out.jsonld'>expand/0088-out.jsonld</a>
+              <a href="expand/0088-out.jsonld">expand/0088-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0089'>
+        <dt id="t0089">
           Test t0089 empty @base applied to the base option
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0089</dd>
             <dt>Type</dt>
@@ -2052,26 +2052,26 @@
             <dd>Use of an empty @base is applied to the base option</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0089-in.jsonld'>expand/0089-in.jsonld</a>
+              <a href="expand/0089-in.jsonld">expand/0089-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0089-out.jsonld'>expand/0089-out.jsonld</a>
+              <a href="expand/0089-out.jsonld">expand/0089-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>base</dt>
                 <dd>http://example/base/</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0090'>
+        <dt id="t0090">
           Test t0090 relative @base overrides base option and document location
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0090</dd>
             <dt>Type</dt>
@@ -2080,26 +2080,26 @@
             <dd>Use of a relative @base overrides base option and document location</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0090-in.jsonld'>expand/0090-in.jsonld</a>
+              <a href="expand/0090-in.jsonld">expand/0090-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0090-out.jsonld'>expand/0090-out.jsonld</a>
+              <a href="expand/0090-out.jsonld">expand/0090-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>base</dt>
                 <dd>http://example/base/</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0091'>
+        <dt id="t0091">
           Test t0091 relative and absolute @base overrides base option and document location
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0091</dd>
             <dt>Type</dt>
@@ -2108,26 +2108,26 @@
             <dd>Use of a relative and absolute @base overrides base option and document location</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0091-in.jsonld'>expand/0091-in.jsonld</a>
+              <a href="expand/0091-in.jsonld">expand/0091-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0091-out.jsonld'>expand/0091-out.jsonld</a>
+              <a href="expand/0091-out.jsonld">expand/0091-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>base</dt>
                 <dd>http://example/base/</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0092'>
+        <dt id="t0092">
           Test t0092 Various relative IRIs as properties with with @vocab: &#39;&#39;
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0092</dd>
             <dt>Type</dt>
@@ -2136,26 +2136,26 @@
             <dd>Pathological relative property IRIs</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0092-in.jsonld'>expand/0092-in.jsonld</a>
+              <a href="expand/0092-in.jsonld">expand/0092-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0092-out.jsonld'>expand/0092-out.jsonld</a>
+              <a href="expand/0092-out.jsonld">expand/0092-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0093'>
+        <dt id="t0093">
           Test t0093 expand @graph container (multiple objects)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0093</dd>
             <dt>Type</dt>
@@ -2164,26 +2164,26 @@
             <dd>Use of @graph containers</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0093-in.jsonld'>expand/0093-in.jsonld</a>
+              <a href="expand/0093-in.jsonld">expand/0093-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0093-out.jsonld'>expand/0093-out.jsonld</a>
+              <a href="expand/0093-out.jsonld">expand/0093-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0094'>
+        <dt id="t0094">
           Test t0094 expand [@graph, @set] container (multiple objects)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0094</dd>
             <dt>Type</dt>
@@ -2192,26 +2192,26 @@
             <dd>Use of [@graph, @set] containers</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0094-in.jsonld'>expand/0094-in.jsonld</a>
+              <a href="expand/0094-in.jsonld">expand/0094-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0094-out.jsonld'>expand/0094-out.jsonld</a>
+              <a href="expand/0094-out.jsonld">expand/0094-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0095'>
+        <dt id="t0095">
           Test t0095 Creates an @graph container if value is a graph (multiple objects)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0095</dd>
             <dt>Type</dt>
@@ -2220,26 +2220,26 @@
             <dd>Double-expand an already expanded graph</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0095-in.jsonld'>expand/0095-in.jsonld</a>
+              <a href="expand/0095-in.jsonld">expand/0095-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0095-out.jsonld'>expand/0095-out.jsonld</a>
+              <a href="expand/0095-out.jsonld">expand/0095-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0096'>
+        <dt id="t0096">
           Test t0096 expand [@graph, @index] container (multiple indexed objects)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0096</dd>
             <dt>Type</dt>
@@ -2248,26 +2248,26 @@
             <dd>Use of @graph containers with @index</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0096-in.jsonld'>expand/0096-in.jsonld</a>
+              <a href="expand/0096-in.jsonld">expand/0096-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0096-out.jsonld'>expand/0096-out.jsonld</a>
+              <a href="expand/0096-out.jsonld">expand/0096-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0097'>
+        <dt id="t0097">
           Test t0097 expand [@graph, @index, @set] container (multiple objects)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0097</dd>
             <dt>Type</dt>
@@ -2276,26 +2276,26 @@
             <dd>Use of @graph containers with @index and @set</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0097-in.jsonld'>expand/0097-in.jsonld</a>
+              <a href="expand/0097-in.jsonld">expand/0097-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0097-out.jsonld'>expand/0097-out.jsonld</a>
+              <a href="expand/0097-out.jsonld">expand/0097-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0098'>
+        <dt id="t0098">
           Test t0098 Do not expand [@graph, @index] container if value is a graph (multiple objects)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0098</dd>
             <dt>Type</dt>
@@ -2304,26 +2304,26 @@
             <dd>Does not create a new graph object if indexed value is already a graph object</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0098-in.jsonld'>expand/0098-in.jsonld</a>
+              <a href="expand/0098-in.jsonld">expand/0098-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0098-out.jsonld'>expand/0098-out.jsonld</a>
+              <a href="expand/0098-out.jsonld">expand/0098-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0099'>
+        <dt id="t0099">
           Test t0099 expand [@graph, @id] container (multiple objects)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0099</dd>
             <dt>Type</dt>
@@ -2332,26 +2332,26 @@
             <dd>Use of @graph containers with @id</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0099-in.jsonld'>expand/0099-in.jsonld</a>
+              <a href="expand/0099-in.jsonld">expand/0099-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0099-out.jsonld'>expand/0099-out.jsonld</a>
+              <a href="expand/0099-out.jsonld">expand/0099-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0100'>
+        <dt id="t0100">
           Test t0100 expand [@graph, @id, @set] container (multiple objects)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0100</dd>
             <dt>Type</dt>
@@ -2360,26 +2360,26 @@
             <dd>Use of @graph containers with @id and @set</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0100-in.jsonld'>expand/0100-in.jsonld</a>
+              <a href="expand/0100-in.jsonld">expand/0100-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0100-out.jsonld'>expand/0100-out.jsonld</a>
+              <a href="expand/0100-out.jsonld">expand/0100-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0101'>
+        <dt id="t0101">
           Test t0101 Do not expand [@graph, @id] container if value is a graph (multiple objects)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0101</dd>
             <dt>Type</dt>
@@ -2388,26 +2388,26 @@
             <dd>Does not create a new graph object if indexed value is already a graph object</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0101-in.jsonld'>expand/0101-in.jsonld</a>
+              <a href="expand/0101-in.jsonld">expand/0101-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0101-out.jsonld'>expand/0101-out.jsonld</a>
+              <a href="expand/0101-out.jsonld">expand/0101-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0102'>
+        <dt id="t0102">
           Test t0102 Expand @graph container if value is a graph (multiple objects)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0102</dd>
             <dt>Type</dt>
@@ -2416,26 +2416,26 @@
             <dd>Creates a new graph object if indexed value is already a graph object</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0102-in.jsonld'>expand/0102-in.jsonld</a>
+              <a href="expand/0102-in.jsonld">expand/0102-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0102-out.jsonld'>expand/0102-out.jsonld</a>
+              <a href="expand/0102-out.jsonld">expand/0102-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0103'>
+        <dt id="t0103">
           Test t0103 Expand @graph container if value is a graph (multiple graphs)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0103</dd>
             <dt>Type</dt>
@@ -2444,26 +2444,26 @@
             <dd>Creates a new graph object if indexed value is already a graph object</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0103-in.jsonld'>expand/0103-in.jsonld</a>
+              <a href="expand/0103-in.jsonld">expand/0103-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0103-out.jsonld'>expand/0103-out.jsonld</a>
+              <a href="expand/0103-out.jsonld">expand/0103-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0104'>
+        <dt id="t0104">
           Test t0104 Creates an @graph container if value is a graph (mixed graph and object)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0104</dd>
             <dt>Type</dt>
@@ -2472,26 +2472,26 @@
             <dd>Double-expand an already expanded graph</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0104-in.jsonld'>expand/0104-in.jsonld</a>
+              <a href="expand/0104-in.jsonld">expand/0104-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0104-out.jsonld'>expand/0104-out.jsonld</a>
+              <a href="expand/0104-out.jsonld">expand/0104-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0105'>
+        <dt id="t0105">
           Test t0105 Do not expand [@graph, @index] container if value is a graph (mixed graph and object)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0105</dd>
             <dt>Type</dt>
@@ -2500,26 +2500,26 @@
             <dd>Does not create a new graph object if indexed value is already a graph object</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0105-in.jsonld'>expand/0105-in.jsonld</a>
+              <a href="expand/0105-in.jsonld">expand/0105-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0105-out.jsonld'>expand/0105-out.jsonld</a>
+              <a href="expand/0105-out.jsonld">expand/0105-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0106'>
+        <dt id="t0106">
           Test t0106 Do not expand [@graph, @id] container if value is a graph (mixed graph and object)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0106</dd>
             <dt>Type</dt>
@@ -2528,26 +2528,26 @@
             <dd>Does not create a new graph object if indexed value is already a graph object</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0106-in.jsonld'>expand/0106-in.jsonld</a>
+              <a href="expand/0106-in.jsonld">expand/0106-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0106-out.jsonld'>expand/0106-out.jsonld</a>
+              <a href="expand/0106-out.jsonld">expand/0106-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0107'>
+        <dt id="t0107">
           Test t0107 expand [@graph, @index] container (indexes with multiple objects)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0107</dd>
             <dt>Type</dt>
@@ -2556,26 +2556,26 @@
             <dd>Use of @graph containers with @index</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0107-in.jsonld'>expand/0107-in.jsonld</a>
+              <a href="expand/0107-in.jsonld">expand/0107-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0107-out.jsonld'>expand/0107-out.jsonld</a>
+              <a href="expand/0107-out.jsonld">expand/0107-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0108'>
+        <dt id="t0108">
           Test t0108 expand [@graph, @id] container (multiple ids and objects)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0108</dd>
             <dt>Type</dt>
@@ -2584,26 +2584,26 @@
             <dd>Use of @graph containers with @id</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0108-in.jsonld'>expand/0108-in.jsonld</a>
+              <a href="expand/0108-in.jsonld">expand/0108-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0108-out.jsonld'>expand/0108-out.jsonld</a>
+              <a href="expand/0108-out.jsonld">expand/0108-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0109'>
+        <dt id="t0109">
           Test t0109 IRI expansion of fragments including &#39;:&#39;
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0109</dd>
             <dt>Type</dt>
@@ -2612,19 +2612,19 @@
             <dd>Do not treat as absolute IRIs values that look like compact IRIs if they&#39;re not absolute</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0109-in.jsonld'>expand/0109-in.jsonld</a>
+              <a href="expand/0109-in.jsonld">expand/0109-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0109-out.jsonld'>expand/0109-out.jsonld</a>
+              <a href="expand/0109-out.jsonld">expand/0109-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0110'>
+        <dt id="t0110">
           Test t0110 Various relative IRIs as properties with with relative @vocab
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0110</dd>
             <dt>Type</dt>
@@ -2633,26 +2633,26 @@
             <dd>Pathological relative property IRIs</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0110-in.jsonld'>expand/0110-in.jsonld</a>
+              <a href="expand/0110-in.jsonld">expand/0110-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0110-out.jsonld'>expand/0110-out.jsonld</a>
+              <a href="expand/0110-out.jsonld">expand/0110-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0111'>
+        <dt id="t0111">
           Test t0111 Various relative IRIs as properties with with relative @vocab itself relative to an existing vocabulary base
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0111</dd>
             <dt>Type</dt>
@@ -2661,26 +2661,26 @@
             <dd>Pathological relative property IRIs</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0111-in.jsonld'>expand/0111-in.jsonld</a>
+              <a href="expand/0111-in.jsonld">expand/0111-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0111-out.jsonld'>expand/0111-out.jsonld</a>
+              <a href="expand/0111-out.jsonld">expand/0111-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0112'>
+        <dt id="t0112">
           Test t0112 Various relative IRIs as properties with with relative @vocab relative to another relative vocabulary base
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0112</dd>
             <dt>Type</dt>
@@ -2689,26 +2689,26 @@
             <dd>Pathological relative property IRIs</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0112-in.jsonld'>expand/0112-in.jsonld</a>
+              <a href="expand/0112-in.jsonld">expand/0112-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0112-out.jsonld'>expand/0112-out.jsonld</a>
+              <a href="expand/0112-out.jsonld">expand/0112-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0113'>
+        <dt id="t0113">
           Test t0113 context with JavaScript Object property names
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0113</dd>
             <dt>Type</dt>
@@ -2717,19 +2717,19 @@
             <dd>Expand with context including JavaScript Object property names</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0113-in.jsonld'>expand/0113-in.jsonld</a>
+              <a href="expand/0113-in.jsonld">expand/0113-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0113-out.jsonld'>expand/0113-out.jsonld</a>
+              <a href="expand/0113-out.jsonld">expand/0113-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0114'>
+        <dt id="t0114">
           Test t0114 Expansion allows multiple properties expanding to @type
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0114</dd>
             <dt>Type</dt>
@@ -2738,26 +2738,26 @@
             <dd>An exception for the colliding keywords error is made for @type</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0114-in.jsonld'>expand/0114-in.jsonld</a>
+              <a href="expand/0114-in.jsonld">expand/0114-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0114-out.jsonld'>expand/0114-out.jsonld</a>
+              <a href="expand/0114-out.jsonld">expand/0114-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0115'>
+        <dt id="t0115">
           Test t0115 Verifies that relative IRIs as properties with @vocab: &#39;&#39; in 1.0 generate an error
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0115</dd>
             <dt>Type</dt>
@@ -2766,7 +2766,7 @@
             <dd>Relative property IRIs with relative @vocab in 1.0</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0115-in.jsonld'>expand/0115-in.jsonld</a>
+              <a href="expand/0115-in.jsonld">expand/0115-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -2774,18 +2774,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.0</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0116'>
+        <dt id="t0116">
           Test t0116 Verifies that relative IRIs as properties with relative @vocab in 1.0 generate an error
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0116</dd>
             <dt>Type</dt>
@@ -2794,7 +2794,7 @@
             <dd>Relative property IRIs with relative @vocab in 1.0</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0116-in.jsonld'>expand/0116-in.jsonld</a>
+              <a href="expand/0116-in.jsonld">expand/0116-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -2802,18 +2802,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.0</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0117'>
+        <dt id="t0117">
           Test t0117 A term starting with a colon can expand to a different IRI
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0117</dd>
             <dt>Type</dt>
@@ -2822,26 +2822,26 @@
             <dd>Terms may begin with a colon and not be treated as IRIs.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0117-in.jsonld'>expand/0117-in.jsonld</a>
+              <a href="expand/0117-in.jsonld">expand/0117-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0117-out.jsonld'>expand/0117-out.jsonld</a>
+              <a href="expand/0117-out.jsonld">expand/0117-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0118'>
+        <dt id="t0118">
           Test t0118 Expanding a value staring with a colon does not treat that value as an IRI
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0118</dd>
             <dt>Type</dt>
@@ -2850,26 +2850,26 @@
             <dd>Terms may begin with a colon and not be treated as IRIs.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0118-in.jsonld'>expand/0118-in.jsonld</a>
+              <a href="expand/0118-in.jsonld">expand/0118-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0118-out.jsonld'>expand/0118-out.jsonld</a>
+              <a href="expand/0118-out.jsonld">expand/0118-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0119'>
+        <dt id="t0119">
           Test t0119 Ignore some terms with @, allow others.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0119</dd>
             <dt>Type</dt>
@@ -2878,26 +2878,26 @@
             <dd>Processors SHOULD generate a warning and MUST ignore terms having the form of a keyword.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0119-in.jsonld'>expand/0119-in.jsonld</a>
+              <a href="expand/0119-in.jsonld">expand/0119-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0119-out.jsonld'>expand/0119-out.jsonld</a>
+              <a href="expand/0119-out.jsonld">expand/0119-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0120'>
+        <dt id="t0120">
           Test t0120 Ignore some values of @id with @, allow others.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0120</dd>
             <dt>Type</dt>
@@ -2906,26 +2906,26 @@
             <dd>Processors SHOULD generate a warning and MUST ignore values of @id having the form of a keyword.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0120-in.jsonld'>expand/0120-in.jsonld</a>
+              <a href="expand/0120-in.jsonld">expand/0120-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0120-out.jsonld'>expand/0120-out.jsonld</a>
+              <a href="expand/0120-out.jsonld">expand/0120-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0121'>
+        <dt id="t0121">
           Test t0121 Ignore some values of @reverse with @, allow others.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0121</dd>
             <dt>Type</dt>
@@ -2934,26 +2934,26 @@
             <dd>Processors SHOULD generate a warning and MUST ignore values of @reverse having the form of a keyword.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0121-in.jsonld'>expand/0121-in.jsonld</a>
+              <a href="expand/0121-in.jsonld">expand/0121-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0121-out.jsonld'>expand/0121-out.jsonld</a>
+              <a href="expand/0121-out.jsonld">expand/0121-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0122'>
+        <dt id="t0122">
           Test t0122 Ignore some IRIs when that start with @ when expanding.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0122</dd>
             <dt>Type</dt>
@@ -2962,15 +2962,15 @@
             <dd>Processors SHOULD generate a warning and MUST ignore IRIs having the form of a keyword. (Note: the resulting document will not be valid JSON-LD, due to the `null` value for `@id`)</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0122-in.jsonld'>expand/0122-in.jsonld</a>
+              <a href="expand/0122-in.jsonld">expand/0122-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0122-out.jsonld'>expand/0122-out.jsonld</a>
+              <a href="expand/0122-out.jsonld">expand/0122-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
                 <dt>normative</dt>
@@ -2979,11 +2979,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='t0123'>
+        <dt id="t0123">
           Test t0123 Value objects including invalid literal datatype IRIs are rejected
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0123</dd>
             <dt>Type</dt>
@@ -2992,7 +2992,7 @@
             <dd>Processors MUST validate datatype IRIs.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0123-in.jsonld'>expand/0123-in.jsonld</a>
+              <a href="expand/0123-in.jsonld">expand/0123-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -3000,18 +3000,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0124'>
+        <dt id="t0124">
           Test t0124 compact IRI as @vocab
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0124</dd>
             <dt>Type</dt>
@@ -3020,26 +3020,26 @@
             <dd>Verifies that @vocab defined as a compact IRI expands properly</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0124-in.jsonld'>expand/0124-in.jsonld</a>
+              <a href="expand/0124-in.jsonld">expand/0124-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0124-out.jsonld'>expand/0124-out.jsonld</a>
+              <a href="expand/0124-out.jsonld">expand/0124-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0125'>
+        <dt id="t0125">
           Test t0125 term as @vocab
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0125</dd>
             <dt>Type</dt>
@@ -3048,26 +3048,26 @@
             <dd>Verifies that @vocab defined as a term expands properly</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0125-in.jsonld'>expand/0125-in.jsonld</a>
+              <a href="expand/0125-in.jsonld">expand/0125-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0125-out.jsonld'>expand/0125-out.jsonld</a>
+              <a href="expand/0125-out.jsonld">expand/0125-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0126'>
+        <dt id="t0126">
           Test t0126 A scoped context may include itself recursively (direct)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0126</dd>
             <dt>Type</dt>
@@ -3076,26 +3076,26 @@
             <dd>Verifies that no exception is raised on expansion when processing a scoped context referencing itself directly</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0126-in.jsonld'>expand/0126-in.jsonld</a>
+              <a href="expand/0126-in.jsonld">expand/0126-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0126-out.jsonld'>expand/0126-out.jsonld</a>
+              <a href="expand/0126-out.jsonld">expand/0126-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0127'>
+        <dt id="t0127">
           Test t0127 A scoped context may include itself recursively (indirect)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0127</dd>
             <dt>Type</dt>
@@ -3104,26 +3104,26 @@
             <dd>Verifies that no exception is raised on expansion when processing a scoped context referencing itself indirectly</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0127-in.jsonld'>expand/0127-in.jsonld</a>
+              <a href="expand/0127-in.jsonld">expand/0127-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0127-out.jsonld'>expand/0127-out.jsonld</a>
+              <a href="expand/0127-out.jsonld">expand/0127-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0128'>
+        <dt id="t0128">
           Test t0128 Two scoped context may include a shared context
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0128</dd>
             <dt>Type</dt>
@@ -3132,26 +3132,26 @@
             <dd>Verifies that no exception is raised on expansion when processing two scoped contexts referencing a shared context</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0128-in.jsonld'>expand/0128-in.jsonld</a>
+              <a href="expand/0128-in.jsonld">expand/0128-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0128-out.jsonld'>expand/0128-out.jsonld</a>
+              <a href="expand/0128-out.jsonld">expand/0128-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='t0129'>
+        <dt id="t0129">
           Test t0129 Base without trailing slash, without path
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0129</dd>
             <dt>Type</dt>
@@ -3160,19 +3160,19 @@
             <dd>Verify URI resolution relative to base (without trailing slash, without path) according to RFC 3986</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0129-in.jsonld'>expand/0129-in.jsonld</a>
+              <a href="expand/0129-in.jsonld">expand/0129-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0129-out.jsonld'>expand/0129-out.jsonld</a>
+              <a href="expand/0129-out.jsonld">expand/0129-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0130'>
+        <dt id="t0130">
           Test t0130 Base without trailing slash, with path
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0130</dd>
             <dt>Type</dt>
@@ -3181,19 +3181,19 @@
             <dd>Verify URI resolution relative to base (without trailing slash, with path) according to RFC 3986</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0130-in.jsonld'>expand/0130-in.jsonld</a>
+              <a href="expand/0130-in.jsonld">expand/0130-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0130-out.jsonld'>expand/0130-out.jsonld</a>
+              <a href="expand/0130-out.jsonld">expand/0130-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id='t0131'>
+        <dt id="t0131">
           Test t0131 Reverse term with property based indexed container
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#t0131</dd>
             <dt>Type</dt>
@@ -3202,26 +3202,54 @@
             <dd>Expanding a reverse term using @container: @index and @index set to a property</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/0131-in.jsonld'>expand/0131-in.jsonld</a>
+              <a href="expand/0131-in.jsonld">expand/0131-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/0131-out.jsonld'>expand/0131-out.jsonld</a>
+              <a href="expand/0131-out.jsonld">expand/0131-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc001'>
+        <dt id="t0132">
+          Test t0132 @base does not expand property keys
+        </dt>
+        <dd>
+          <dl class="entry">
+            <dt>id</dt>
+            <dd>#t0132</dd>
+            <dt>Type</dt>
+            <dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+            <dt>Purpose</dt>
+            <dd>Property keys are expanded vocabulary-relative (@vocab, term definitions, compact IRIs with a defined prefix). @base is for document-relative IRI resolution where the algorithms pass that flag (e.g. certain @id and @type values), not for unmapped simple keys. With only @base set, an unmapped key like name has no vocabulary mapping and must be dropped; a relative @type token still resolves against the base. See IRI Expansion in the JSON-LD 1.1 Processing Algorithms and API.</dd>
+            <dt>input</dt>
+            <dd>
+              <a href="expand/0132-in.jsonld">expand/0132-in.jsonld</a>
+            </dd>
+            <dt>expect</dt>
+            <dd>
+              <a href="expand/0132-out.jsonld">expand/0132-out.jsonld</a>
+            </dd>
+            <dt>Options</dt>
+            <dd>
+              <dl class="options">
+                <dt>specVersion</dt>
+                <dd>json-ld-1.1</dd>
+              </dl>
+            </dd>
+          </dl>
+        </dd>
+        <dt id="tc001">
           Test tc001 adding new term
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc001</dd>
             <dt>Type</dt>
@@ -3230,26 +3258,26 @@
             <dd>Expansion using a scoped context uses term scope for selecting proper term</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c001-in.jsonld'>expand/c001-in.jsonld</a>
+              <a href="expand/c001-in.jsonld">expand/c001-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c001-out.jsonld'>expand/c001-out.jsonld</a>
+              <a href="expand/c001-out.jsonld">expand/c001-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc002'>
+        <dt id="tc002">
           Test tc002 overriding a term
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc002</dd>
             <dt>Type</dt>
@@ -3258,26 +3286,26 @@
             <dd>Expansion using a scoped context uses term scope for selecting proper term</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c002-in.jsonld'>expand/c002-in.jsonld</a>
+              <a href="expand/c002-in.jsonld">expand/c002-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c002-out.jsonld'>expand/c002-out.jsonld</a>
+              <a href="expand/c002-out.jsonld">expand/c002-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc003'>
+        <dt id="tc003">
           Test tc003 property and value with different terms mapping to the same expanded property
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc003</dd>
             <dt>Type</dt>
@@ -3286,26 +3314,26 @@
             <dd>Expansion using a scoped context uses term scope for selecting proper term</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c003-in.jsonld'>expand/c003-in.jsonld</a>
+              <a href="expand/c003-in.jsonld">expand/c003-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c003-out.jsonld'>expand/c003-out.jsonld</a>
+              <a href="expand/c003-out.jsonld">expand/c003-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc004'>
+        <dt id="tc004">
           Test tc004 deep @context affects nested nodes
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc004</dd>
             <dt>Type</dt>
@@ -3314,26 +3342,26 @@
             <dd>Expansion using a scoped context uses term scope for selecting proper term</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c004-in.jsonld'>expand/c004-in.jsonld</a>
+              <a href="expand/c004-in.jsonld">expand/c004-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c004-out.jsonld'>expand/c004-out.jsonld</a>
+              <a href="expand/c004-out.jsonld">expand/c004-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc005'>
+        <dt id="tc005">
           Test tc005 scoped context layers on intemediate contexts
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc005</dd>
             <dt>Type</dt>
@@ -3342,26 +3370,26 @@
             <dd>Expansion using a scoped context uses term scope for selecting proper term</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c005-in.jsonld'>expand/c005-in.jsonld</a>
+              <a href="expand/c005-in.jsonld">expand/c005-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c005-out.jsonld'>expand/c005-out.jsonld</a>
+              <a href="expand/c005-out.jsonld">expand/c005-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc006'>
+        <dt id="tc006">
           Test tc006 adding new term
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc006</dd>
             <dt>Type</dt>
@@ -3370,26 +3398,26 @@
             <dd>scoped context on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c006-in.jsonld'>expand/c006-in.jsonld</a>
+              <a href="expand/c006-in.jsonld">expand/c006-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c006-out.jsonld'>expand/c006-out.jsonld</a>
+              <a href="expand/c006-out.jsonld">expand/c006-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc007'>
+        <dt id="tc007">
           Test tc007 overriding a term
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc007</dd>
             <dt>Type</dt>
@@ -3398,26 +3426,26 @@
             <dd>scoped context on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c007-in.jsonld'>expand/c007-in.jsonld</a>
+              <a href="expand/c007-in.jsonld">expand/c007-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c007-out.jsonld'>expand/c007-out.jsonld</a>
+              <a href="expand/c007-out.jsonld">expand/c007-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc008'>
+        <dt id="tc008">
           Test tc008 alias of @type
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc008</dd>
             <dt>Type</dt>
@@ -3426,26 +3454,26 @@
             <dd>scoped context on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c008-in.jsonld'>expand/c008-in.jsonld</a>
+              <a href="expand/c008-in.jsonld">expand/c008-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c008-out.jsonld'>expand/c008-out.jsonld</a>
+              <a href="expand/c008-out.jsonld">expand/c008-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc009'>
+        <dt id="tc009">
           Test tc009 deep @type-scoped @context does NOT affect nested nodes
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc009</dd>
             <dt>Type</dt>
@@ -3454,26 +3482,26 @@
             <dd>scoped context on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c009-in.jsonld'>expand/c009-in.jsonld</a>
+              <a href="expand/c009-in.jsonld">expand/c009-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c009-out.jsonld'>expand/c009-out.jsonld</a>
+              <a href="expand/c009-out.jsonld">expand/c009-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc010'>
+        <dt id="tc010">
           Test tc010 scoped context layers on intemediate contexts
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc010</dd>
             <dt>Type</dt>
@@ -3482,26 +3510,26 @@
             <dd>scoped context on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c010-in.jsonld'>expand/c010-in.jsonld</a>
+              <a href="expand/c010-in.jsonld">expand/c010-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c010-out.jsonld'>expand/c010-out.jsonld</a>
+              <a href="expand/c010-out.jsonld">expand/c010-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc011'>
+        <dt id="tc011">
           Test tc011 orders @type terms when applying scoped contexts
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc011</dd>
             <dt>Type</dt>
@@ -3510,26 +3538,26 @@
             <dd>scoped context on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c011-in.jsonld'>expand/c011-in.jsonld</a>
+              <a href="expand/c011-in.jsonld">expand/c011-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c011-out.jsonld'>expand/c011-out.jsonld</a>
+              <a href="expand/c011-out.jsonld">expand/c011-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc012'>
+        <dt id="tc012">
           Test tc012 deep property-term scoped @context in @type-scoped @context affects nested nodes
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc012</dd>
             <dt>Type</dt>
@@ -3538,26 +3566,26 @@
             <dd>scoped context on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c012-in.jsonld'>expand/c012-in.jsonld</a>
+              <a href="expand/c012-in.jsonld">expand/c012-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c012-out.jsonld'>expand/c012-out.jsonld</a>
+              <a href="expand/c012-out.jsonld">expand/c012-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc013'>
+        <dt id="tc013">
           Test tc013 type maps use scoped context from type index and not scoped context from containing
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc013</dd>
             <dt>Type</dt>
@@ -3566,26 +3594,26 @@
             <dd>scoped context on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c013-in.jsonld'>expand/c013-in.jsonld</a>
+              <a href="expand/c013-in.jsonld">expand/c013-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c013-out.jsonld'>expand/c013-out.jsonld</a>
+              <a href="expand/c013-out.jsonld">expand/c013-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc014'>
+        <dt id="tc014">
           Test tc014 type-scoped context nullification
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc014</dd>
             <dt>Type</dt>
@@ -3594,26 +3622,26 @@
             <dd>type-scoped context nullification</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c014-in.jsonld'>expand/c014-in.jsonld</a>
+              <a href="expand/c014-in.jsonld">expand/c014-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c014-out.jsonld'>expand/c014-out.jsonld</a>
+              <a href="expand/c014-out.jsonld">expand/c014-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc015'>
+        <dt id="tc015">
           Test tc015 type-scoped base
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc015</dd>
             <dt>Type</dt>
@@ -3622,26 +3650,26 @@
             <dd>type-scoped base</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c015-in.jsonld'>expand/c015-in.jsonld</a>
+              <a href="expand/c015-in.jsonld">expand/c015-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c015-out.jsonld'>expand/c015-out.jsonld</a>
+              <a href="expand/c015-out.jsonld">expand/c015-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc016'>
+        <dt id="tc016">
           Test tc016 type-scoped vocab
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc016</dd>
             <dt>Type</dt>
@@ -3650,26 +3678,26 @@
             <dd>type-scoped vocab</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c016-in.jsonld'>expand/c016-in.jsonld</a>
+              <a href="expand/c016-in.jsonld">expand/c016-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c016-out.jsonld'>expand/c016-out.jsonld</a>
+              <a href="expand/c016-out.jsonld">expand/c016-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc017'>
+        <dt id="tc017">
           Test tc017 multiple type-scoped contexts are properly reverted
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc017</dd>
             <dt>Type</dt>
@@ -3678,26 +3706,26 @@
             <dd>multiple type-scoped contexts are property reverted</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c017-in.jsonld'>expand/c017-in.jsonld</a>
+              <a href="expand/c017-in.jsonld">expand/c017-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c017-out.jsonld'>expand/c017-out.jsonld</a>
+              <a href="expand/c017-out.jsonld">expand/c017-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc018'>
+        <dt id="tc018">
           Test tc018 multiple type-scoped types resolved against previous context
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc018</dd>
             <dt>Type</dt>
@@ -3706,26 +3734,26 @@
             <dd>multiple type-scoped types resolved against previous context</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c018-in.jsonld'>expand/c018-in.jsonld</a>
+              <a href="expand/c018-in.jsonld">expand/c018-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c018-out.jsonld'>expand/c018-out.jsonld</a>
+              <a href="expand/c018-out.jsonld">expand/c018-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc019'>
+        <dt id="tc019">
           Test tc019 type-scoped context with multiple property scoped terms
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc019</dd>
             <dt>Type</dt>
@@ -3734,26 +3762,26 @@
             <dd>type-scoped context with multiple property scoped terms</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c019-in.jsonld'>expand/c019-in.jsonld</a>
+              <a href="expand/c019-in.jsonld">expand/c019-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c019-out.jsonld'>expand/c019-out.jsonld</a>
+              <a href="expand/c019-out.jsonld">expand/c019-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc020'>
+        <dt id="tc020">
           Test tc020 type-scoped value
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc020</dd>
             <dt>Type</dt>
@@ -3762,26 +3790,26 @@
             <dd>type-scoped value</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c020-in.jsonld'>expand/c020-in.jsonld</a>
+              <a href="expand/c020-in.jsonld">expand/c020-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c020-out.jsonld'>expand/c020-out.jsonld</a>
+              <a href="expand/c020-out.jsonld">expand/c020-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc021'>
+        <dt id="tc021">
           Test tc021 type-scoped value mix
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc021</dd>
             <dt>Type</dt>
@@ -3790,26 +3818,26 @@
             <dd>type-scoped value mix</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c021-in.jsonld'>expand/c021-in.jsonld</a>
+              <a href="expand/c021-in.jsonld">expand/c021-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c021-out.jsonld'>expand/c021-out.jsonld</a>
+              <a href="expand/c021-out.jsonld">expand/c021-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc022'>
+        <dt id="tc022">
           Test tc022 type-scoped property-scoped contexts including @type:@vocab
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc022</dd>
             <dt>Type</dt>
@@ -3818,26 +3846,26 @@
             <dd>type-scoped property-scoped contexts including @type:@vocab</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c022-in.jsonld'>expand/c022-in.jsonld</a>
+              <a href="expand/c022-in.jsonld">expand/c022-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c022-out.jsonld'>expand/c022-out.jsonld</a>
+              <a href="expand/c022-out.jsonld">expand/c022-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc023'>
+        <dt id="tc023">
           Test tc023 composed type-scoped property-scoped contexts including @type:@vocab
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc023</dd>
             <dt>Type</dt>
@@ -3846,26 +3874,26 @@
             <dd>composed type-scoped property-scoped contexts including @type:@vocab</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c023-in.jsonld'>expand/c023-in.jsonld</a>
+              <a href="expand/c023-in.jsonld">expand/c023-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c023-out.jsonld'>expand/c023-out.jsonld</a>
+              <a href="expand/c023-out.jsonld">expand/c023-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc024'>
+        <dt id="tc024">
           Test tc024 type-scoped + property-scoped + values evaluates against previous context
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc024</dd>
             <dt>Type</dt>
@@ -3874,26 +3902,26 @@
             <dd>type-scoped + property-scoped + values evaluates against previous context</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c024-in.jsonld'>expand/c024-in.jsonld</a>
+              <a href="expand/c024-in.jsonld">expand/c024-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c024-out.jsonld'>expand/c024-out.jsonld</a>
+              <a href="expand/c024-out.jsonld">expand/c024-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc025'>
+        <dt id="tc025">
           Test tc025 type-scoped + graph container
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc025</dd>
             <dt>Type</dt>
@@ -3902,26 +3930,26 @@
             <dd>type-scoped + graph container</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c025-in.jsonld'>expand/c025-in.jsonld</a>
+              <a href="expand/c025-in.jsonld">expand/c025-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c025-out.jsonld'>expand/c025-out.jsonld</a>
+              <a href="expand/c025-out.jsonld">expand/c025-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc026'>
+        <dt id="tc026">
           Test tc026 @propagate: true on type-scoped context
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc026</dd>
             <dt>Type</dt>
@@ -3930,26 +3958,26 @@
             <dd>type-scoped context with @propagate: true survive node-objects</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c026-in.jsonld'>expand/c026-in.jsonld</a>
+              <a href="expand/c026-in.jsonld">expand/c026-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c026-out.jsonld'>expand/c026-out.jsonld</a>
+              <a href="expand/c026-out.jsonld">expand/c026-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc027'>
+        <dt id="tc027">
           Test tc027 @propagate: false on property-scoped context
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc027</dd>
             <dt>Type</dt>
@@ -3958,26 +3986,26 @@
             <dd>property-scoped context with @propagate: false do not survive node-objects</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c027-in.jsonld'>expand/c027-in.jsonld</a>
+              <a href="expand/c027-in.jsonld">expand/c027-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c027-out.jsonld'>expand/c027-out.jsonld</a>
+              <a href="expand/c027-out.jsonld">expand/c027-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc028'>
+        <dt id="tc028">
           Test tc028 @propagate: false on embedded context
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc028</dd>
             <dt>Type</dt>
@@ -3986,26 +4014,26 @@
             <dd>embedded context with @propagate: false do not survive node-objects</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c028-in.jsonld'>expand/c028-in.jsonld</a>
+              <a href="expand/c028-in.jsonld">expand/c028-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c028-out.jsonld'>expand/c028-out.jsonld</a>
+              <a href="expand/c028-out.jsonld">expand/c028-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc029'>
+        <dt id="tc029">
           Test tc029 @propagate is invalid in 1.0
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc029</dd>
             <dt>Type</dt>
@@ -4014,7 +4042,7 @@
             <dd>@propagate is invalid in 1.0</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c029-in.jsonld'>expand/c029-in.jsonld</a>
+              <a href="expand/c029-in.jsonld">expand/c029-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4022,7 +4050,7 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
                 <dt>processingMode</dt>
@@ -4031,11 +4059,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='tc030'>
+        <dt id="tc030">
           Test tc030 @propagate must be boolean valued
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc030</dd>
             <dt>Type</dt>
@@ -4044,7 +4072,7 @@
             <dd>@propagate must be boolean valued</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c030-in.jsonld'>expand/c030-in.jsonld</a>
+              <a href="expand/c030-in.jsonld">expand/c030-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4052,18 +4080,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc031'>
+        <dt id="tc031">
           Test tc031 @context resolutions respects relative URLs.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc031</dd>
             <dt>Type</dt>
@@ -4072,26 +4100,26 @@
             <dd>URL resolution follows RFC3986</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c031-in.jsonld'>expand/c031-in.jsonld</a>
+              <a href="expand/c031-in.jsonld">expand/c031-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c031-out.jsonld'>expand/c031-out.jsonld</a>
+              <a href="expand/c031-out.jsonld">expand/c031-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc032'>
+        <dt id="tc032">
           Test tc032 Unused embedded context with error.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc032</dd>
             <dt>Type</dt>
@@ -4100,7 +4128,7 @@
             <dd>An embedded context which is never used should still be checked.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c032-in.jsonld'>expand/c032-in.jsonld</a>
+              <a href="expand/c032-in.jsonld">expand/c032-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4108,18 +4136,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc033'>
+        <dt id="tc033">
           Test tc033 Unused context with an embedded context error.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc033</dd>
             <dt>Type</dt>
@@ -4128,7 +4156,7 @@
             <dd>An unused context with an embedded context should still be checked.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c033-in.jsonld'>expand/c033-in.jsonld</a>
+              <a href="expand/c033-in.jsonld">expand/c033-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4136,18 +4164,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc034'>
+        <dt id="tc034">
           Test tc034 Remote scoped context.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc034</dd>
             <dt>Type</dt>
@@ -4156,26 +4184,26 @@
             <dd>Scoped contexts may be externally loaded.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c034-in.jsonld'>expand/c034-in.jsonld</a>
+              <a href="expand/c034-in.jsonld">expand/c034-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c034-out.jsonld'>expand/c034-out.jsonld</a>
+              <a href="expand/c034-out.jsonld">expand/c034-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc035'>
+        <dt id="tc035">
           Test tc035 Term scoping with embedded contexts.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc035</dd>
             <dt>Type</dt>
@@ -4184,26 +4212,26 @@
             <dd>Terms should make use of @vocab relative to the scope in which the term was defined.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c035-in.jsonld'>expand/c035-in.jsonld</a>
+              <a href="expand/c035-in.jsonld">expand/c035-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c035-out.jsonld'>expand/c035-out.jsonld</a>
+              <a href="expand/c035-out.jsonld">expand/c035-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc036'>
+        <dt id="tc036">
           Test tc036 Expansion with empty property-scoped context.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc036</dd>
             <dt>Type</dt>
@@ -4212,26 +4240,26 @@
             <dd>Adding a minimal/empty property-scoped context should not affect expansion of terms defined in the outer scope.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c036-in.jsonld'>expand/c036-in.jsonld</a>
+              <a href="expand/c036-in.jsonld">expand/c036-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c036-out.jsonld'>expand/c036-out.jsonld</a>
+              <a href="expand/c036-out.jsonld">expand/c036-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc037'>
+        <dt id="tc037">
           Test tc037 property-scoped contexts which are alias of @nest
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc037</dd>
             <dt>Type</dt>
@@ -4240,26 +4268,26 @@
             <dd>Nesting terms may have property-scoped contexts defined.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c037-in.jsonld'>expand/c037-in.jsonld</a>
+              <a href="expand/c037-in.jsonld">expand/c037-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c037-out.jsonld'>expand/c037-out.jsonld</a>
+              <a href="expand/c037-out.jsonld">expand/c037-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tc038'>
+        <dt id="tc038">
           Test tc038 Bibframe example (poor-mans inferrence)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tc038</dd>
             <dt>Type</dt>
@@ -4268,26 +4296,26 @@
             <dd>Nesting terms may have property-scoped contexts defined.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/c038-in.jsonld'>expand/c038-in.jsonld</a>
+              <a href="expand/c038-in.jsonld">expand/c038-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/c038-out.jsonld'>expand/c038-out.jsonld</a>
+              <a href="expand/c038-out.jsonld">expand/c038-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tdi01'>
+        <dt id="tdi01">
           Test tdi01 Expand string using default and term directions
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tdi01</dd>
             <dt>Type</dt>
@@ -4296,26 +4324,26 @@
             <dd>Strings are coerced to have @direction based on default and term direction.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/di01-in.jsonld'>expand/di01-in.jsonld</a>
+              <a href="expand/di01-in.jsonld">expand/di01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/di01-out.jsonld'>expand/di01-out.jsonld</a>
+              <a href="expand/di01-out.jsonld">expand/di01-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tdi02'>
+        <dt id="tdi02">
           Test tdi02 Expand string using default and term directions and languages
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tdi02</dd>
             <dt>Type</dt>
@@ -4324,26 +4352,26 @@
             <dd>Strings are coerced to have @direction based on default and term direction.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/di02-in.jsonld'>expand/di02-in.jsonld</a>
+              <a href="expand/di02-in.jsonld">expand/di02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/di02-out.jsonld'>expand/di02-out.jsonld</a>
+              <a href="expand/di02-out.jsonld">expand/di02-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tdi03'>
+        <dt id="tdi03">
           Test tdi03 expand list values with @direction
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tdi03</dd>
             <dt>Type</dt>
@@ -4352,26 +4380,26 @@
             <dd>List values where the term has @direction are used in expansion.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/di03-in.jsonld'>expand/di03-in.jsonld</a>
+              <a href="expand/di03-in.jsonld">expand/di03-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/di03-out.jsonld'>expand/di03-out.jsonld</a>
+              <a href="expand/di03-out.jsonld">expand/di03-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tdi04'>
+        <dt id="tdi04">
           Test tdi04 simple language map with term direction
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tdi04</dd>
             <dt>Type</dt>
@@ -4380,26 +4408,26 @@
             <dd>Term selection with language maps and @direction.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/di04-in.jsonld'>expand/di04-in.jsonld</a>
+              <a href="expand/di04-in.jsonld">expand/di04-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/di04-out.jsonld'>expand/di04-out.jsonld</a>
+              <a href="expand/di04-out.jsonld">expand/di04-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tdi05'>
+        <dt id="tdi05">
           Test tdi05 simple language mapwith overriding term direction
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tdi05</dd>
             <dt>Type</dt>
@@ -4408,26 +4436,26 @@
             <dd>Term selection with language maps and @direction.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/di05-in.jsonld'>expand/di05-in.jsonld</a>
+              <a href="expand/di05-in.jsonld">expand/di05-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/di05-out.jsonld'>expand/di05-out.jsonld</a>
+              <a href="expand/di05-out.jsonld">expand/di05-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tdi06'>
+        <dt id="tdi06">
           Test tdi06 simple language mapwith overriding null direction
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tdi06</dd>
             <dt>Type</dt>
@@ -4436,26 +4464,26 @@
             <dd>Term selection with language maps and @direction.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/di06-in.jsonld'>expand/di06-in.jsonld</a>
+              <a href="expand/di06-in.jsonld">expand/di06-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/di06-out.jsonld'>expand/di06-out.jsonld</a>
+              <a href="expand/di06-out.jsonld">expand/di06-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tdi07'>
+        <dt id="tdi07">
           Test tdi07 simple language map with mismatching term direction
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tdi07</dd>
             <dt>Type</dt>
@@ -4464,26 +4492,26 @@
             <dd>Term selection with language maps and @direction.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/di07-in.jsonld'>expand/di07-in.jsonld</a>
+              <a href="expand/di07-in.jsonld">expand/di07-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/di07-out.jsonld'>expand/di07-out.jsonld</a>
+              <a href="expand/di07-out.jsonld">expand/di07-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tdi08'>
+        <dt id="tdi08">
           Test tdi08 @direction must be one of ltr or rtl
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tdi08</dd>
             <dt>Type</dt>
@@ -4492,7 +4520,7 @@
             <dd>Generate an error if @direction has illegal value.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/di08-in.jsonld'>expand/di08-in.jsonld</a>
+              <a href="expand/di08-in.jsonld">expand/di08-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4500,18 +4528,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tdi09'>
+        <dt id="tdi09">
           Test tdi09 @direction is incompatible with @type
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tdi09</dd>
             <dt>Type</dt>
@@ -4520,7 +4548,7 @@
             <dd>Value objects can have either @type but not @language or @direction.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/di09-in.jsonld'>expand/di09-in.jsonld</a>
+              <a href="expand/di09-in.jsonld">expand/di09-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4528,18 +4556,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tec01'>
+        <dt id="tec01">
           Test tec01 Invalid keyword in term definition
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tec01</dd>
             <dt>Type</dt>
@@ -4548,7 +4576,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid term definition is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/ec01-in.jsonld'>expand/ec01-in.jsonld</a>
+              <a href="expand/ec01-in.jsonld">expand/ec01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4556,18 +4584,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tec02'>
+        <dt id="tec02">
           Test tec02 Term definition on @type with empty map
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tec02</dd>
             <dt>Type</dt>
@@ -4576,7 +4604,7 @@
             <dd>Verifies that an exception is raised if @type is defined as a term with an empty map</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/ec02-in.jsonld'>expand/ec02-in.jsonld</a>
+              <a href="expand/ec02-in.jsonld">expand/ec02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4584,18 +4612,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tem01'>
+        <dt id="tem01">
           Test tem01 Invalid container mapping
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tem01</dd>
             <dt>Type</dt>
@@ -4604,7 +4632,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid container mapping is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/em01-in.jsonld'>expand/em01-in.jsonld</a>
+              <a href="expand/em01-in.jsonld">expand/em01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4612,18 +4640,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='ten01'>
+        <dt id="ten01">
           Test ten01 @nest MUST NOT have a string value
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ten01</dd>
             <dt>Type</dt>
@@ -4632,7 +4660,7 @@
             <dd>container: @nest</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/en01-in.jsonld'>expand/en01-in.jsonld</a>
+              <a href="expand/en01-in.jsonld">expand/en01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4640,18 +4668,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='ten02'>
+        <dt id="ten02">
           Test ten02 @nest MUST NOT have a boolen value
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ten02</dd>
             <dt>Type</dt>
@@ -4660,7 +4688,7 @@
             <dd>Transparent Nesting</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/en02-in.jsonld'>expand/en02-in.jsonld</a>
+              <a href="expand/en02-in.jsonld">expand/en02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4668,18 +4696,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='ten03'>
+        <dt id="ten03">
           Test ten03 @nest MUST NOT have a numeric value
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ten03</dd>
             <dt>Type</dt>
@@ -4688,7 +4716,7 @@
             <dd>Transparent Nesting</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/en03-in.jsonld'>expand/en03-in.jsonld</a>
+              <a href="expand/en03-in.jsonld">expand/en03-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4696,18 +4724,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='ten04'>
+        <dt id="ten04">
           Test ten04 @nest MUST NOT have a value object value
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ten04</dd>
             <dt>Type</dt>
@@ -4716,7 +4744,7 @@
             <dd>Transparent Nesting</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/en04-in.jsonld'>expand/en04-in.jsonld</a>
+              <a href="expand/en04-in.jsonld">expand/en04-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4724,18 +4752,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='ten05'>
+        <dt id="ten05">
           Test ten05 does not allow a keyword other than @nest for the value of @nest
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ten05</dd>
             <dt>Type</dt>
@@ -4744,7 +4772,7 @@
             <dd>Transparent Nesting</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/en05-in.jsonld'>expand/en05-in.jsonld</a>
+              <a href="expand/en05-in.jsonld">expand/en05-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4752,18 +4780,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='ten06'>
+        <dt id="ten06">
           Test ten06 does not allow @nest with @reverse
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ten06</dd>
             <dt>Type</dt>
@@ -4772,7 +4800,7 @@
             <dd>Transparent Nesting</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/en06-in.jsonld'>expand/en06-in.jsonld</a>
+              <a href="expand/en06-in.jsonld">expand/en06-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4780,18 +4808,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tep02'>
+        <dt id="tep02">
           Test tep02 processingMode json-ld-1.0 conflicts with @version: 1.1
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tep02</dd>
             <dt>Type</dt>
@@ -4800,7 +4828,7 @@
             <dd>If processingMode is explicitly json-ld-1.0, it will conflict with 1.1 features.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/ep02-in.jsonld'>expand/ep02-in.jsonld</a>
+              <a href="expand/ep02-in.jsonld">expand/ep02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4808,7 +4836,7 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>processingMode</dt>
                 <dd>json-ld-1.0</dd>
                 <dt>specVersion</dt>
@@ -4817,11 +4845,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='tep03'>
+        <dt id="tep03">
           Test tep03 @version must be 1.1
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tep03</dd>
             <dt>Type</dt>
@@ -4830,7 +4858,7 @@
             <dd>If @version is specified, it must be 1.1</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/ep03-in.jsonld'>expand/ep03-in.jsonld</a>
+              <a href="expand/ep03-in.jsonld">expand/ep03-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4838,18 +4866,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='ter01'>
+        <dt id="ter01">
           Test ter01 Keywords cannot be aliased to other keywords
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter01</dd>
             <dt>Type</dt>
@@ -4858,7 +4886,7 @@
             <dd>Verifies that an exception is raised on expansion when processing an invalid context aliasing a keyword to another keyword</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er01-in.jsonld'>expand/er01-in.jsonld</a>
+              <a href="expand/er01-in.jsonld">expand/er01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4866,11 +4894,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter02'>
+        <dt id="ter02">
           Test ter02 A context may not include itself recursively (direct)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter02</dd>
             <dt>Type</dt>
@@ -4879,7 +4907,7 @@
             <dd>Verifies that an exception is raised on expansion when processing a context referencing itself</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er02-in.jsonld'>expand/er02-in.jsonld</a>
+              <a href="expand/er02-in.jsonld">expand/er02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4887,18 +4915,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.0</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='ter03'>
+        <dt id="ter03">
           Test ter03 A context may not include itself recursively (indirect)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter03</dd>
             <dt>Type</dt>
@@ -4907,7 +4935,7 @@
             <dd>Verifies that an exception is raised on expansion when processing a context referencing itself indirectly</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er03-in.jsonld'>expand/er03-in.jsonld</a>
+              <a href="expand/er03-in.jsonld">expand/er03-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4915,18 +4943,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.0</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='ter04'>
+        <dt id="ter04">
           Test ter04 Error dereferencing a remote context
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter04</dd>
             <dt>Type</dt>
@@ -4935,7 +4963,7 @@
             <dd>Verifies that an exception is raised on expansion when a context dereference results in an error</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er04-in.jsonld'>expand/er04-in.jsonld</a>
+              <a href="expand/er04-in.jsonld">expand/er04-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4943,11 +4971,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter05'>
+        <dt id="ter05">
           Test ter05 Invalid remote context
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter05</dd>
             <dt>Type</dt>
@@ -4956,7 +4984,7 @@
             <dd>Verifies that an exception is raised on expansion when a remote context is not an object containing @context</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er05-in.jsonld'>expand/er05-in.jsonld</a>
+              <a href="expand/er05-in.jsonld">expand/er05-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4964,18 +4992,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='ter06'>
+        <dt id="ter06">
           Test ter06 Invalid local context
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter06</dd>
             <dt>Type</dt>
@@ -4984,7 +5012,7 @@
             <dd>Verifies that an exception is raised on expansion when a context is not a string or object</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er06-in.jsonld'>expand/er06-in.jsonld</a>
+              <a href="expand/er06-in.jsonld">expand/er06-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4992,11 +5020,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter07'>
+        <dt id="ter07">
           Test ter07 Invalid base IRI
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter07</dd>
             <dt>Type</dt>
@@ -5005,7 +5033,7 @@
             <dd>Verifies that an exception is raised on expansion when a context contains an invalid @base</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er07-in.jsonld'>expand/er07-in.jsonld</a>
+              <a href="expand/er07-in.jsonld">expand/er07-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5013,11 +5041,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter08'>
+        <dt id="ter08">
           Test ter08 Invalid vocab mapping
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter08</dd>
             <dt>Type</dt>
@@ -5026,7 +5054,7 @@
             <dd>Verifies that an exception is raised on expansion when a context contains an invalid @vocab mapping</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er08-in.jsonld'>expand/er08-in.jsonld</a>
+              <a href="expand/er08-in.jsonld">expand/er08-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5034,11 +5062,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter09'>
+        <dt id="ter09">
           Test ter09 Invalid default language
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter09</dd>
             <dt>Type</dt>
@@ -5047,7 +5075,7 @@
             <dd>Verifies that an exception is raised on expansion when a context contains an invalid @language</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er09-in.jsonld'>expand/er09-in.jsonld</a>
+              <a href="expand/er09-in.jsonld">expand/er09-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5055,11 +5083,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter10'>
+        <dt id="ter10">
           Test ter10 Cyclic IRI mapping
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter10</dd>
             <dt>Type</dt>
@@ -5068,7 +5096,7 @@
             <dd>Verifies that an exception is raised on expansion when a cyclic IRI mapping is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er10-in.jsonld'>expand/er10-in.jsonld</a>
+              <a href="expand/er10-in.jsonld">expand/er10-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5076,11 +5104,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter11'>
+        <dt id="ter11">
           Test ter11 Invalid term definition
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter11</dd>
             <dt>Type</dt>
@@ -5089,7 +5117,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid term definition is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er11-in.jsonld'>expand/er11-in.jsonld</a>
+              <a href="expand/er11-in.jsonld">expand/er11-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5097,11 +5125,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter12'>
+        <dt id="ter12">
           Test ter12 Invalid type mapping (not a string)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter12</dd>
             <dt>Type</dt>
@@ -5110,7 +5138,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid type mapping is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er12-in.jsonld'>expand/er12-in.jsonld</a>
+              <a href="expand/er12-in.jsonld">expand/er12-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5118,11 +5146,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter13'>
+        <dt id="ter13">
           Test ter13 Invalid type mapping (not absolute IRI)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter13</dd>
             <dt>Type</dt>
@@ -5131,7 +5159,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid type mapping is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er13-in.jsonld'>expand/er13-in.jsonld</a>
+              <a href="expand/er13-in.jsonld">expand/er13-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5139,11 +5167,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter14'>
+        <dt id="ter14">
           Test ter14 Invalid reverse property (contains @id)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter14</dd>
             <dt>Type</dt>
@@ -5152,7 +5180,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid reverse property is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er14-in.jsonld'>expand/er14-in.jsonld</a>
+              <a href="expand/er14-in.jsonld">expand/er14-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5160,11 +5188,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter15'>
+        <dt id="ter15">
           Test ter15 Invalid IRI mapping (@reverse not a string)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter15</dd>
             <dt>Type</dt>
@@ -5173,7 +5201,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid IRI mapping is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er15-in.jsonld'>expand/er15-in.jsonld</a>
+              <a href="expand/er15-in.jsonld">expand/er15-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5181,11 +5209,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter17'>
+        <dt id="ter17">
           Test ter17 Invalid reverse property (invalid @container)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter17</dd>
             <dt>Type</dt>
@@ -5194,7 +5222,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid reverse property is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er17-in.jsonld'>expand/er17-in.jsonld</a>
+              <a href="expand/er17-in.jsonld">expand/er17-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5202,11 +5230,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter18'>
+        <dt id="ter18">
           Test ter18 Invalid IRI mapping (@id not a string)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter18</dd>
             <dt>Type</dt>
@@ -5215,7 +5243,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid IRI mapping is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er18-in.jsonld'>expand/er18-in.jsonld</a>
+              <a href="expand/er18-in.jsonld">expand/er18-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5223,11 +5251,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter19'>
+        <dt id="ter19">
           Test ter19 Invalid keyword alias (@context)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter19</dd>
             <dt>Type</dt>
@@ -5236,7 +5264,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid keyword alias is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er19-in.jsonld'>expand/er19-in.jsonld</a>
+              <a href="expand/er19-in.jsonld">expand/er19-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5244,11 +5272,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter20'>
+        <dt id="ter20">
           Test ter20 Invalid IRI mapping (no vocab mapping)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter20</dd>
             <dt>Type</dt>
@@ -5257,7 +5285,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid IRI mapping is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er20-in.jsonld'>expand/er20-in.jsonld</a>
+              <a href="expand/er20-in.jsonld">expand/er20-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5265,11 +5293,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter21'>
+        <dt id="ter21">
           Test ter21 Invalid container mapping
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter21</dd>
             <dt>Type</dt>
@@ -5278,7 +5306,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid container mapping is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er21-in.jsonld'>expand/er21-in.jsonld</a>
+              <a href="expand/er21-in.jsonld">expand/er21-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5286,7 +5314,7 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>processingMode</dt>
                 <dd>json-ld-1.0</dd>
                 <dt>specVersion</dt>
@@ -5295,11 +5323,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter22'>
+        <dt id="ter22">
           Test ter22 Invalid language mapping
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter22</dd>
             <dt>Type</dt>
@@ -5308,7 +5336,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid language mapping is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er22-in.jsonld'>expand/er22-in.jsonld</a>
+              <a href="expand/er22-in.jsonld">expand/er22-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5316,11 +5344,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter23'>
+        <dt id="ter23">
           Test ter23 Invalid IRI mapping (relative IRI in @type)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter23</dd>
             <dt>Type</dt>
@@ -5329,7 +5357,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid type mapping is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er23-in.jsonld'>expand/er23-in.jsonld</a>
+              <a href="expand/er23-in.jsonld">expand/er23-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5337,11 +5365,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter24'>
+        <dt id="ter24">
           Test ter24 List of lists (from array)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter24</dd>
             <dt>Type</dt>
@@ -5350,7 +5378,7 @@
             <dd>Verifies that an exception is raised in Expansion when a list of lists is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er24-in.jsonld'>expand/er24-in.jsonld</a>
+              <a href="expand/er24-in.jsonld">expand/er24-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5358,18 +5386,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.0</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='ter25'>
+        <dt id="ter25">
           Test ter25 Invalid reverse property map
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter25</dd>
             <dt>Type</dt>
@@ -5378,7 +5406,7 @@
             <dd>Verifies that an exception is raised in Expansion when a invalid reverse property map is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er25-in.jsonld'>expand/er25-in.jsonld</a>
+              <a href="expand/er25-in.jsonld">expand/er25-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5386,11 +5414,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter26'>
+        <dt id="ter26">
           Test ter26 Colliding keywords
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter26</dd>
             <dt>Type</dt>
@@ -5399,7 +5427,7 @@
             <dd>Verifies that an exception is raised in Expansion when colliding keywords are found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er26-in.jsonld'>expand/er26-in.jsonld</a>
+              <a href="expand/er26-in.jsonld">expand/er26-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5407,11 +5435,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter27'>
+        <dt id="ter27">
           Test ter27 Invalid @id value
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter27</dd>
             <dt>Type</dt>
@@ -5420,7 +5448,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid @id value is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er27-in.jsonld'>expand/er27-in.jsonld</a>
+              <a href="expand/er27-in.jsonld">expand/er27-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5428,11 +5456,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter28'>
+        <dt id="ter28">
           Test ter28 Invalid type value
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter28</dd>
             <dt>Type</dt>
@@ -5441,7 +5469,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid type value is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er28-in.jsonld'>expand/er28-in.jsonld</a>
+              <a href="expand/er28-in.jsonld">expand/er28-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5449,11 +5477,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter29'>
+        <dt id="ter29">
           Test ter29 Invalid value object value
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter29</dd>
             <dt>Type</dt>
@@ -5462,7 +5490,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid value object value is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er29-in.jsonld'>expand/er29-in.jsonld</a>
+              <a href="expand/er29-in.jsonld">expand/er29-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5470,11 +5498,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter30'>
+        <dt id="ter30">
           Test ter30 Invalid language-tagged string
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter30</dd>
             <dt>Type</dt>
@@ -5483,7 +5511,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid language-tagged string value is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er30-in.jsonld'>expand/er30-in.jsonld</a>
+              <a href="expand/er30-in.jsonld">expand/er30-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5491,11 +5519,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter31'>
+        <dt id="ter31">
           Test ter31 Invalid @index value
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter31</dd>
             <dt>Type</dt>
@@ -5504,7 +5532,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid @index value value is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er31-in.jsonld'>expand/er31-in.jsonld</a>
+              <a href="expand/er31-in.jsonld">expand/er31-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5512,11 +5540,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter32'>
+        <dt id="ter32">
           Test ter32 List of lists (from array)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter32</dd>
             <dt>Type</dt>
@@ -5525,7 +5553,7 @@
             <dd>Verifies that an exception is raised in Expansion when a list of lists is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er32-in.jsonld'>expand/er32-in.jsonld</a>
+              <a href="expand/er32-in.jsonld">expand/er32-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5533,18 +5561,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.0</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='ter33'>
+        <dt id="ter33">
           Test ter33 Invalid @reverse value
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter33</dd>
             <dt>Type</dt>
@@ -5553,7 +5581,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid @reverse value is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er33-in.jsonld'>expand/er33-in.jsonld</a>
+              <a href="expand/er33-in.jsonld">expand/er33-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5561,11 +5589,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter34'>
+        <dt id="ter34">
           Test ter34 Invalid reverse property value (in @reverse)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter34</dd>
             <dt>Type</dt>
@@ -5574,7 +5602,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid reverse property value is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er34-in.jsonld'>expand/er34-in.jsonld</a>
+              <a href="expand/er34-in.jsonld">expand/er34-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5582,11 +5610,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter35'>
+        <dt id="ter35">
           Test ter35 Invalid language map value
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter35</dd>
             <dt>Type</dt>
@@ -5595,7 +5623,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid language map value is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er35-in.jsonld'>expand/er35-in.jsonld</a>
+              <a href="expand/er35-in.jsonld">expand/er35-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5603,11 +5631,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter36'>
+        <dt id="ter36">
           Test ter36 Invalid reverse property value (through coercion)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter36</dd>
             <dt>Type</dt>
@@ -5616,7 +5644,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid reverse property value is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er36-in.jsonld'>expand/er36-in.jsonld</a>
+              <a href="expand/er36-in.jsonld">expand/er36-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5624,11 +5652,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter37'>
+        <dt id="ter37">
           Test ter37 Invalid value object (unexpected keyword)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter37</dd>
             <dt>Type</dt>
@@ -5637,7 +5665,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid value object is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er37-in.jsonld'>expand/er37-in.jsonld</a>
+              <a href="expand/er37-in.jsonld">expand/er37-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5645,11 +5673,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter38'>
+        <dt id="ter38">
           Test ter38 Invalid value object (@type and @language)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter38</dd>
             <dt>Type</dt>
@@ -5658,7 +5686,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid value object is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er38-in.jsonld'>expand/er38-in.jsonld</a>
+              <a href="expand/er38-in.jsonld">expand/er38-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5666,11 +5694,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter39'>
+        <dt id="ter39">
           Test ter39 Invalid language-tagged value
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter39</dd>
             <dt>Type</dt>
@@ -5679,7 +5707,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid language-tagged value is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er39-in.jsonld'>expand/er39-in.jsonld</a>
+              <a href="expand/er39-in.jsonld">expand/er39-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5687,11 +5715,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter40'>
+        <dt id="ter40">
           Test ter40 Invalid typed value
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter40</dd>
             <dt>Type</dt>
@@ -5700,7 +5728,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid typed value is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er40-in.jsonld'>expand/er40-in.jsonld</a>
+              <a href="expand/er40-in.jsonld">expand/er40-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5708,11 +5736,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter41'>
+        <dt id="ter41">
           Test ter41 Invalid set or list object
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter41</dd>
             <dt>Type</dt>
@@ -5721,7 +5749,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid set or list object is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er41-in.jsonld'>expand/er41-in.jsonld</a>
+              <a href="expand/er41-in.jsonld">expand/er41-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5729,11 +5757,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter42'>
+        <dt id="ter42">
           Test ter42 Keywords may not be redefined in 1.0
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter42</dd>
             <dt>Type</dt>
@@ -5742,7 +5770,7 @@
             <dd>Verifies that an exception is raised on expansion when processing an invalid context attempting to define @container on a keyword</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er42-in.jsonld'>expand/er42-in.jsonld</a>
+              <a href="expand/er42-in.jsonld">expand/er42-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5750,7 +5778,7 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
                 <dt>processingMode</dt>
@@ -5759,11 +5787,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter43'>
+        <dt id="ter43">
           Test ter43 Term definition with @id: @type
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter43</dd>
             <dt>Type</dt>
@@ -5772,7 +5800,7 @@
             <dd>Expanding term mapping to @type uses @type syntax now illegal</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er43-in.jsonld'>expand/er43-in.jsonld</a>
+              <a href="expand/er43-in.jsonld">expand/er43-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5780,18 +5808,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='ter44'>
+        <dt id="ter44">
           Test ter44 Redefine terms looking like compact IRIs
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter44</dd>
             <dt>Type</dt>
@@ -5800,7 +5828,7 @@
             <dd>Term definitions may look like compact IRIs, but must be consistent.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er44-in.jsonld'>expand/er44-in.jsonld</a>
+              <a href="expand/er44-in.jsonld">expand/er44-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5808,18 +5836,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='ter48'>
+        <dt id="ter48">
           Test ter48 Invalid term as relative IRI
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter48</dd>
             <dt>Type</dt>
@@ -5828,7 +5856,7 @@
             <dd>Verifies that a relative IRI cannot be used as a term.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er48-in.jsonld'>expand/er48-in.jsonld</a>
+              <a href="expand/er48-in.jsonld">expand/er48-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5836,18 +5864,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='ter49'>
+        <dt id="ter49">
           Test ter49 A relative IRI cannot be used as a prefix
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter49</dd>
             <dt>Type</dt>
@@ -5856,7 +5884,7 @@
             <dd>Verifies that a relative IRI cannot be used as a term.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er49-in.jsonld'>expand/er49-in.jsonld</a>
+              <a href="expand/er49-in.jsonld">expand/er49-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5864,18 +5892,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='ter50'>
+        <dt id="ter50">
           Test ter50 Invalid reverse id
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter50</dd>
             <dt>Type</dt>
@@ -5884,7 +5912,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid IRI is used for @reverse.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er50-in.jsonld'>expand/er50-in.jsonld</a>
+              <a href="expand/er50-in.jsonld">expand/er50-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5892,11 +5920,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter51'>
+        <dt id="ter51">
           Test ter51 Invalid value object value using a value alias
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter51</dd>
             <dt>Type</dt>
@@ -5905,7 +5933,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid value object value is found using a value alias</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er51-in.jsonld'>expand/er51-in.jsonld</a>
+              <a href="expand/er51-in.jsonld">expand/er51-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5913,11 +5941,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter52'>
+        <dt id="ter52">
           Test ter52 Definition for the empty term
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter52</dd>
             <dt>Type</dt>
@@ -5926,7 +5954,7 @@
             <dd>Verifies that an exception is raised on expansion when a context contains a definition for the empty term</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er52-in.jsonld'>expand/er52-in.jsonld</a>
+              <a href="expand/er52-in.jsonld">expand/er52-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5934,11 +5962,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter53'>
+        <dt id="ter53">
           Test ter53 Invalid prefix value
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter53</dd>
             <dt>Type</dt>
@@ -5947,7 +5975,7 @@
             <dd>Verifies that an exception is raised on expansion when a context contains an invalid @prefix value</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er53-in.jsonld'>expand/er53-in.jsonld</a>
+              <a href="expand/er53-in.jsonld">expand/er53-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5955,18 +5983,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='ter54'>
+        <dt id="ter54">
           Test ter54 Invalid value object, multiple values for @type.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter54</dd>
             <dt>Type</dt>
@@ -5975,7 +6003,7 @@
             <dd>The value of @type in a value object MUST be a string or null.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er54-in.jsonld'>expand/er54-in.jsonld</a>
+              <a href="expand/er54-in.jsonld">expand/er54-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5983,11 +6011,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter55'>
+        <dt id="ter55">
           Test ter55 Invalid term definition, multiple values for @type.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter55</dd>
             <dt>Type</dt>
@@ -5996,7 +6024,7 @@
             <dd>The value of @type in an expanded term definition object MUST be a string or null.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er55-in.jsonld'>expand/er55-in.jsonld</a>
+              <a href="expand/er55-in.jsonld">expand/er55-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -6004,11 +6032,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ter56'>
+        <dt id="ter56">
           Test ter56 Invalid redefinition of @context keyword.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ter56</dd>
             <dt>Type</dt>
@@ -6017,7 +6045,7 @@
             <dd>Verifies that an exception is raised when attempting to redefine @context.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/er56-in.jsonld'>expand/er56-in.jsonld</a>
+              <a href="expand/er56-in.jsonld">expand/er56-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -6025,11 +6053,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='tes01'>
+        <dt id="tes01">
           Test tes01 Using an array value for @context is illegal in JSON-LD 1.0
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tes01</dd>
             <dt>Type</dt>
@@ -6038,7 +6066,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid container mapping is found</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/es01-in.jsonld'>expand/es01-in.jsonld</a>
+              <a href="expand/es01-in.jsonld">expand/es01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -6046,7 +6074,7 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>processingMode</dt>
                 <dd>json-ld-1.0</dd>
                 <dt>specVersion</dt>
@@ -6055,11 +6083,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='tes02'>
+        <dt id="tes02">
           Test tes02 Mapping @container: [@list, @set] is invalid
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tes02</dd>
             <dt>Type</dt>
@@ -6068,7 +6096,7 @@
             <dd>Testing legal combinations of @set with other container values</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/es02-in.jsonld'>expand/es02-in.jsonld</a>
+              <a href="expand/es02-in.jsonld">expand/es02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -6076,18 +6104,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tin01'>
+        <dt id="tin01">
           Test tin01 Basic Included array
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tin01</dd>
             <dt>Type</dt>
@@ -6096,26 +6124,26 @@
             <dd>Tests included blocks.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/in01-in.jsonld'>expand/in01-in.jsonld</a>
+              <a href="expand/in01-in.jsonld">expand/in01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/in01-out.jsonld'>expand/in01-out.jsonld</a>
+              <a href="expand/in01-out.jsonld">expand/in01-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tin02'>
+        <dt id="tin02">
           Test tin02 Basic Included object
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tin02</dd>
             <dt>Type</dt>
@@ -6124,26 +6152,26 @@
             <dd>Tests included blocks.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/in02-in.jsonld'>expand/in02-in.jsonld</a>
+              <a href="expand/in02-in.jsonld">expand/in02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/in02-out.jsonld'>expand/in02-out.jsonld</a>
+              <a href="expand/in02-out.jsonld">expand/in02-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tin03'>
+        <dt id="tin03">
           Test tin03 Multiple properties mapping to @included are folded together
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tin03</dd>
             <dt>Type</dt>
@@ -6152,26 +6180,26 @@
             <dd>Tests included blocks.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/in03-in.jsonld'>expand/in03-in.jsonld</a>
+              <a href="expand/in03-in.jsonld">expand/in03-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/in03-out.jsonld'>expand/in03-out.jsonld</a>
+              <a href="expand/in03-out.jsonld">expand/in03-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tin04'>
+        <dt id="tin04">
           Test tin04 Included containing @included
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tin04</dd>
             <dt>Type</dt>
@@ -6180,26 +6208,26 @@
             <dd>Tests included blocks.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/in04-in.jsonld'>expand/in04-in.jsonld</a>
+              <a href="expand/in04-in.jsonld">expand/in04-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/in04-out.jsonld'>expand/in04-out.jsonld</a>
+              <a href="expand/in04-out.jsonld">expand/in04-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tin05'>
+        <dt id="tin05">
           Test tin05 Property value with @included
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tin05</dd>
             <dt>Type</dt>
@@ -6208,26 +6236,26 @@
             <dd>Tests included blocks.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/in05-in.jsonld'>expand/in05-in.jsonld</a>
+              <a href="expand/in05-in.jsonld">expand/in05-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/in05-out.jsonld'>expand/in05-out.jsonld</a>
+              <a href="expand/in05-out.jsonld">expand/in05-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tin06'>
+        <dt id="tin06">
           Test tin06 json.api example
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tin06</dd>
             <dt>Type</dt>
@@ -6236,26 +6264,26 @@
             <dd>Tests included blocks.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/in06-in.jsonld'>expand/in06-in.jsonld</a>
+              <a href="expand/in06-in.jsonld">expand/in06-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/in06-out.jsonld'>expand/in06-out.jsonld</a>
+              <a href="expand/in06-out.jsonld">expand/in06-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tin07'>
+        <dt id="tin07">
           Test tin07 Error if @included value is a string
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tin07</dd>
             <dt>Type</dt>
@@ -6264,7 +6292,7 @@
             <dd>Tests included blocks.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/in07-in.jsonld'>expand/in07-in.jsonld</a>
+              <a href="expand/in07-in.jsonld">expand/in07-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -6272,18 +6300,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tin08'>
+        <dt id="tin08">
           Test tin08 Error if @included value is a value object
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tin08</dd>
             <dt>Type</dt>
@@ -6292,7 +6320,7 @@
             <dd>Tests included blocks.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/in08-in.jsonld'>expand/in08-in.jsonld</a>
+              <a href="expand/in08-in.jsonld">expand/in08-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -6300,18 +6328,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tin09'>
+        <dt id="tin09">
           Test tin09 Error if @included value is a list object
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tin09</dd>
             <dt>Type</dt>
@@ -6320,7 +6348,7 @@
             <dd>Tests included blocks.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/in09-in.jsonld'>expand/in09-in.jsonld</a>
+              <a href="expand/in09-in.jsonld">expand/in09-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -6328,18 +6356,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tjs01'>
+        <dt id="tjs01">
           Test tjs01 Expand JSON literal (boolean true)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tjs01</dd>
             <dt>Type</dt>
@@ -6348,26 +6376,26 @@
             <dd>Tests expanding property with @type @json to a JSON literal (boolean true).</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/js01-in.jsonld'>expand/js01-in.jsonld</a>
+              <a href="expand/js01-in.jsonld">expand/js01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/js01-out.jsonld'>expand/js01-out.jsonld</a>
+              <a href="expand/js01-out.jsonld">expand/js01-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tjs02'>
+        <dt id="tjs02">
           Test tjs02 Expand JSON literal (boolean false)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tjs02</dd>
             <dt>Type</dt>
@@ -6376,26 +6404,26 @@
             <dd>Tests expanding property with @type @json to a JSON literal (boolean false).</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/js02-in.jsonld'>expand/js02-in.jsonld</a>
+              <a href="expand/js02-in.jsonld">expand/js02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/js02-out.jsonld'>expand/js02-out.jsonld</a>
+              <a href="expand/js02-out.jsonld">expand/js02-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tjs03'>
+        <dt id="tjs03">
           Test tjs03 Expand JSON literal (double)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tjs03</dd>
             <dt>Type</dt>
@@ -6404,26 +6432,26 @@
             <dd>Tests expanding property with @type @json to a JSON literal (double).</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/js03-in.jsonld'>expand/js03-in.jsonld</a>
+              <a href="expand/js03-in.jsonld">expand/js03-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/js03-out.jsonld'>expand/js03-out.jsonld</a>
+              <a href="expand/js03-out.jsonld">expand/js03-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tjs04'>
+        <dt id="tjs04">
           Test tjs04 Expand JSON literal (double-zero)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tjs04</dd>
             <dt>Type</dt>
@@ -6432,26 +6460,26 @@
             <dd>Tests expanding property with @type @json to a JSON literal (double-zero).</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/js04-in.jsonld'>expand/js04-in.jsonld</a>
+              <a href="expand/js04-in.jsonld">expand/js04-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/js04-out.jsonld'>expand/js04-out.jsonld</a>
+              <a href="expand/js04-out.jsonld">expand/js04-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tjs05'>
+        <dt id="tjs05">
           Test tjs05 Expand JSON literal (integer)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tjs05</dd>
             <dt>Type</dt>
@@ -6460,26 +6488,26 @@
             <dd>Tests expanding property with @type @json to a JSON literal (integer).</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/js05-in.jsonld'>expand/js05-in.jsonld</a>
+              <a href="expand/js05-in.jsonld">expand/js05-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/js05-out.jsonld'>expand/js05-out.jsonld</a>
+              <a href="expand/js05-out.jsonld">expand/js05-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tjs06'>
+        <dt id="tjs06">
           Test tjs06 Expand JSON literal (object)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tjs06</dd>
             <dt>Type</dt>
@@ -6488,26 +6516,26 @@
             <dd>Tests expanding property with @type @json to a JSON literal (object).</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/js06-in.jsonld'>expand/js06-in.jsonld</a>
+              <a href="expand/js06-in.jsonld">expand/js06-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/js06-out.jsonld'>expand/js06-out.jsonld</a>
+              <a href="expand/js06-out.jsonld">expand/js06-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tjs07'>
+        <dt id="tjs07">
           Test tjs07 Expand JSON literal (array)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tjs07</dd>
             <dt>Type</dt>
@@ -6516,26 +6544,26 @@
             <dd>Tests expanding property with @type @json to a JSON literal (array).</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/js07-in.jsonld'>expand/js07-in.jsonld</a>
+              <a href="expand/js07-in.jsonld">expand/js07-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/js07-out.jsonld'>expand/js07-out.jsonld</a>
+              <a href="expand/js07-out.jsonld">expand/js07-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tjs08'>
+        <dt id="tjs08">
           Test tjs08 Expand JSON literal with array canonicalization
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tjs08</dd>
             <dt>Type</dt>
@@ -6544,26 +6572,26 @@
             <dd>Tests expanding JSON literal with array canonicalization.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/js08-in.jsonld'>expand/js08-in.jsonld</a>
+              <a href="expand/js08-in.jsonld">expand/js08-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/js08-out.jsonld'>expand/js08-out.jsonld</a>
+              <a href="expand/js08-out.jsonld">expand/js08-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tjs09'>
+        <dt id="tjs09">
           Test tjs09 Transform JSON literal with string canonicalization
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tjs09</dd>
             <dt>Type</dt>
@@ -6572,26 +6600,26 @@
             <dd>Tests expanding JSON literal with string canonicalization.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/js09-in.jsonld'>expand/js09-in.jsonld</a>
+              <a href="expand/js09-in.jsonld">expand/js09-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/js09-out.jsonld'>expand/js09-out.jsonld</a>
+              <a href="expand/js09-out.jsonld">expand/js09-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tjs10'>
+        <dt id="tjs10">
           Test tjs10 Expand JSON literal with structural canonicalization
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tjs10</dd>
             <dt>Type</dt>
@@ -6600,26 +6628,26 @@
             <dd>Tests expanding JSON literal with structural canonicalization.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/js10-in.jsonld'>expand/js10-in.jsonld</a>
+              <a href="expand/js10-in.jsonld">expand/js10-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/js10-out.jsonld'>expand/js10-out.jsonld</a>
+              <a href="expand/js10-out.jsonld">expand/js10-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tjs11'>
+        <dt id="tjs11">
           Test tjs11 Expand JSON literal with unicode canonicalization
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tjs11</dd>
             <dt>Type</dt>
@@ -6628,26 +6656,26 @@
             <dd>Tests expanding JSON literal with unicode canonicalization.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/js11-in.jsonld'>expand/js11-in.jsonld</a>
+              <a href="expand/js11-in.jsonld">expand/js11-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/js11-out.jsonld'>expand/js11-out.jsonld</a>
+              <a href="expand/js11-out.jsonld">expand/js11-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tjs12'>
+        <dt id="tjs12">
           Test tjs12 Expand JSON literal with value canonicalization
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tjs12</dd>
             <dt>Type</dt>
@@ -6656,26 +6684,26 @@
             <dd>Tests expanding JSON literal with value canonicalization.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/js12-in.jsonld'>expand/js12-in.jsonld</a>
+              <a href="expand/js12-in.jsonld">expand/js12-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/js12-out.jsonld'>expand/js12-out.jsonld</a>
+              <a href="expand/js12-out.jsonld">expand/js12-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tjs13'>
+        <dt id="tjs13">
           Test tjs13 Expand JSON literal with wierd canonicalization
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tjs13</dd>
             <dt>Type</dt>
@@ -6684,26 +6712,26 @@
             <dd>Tests expanding JSON literal with wierd canonicalization.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/js13-in.jsonld'>expand/js13-in.jsonld</a>
+              <a href="expand/js13-in.jsonld">expand/js13-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/js13-out.jsonld'>expand/js13-out.jsonld</a>
+              <a href="expand/js13-out.jsonld">expand/js13-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tjs14'>
+        <dt id="tjs14">
           Test tjs14 Expand JSON literal without expanding contents
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tjs14</dd>
             <dt>Type</dt>
@@ -6712,26 +6740,26 @@
             <dd>Tests expanding JSON literal does not expand terms inside json.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/js14-in.jsonld'>expand/js14-in.jsonld</a>
+              <a href="expand/js14-in.jsonld">expand/js14-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/js14-out.jsonld'>expand/js14-out.jsonld</a>
+              <a href="expand/js14-out.jsonld">expand/js14-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tjs15'>
+        <dt id="tjs15">
           Test tjs15 Expand JSON literal aleady in expanded form
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tjs15</dd>
             <dt>Type</dt>
@@ -6740,26 +6768,26 @@
             <dd>Tests expanding JSON literal in expanded form.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/js15-in.jsonld'>expand/js15-in.jsonld</a>
+              <a href="expand/js15-in.jsonld">expand/js15-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/js15-out.jsonld'>expand/js15-out.jsonld</a>
+              <a href="expand/js15-out.jsonld">expand/js15-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tjs16'>
+        <dt id="tjs16">
           Test tjs16 Expand JSON literal aleady in expanded form with aliased keys
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tjs16</dd>
             <dt>Type</dt>
@@ -6768,26 +6796,26 @@
             <dd>Tests expanding JSON literal in expanded form with aliased keys in value object.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/js16-in.jsonld'>expand/js16-in.jsonld</a>
+              <a href="expand/js16-in.jsonld">expand/js16-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/js16-out.jsonld'>expand/js16-out.jsonld</a>
+              <a href="expand/js16-out.jsonld">expand/js16-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tjs17'>
+        <dt id="tjs17">
           Test tjs17 Expand JSON literal (string)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tjs17</dd>
             <dt>Type</dt>
@@ -6796,26 +6824,26 @@
             <dd>Tests expanding property with @type @json to a JSON literal (string).</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/js17-in.jsonld'>expand/js17-in.jsonld</a>
+              <a href="expand/js17-in.jsonld">expand/js17-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/js17-out.jsonld'>expand/js17-out.jsonld</a>
+              <a href="expand/js17-out.jsonld">expand/js17-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tjs18'>
+        <dt id="tjs18">
           Test tjs18 Expand JSON literal (null)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tjs18</dd>
             <dt>Type</dt>
@@ -6824,26 +6852,26 @@
             <dd>Tests expanding property with @type @json to a JSON literal (null).</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/js18-in.jsonld'>expand/js18-in.jsonld</a>
+              <a href="expand/js18-in.jsonld">expand/js18-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/js18-out.jsonld'>expand/js18-out.jsonld</a>
+              <a href="expand/js18-out.jsonld">expand/js18-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tjs19'>
+        <dt id="tjs19">
           Test tjs19 Expand JSON literal with aliased @type
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tjs19</dd>
             <dt>Type</dt>
@@ -6852,26 +6880,26 @@
             <dd>Tests expanding JSON literal with aliased @type.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/js19-in.jsonld'>expand/js19-in.jsonld</a>
+              <a href="expand/js19-in.jsonld">expand/js19-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/js19-out.jsonld'>expand/js19-out.jsonld</a>
+              <a href="expand/js19-out.jsonld">expand/js19-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tjs20'>
+        <dt id="tjs20">
           Test tjs20 Expand JSON literal with aliased @value
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tjs20</dd>
             <dt>Type</dt>
@@ -6880,26 +6908,26 @@
             <dd>Tests expanding JSON literal with aliased @value.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/js20-in.jsonld'>expand/js20-in.jsonld</a>
+              <a href="expand/js20-in.jsonld">expand/js20-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/js20-out.jsonld'>expand/js20-out.jsonld</a>
+              <a href="expand/js20-out.jsonld">expand/js20-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tjs21'>
+        <dt id="tjs21">
           Test tjs21 Expand JSON literal with @context
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tjs21</dd>
             <dt>Type</dt>
@@ -6908,26 +6936,26 @@
             <dd>Tests expanding JSON literal with a @context.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/js21-in.jsonld'>expand/js21-in.jsonld</a>
+              <a href="expand/js21-in.jsonld">expand/js21-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/js21-out.jsonld'>expand/js21-out.jsonld</a>
+              <a href="expand/js21-out.jsonld">expand/js21-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tjs22'>
+        <dt id="tjs22">
           Test tjs22 Expand JSON literal (null) aleady in expanded form.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tjs22</dd>
             <dt>Type</dt>
@@ -6936,26 +6964,26 @@
             <dd>Tests expanding property with @type @json to a JSON literal (null).</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/js22-in.jsonld'>expand/js22-in.jsonld</a>
+              <a href="expand/js22-in.jsonld">expand/js22-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/js22-out.jsonld'>expand/js22-out.jsonld</a>
+              <a href="expand/js22-out.jsonld">expand/js22-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tjs23'>
+        <dt id="tjs23">
           Test tjs23 Expand JSON literal (empty array).
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tjs23</dd>
             <dt>Type</dt>
@@ -6964,26 +6992,26 @@
             <dd>Tests expanding property with @type @json to a JSON literal (empty array).</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/js23-in.jsonld'>expand/js23-in.jsonld</a>
+              <a href="expand/js23-in.jsonld">expand/js23-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/js23-out.jsonld'>expand/js23-out.jsonld</a>
+              <a href="expand/js23-out.jsonld">expand/js23-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tl001'>
+        <dt id="tl001">
           Test tl001 Language map with null value
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tl001</dd>
             <dt>Type</dt>
@@ -6992,26 +7020,26 @@
             <dd>A language map may have a null value, which is ignored</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/l001-in.jsonld'>expand/l001-in.jsonld</a>
+              <a href="expand/l001-in.jsonld">expand/l001-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/l001-out.jsonld'>expand/l001-out.jsonld</a>
+              <a href="expand/l001-out.jsonld">expand/l001-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tli01'>
+        <dt id="tli01">
           Test tli01 @list containing @list
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tli01</dd>
             <dt>Type</dt>
@@ -7020,26 +7048,26 @@
             <dd>List of lists</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/li01-in.jsonld'>expand/li01-in.jsonld</a>
+              <a href="expand/li01-in.jsonld">expand/li01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/li01-out.jsonld'>expand/li01-out.jsonld</a>
+              <a href="expand/li01-out.jsonld">expand/li01-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tli02'>
+        <dt id="tli02">
           Test tli02 @list containing empty @list
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tli02</dd>
             <dt>Type</dt>
@@ -7048,26 +7076,26 @@
             <dd>List of lists</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/li02-in.jsonld'>expand/li02-in.jsonld</a>
+              <a href="expand/li02-in.jsonld">expand/li02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/li02-out.jsonld'>expand/li02-out.jsonld</a>
+              <a href="expand/li02-out.jsonld">expand/li02-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tli03'>
+        <dt id="tli03">
           Test tli03 @list containing @list (with coercion)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tli03</dd>
             <dt>Type</dt>
@@ -7076,26 +7104,26 @@
             <dd>List of lists</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/li03-in.jsonld'>expand/li03-in.jsonld</a>
+              <a href="expand/li03-in.jsonld">expand/li03-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/li03-out.jsonld'>expand/li03-out.jsonld</a>
+              <a href="expand/li03-out.jsonld">expand/li03-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tli04'>
+        <dt id="tli04">
           Test tli04 @list containing empty @list (with coercion)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tli04</dd>
             <dt>Type</dt>
@@ -7104,26 +7132,26 @@
             <dd>List of lists</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/li04-in.jsonld'>expand/li04-in.jsonld</a>
+              <a href="expand/li04-in.jsonld">expand/li04-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/li04-out.jsonld'>expand/li04-out.jsonld</a>
+              <a href="expand/li04-out.jsonld">expand/li04-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tli05'>
+        <dt id="tli05">
           Test tli05 coerced @list containing an array
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tli05</dd>
             <dt>Type</dt>
@@ -7132,26 +7160,26 @@
             <dd>List of lists</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/li05-in.jsonld'>expand/li05-in.jsonld</a>
+              <a href="expand/li05-in.jsonld">expand/li05-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/li05-out.jsonld'>expand/li05-out.jsonld</a>
+              <a href="expand/li05-out.jsonld">expand/li05-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tli06'>
+        <dt id="tli06">
           Test tli06 coerced @list containing an empty array
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tli06</dd>
             <dt>Type</dt>
@@ -7160,26 +7188,26 @@
             <dd>List of lists</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/li06-in.jsonld'>expand/li06-in.jsonld</a>
+              <a href="expand/li06-in.jsonld">expand/li06-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/li06-out.jsonld'>expand/li06-out.jsonld</a>
+              <a href="expand/li06-out.jsonld">expand/li06-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tli07'>
+        <dt id="tli07">
           Test tli07 coerced @list containing deep arrays
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tli07</dd>
             <dt>Type</dt>
@@ -7188,26 +7216,26 @@
             <dd>List of lists</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/li07-in.jsonld'>expand/li07-in.jsonld</a>
+              <a href="expand/li07-in.jsonld">expand/li07-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/li07-out.jsonld'>expand/li07-out.jsonld</a>
+              <a href="expand/li07-out.jsonld">expand/li07-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tli08'>
+        <dt id="tli08">
           Test tli08 coerced @list containing deep empty arrays
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tli08</dd>
             <dt>Type</dt>
@@ -7216,26 +7244,26 @@
             <dd>List of lists</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/li08-in.jsonld'>expand/li08-in.jsonld</a>
+              <a href="expand/li08-in.jsonld">expand/li08-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/li08-out.jsonld'>expand/li08-out.jsonld</a>
+              <a href="expand/li08-out.jsonld">expand/li08-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tli09'>
+        <dt id="tli09">
           Test tli09 coerced @list containing multiple lists
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tli09</dd>
             <dt>Type</dt>
@@ -7244,26 +7272,26 @@
             <dd>List of lists</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/li09-in.jsonld'>expand/li09-in.jsonld</a>
+              <a href="expand/li09-in.jsonld">expand/li09-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/li09-out.jsonld'>expand/li09-out.jsonld</a>
+              <a href="expand/li09-out.jsonld">expand/li09-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tli10'>
+        <dt id="tli10">
           Test tli10 coerced @list containing mixed list values
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tli10</dd>
             <dt>Type</dt>
@@ -7272,26 +7300,26 @@
             <dd>List of lists</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/li10-in.jsonld'>expand/li10-in.jsonld</a>
+              <a href="expand/li10-in.jsonld">expand/li10-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/li10-out.jsonld'>expand/li10-out.jsonld</a>
+              <a href="expand/li10-out.jsonld">expand/li10-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tm001'>
+        <dt id="tm001">
           Test tm001 Adds @id to object not having an @id
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tm001</dd>
             <dt>Type</dt>
@@ -7300,26 +7328,26 @@
             <dd>Expansion using @container: @id</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/m001-in.jsonld'>expand/m001-in.jsonld</a>
+              <a href="expand/m001-in.jsonld">expand/m001-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/m001-out.jsonld'>expand/m001-out.jsonld</a>
+              <a href="expand/m001-out.jsonld">expand/m001-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tm002'>
+        <dt id="tm002">
           Test tm002 Retains @id in object already having an @id
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tm002</dd>
             <dt>Type</dt>
@@ -7328,26 +7356,26 @@
             <dd>Expansion using @container: @id</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/m002-in.jsonld'>expand/m002-in.jsonld</a>
+              <a href="expand/m002-in.jsonld">expand/m002-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/m002-out.jsonld'>expand/m002-out.jsonld</a>
+              <a href="expand/m002-out.jsonld">expand/m002-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tm003'>
+        <dt id="tm003">
           Test tm003 Adds @type to object not having an @type
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tm003</dd>
             <dt>Type</dt>
@@ -7356,26 +7384,26 @@
             <dd>Expansion using @container: @type</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/m003-in.jsonld'>expand/m003-in.jsonld</a>
+              <a href="expand/m003-in.jsonld">expand/m003-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/m003-out.jsonld'>expand/m003-out.jsonld</a>
+              <a href="expand/m003-out.jsonld">expand/m003-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tm004'>
+        <dt id="tm004">
           Test tm004 Prepends @type in object already having an @type
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tm004</dd>
             <dt>Type</dt>
@@ -7384,26 +7412,26 @@
             <dd>Expansion using @container: @type</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/m004-in.jsonld'>expand/m004-in.jsonld</a>
+              <a href="expand/m004-in.jsonld">expand/m004-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/m004-out.jsonld'>expand/m004-out.jsonld</a>
+              <a href="expand/m004-out.jsonld">expand/m004-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tm005'>
+        <dt id="tm005">
           Test tm005 Adds expanded @id to object
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tm005</dd>
             <dt>Type</dt>
@@ -7412,15 +7440,15 @@
             <dd>Expansion using @container: @id</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/m005-in.jsonld'>expand/m005-in.jsonld</a>
+              <a href="expand/m005-in.jsonld">expand/m005-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/m005-out.jsonld'>expand/m005-out.jsonld</a>
+              <a href="expand/m005-out.jsonld">expand/m005-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>base</dt>
                 <dd>http://example.org/</dd>
                 <dt>specVersion</dt>
@@ -7429,11 +7457,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='tm006'>
+        <dt id="tm006">
           Test tm006 Adds vocabulary expanded @type to object
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tm006</dd>
             <dt>Type</dt>
@@ -7442,26 +7470,26 @@
             <dd>Expansion using @container: @type</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/m006-in.jsonld'>expand/m006-in.jsonld</a>
+              <a href="expand/m006-in.jsonld">expand/m006-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/m006-out.jsonld'>expand/m006-out.jsonld</a>
+              <a href="expand/m006-out.jsonld">expand/m006-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tm007'>
+        <dt id="tm007">
           Test tm007 Adds document expanded @type to object
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tm007</dd>
             <dt>Type</dt>
@@ -7470,26 +7498,26 @@
             <dd>Expansion using @container: @type</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/m007-in.jsonld'>expand/m007-in.jsonld</a>
+              <a href="expand/m007-in.jsonld">expand/m007-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/m007-out.jsonld'>expand/m007-out.jsonld</a>
+              <a href="expand/m007-out.jsonld">expand/m007-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tm008'>
+        <dt id="tm008">
           Test tm008 When type is in a type map
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tm008</dd>
             <dt>Type</dt>
@@ -7498,26 +7526,26 @@
             <dd>scoped context on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/m008-in.jsonld'>expand/m008-in.jsonld</a>
+              <a href="expand/m008-in.jsonld">expand/m008-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/m008-out.jsonld'>expand/m008-out.jsonld</a>
+              <a href="expand/m008-out.jsonld">expand/m008-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tm009'>
+        <dt id="tm009">
           Test tm009 language map with @none
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tm009</dd>
             <dt>Type</dt>
@@ -7526,26 +7554,26 @@
             <dd>index on @language</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/m009-in.jsonld'>expand/m009-in.jsonld</a>
+              <a href="expand/m009-in.jsonld">expand/m009-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/m009-out.jsonld'>expand/m009-out.jsonld</a>
+              <a href="expand/m009-out.jsonld">expand/m009-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tm010'>
+        <dt id="tm010">
           Test tm010 language map with alias of @none
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tm010</dd>
             <dt>Type</dt>
@@ -7554,26 +7582,26 @@
             <dd>index on @language</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/m010-in.jsonld'>expand/m010-in.jsonld</a>
+              <a href="expand/m010-in.jsonld">expand/m010-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/m010-out.jsonld'>expand/m010-out.jsonld</a>
+              <a href="expand/m010-out.jsonld">expand/m010-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tm011'>
+        <dt id="tm011">
           Test tm011 id map with @none
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tm011</dd>
             <dt>Type</dt>
@@ -7582,26 +7610,26 @@
             <dd>index on @id</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/m011-in.jsonld'>expand/m011-in.jsonld</a>
+              <a href="expand/m011-in.jsonld">expand/m011-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/m011-out.jsonld'>expand/m011-out.jsonld</a>
+              <a href="expand/m011-out.jsonld">expand/m011-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tm012'>
+        <dt id="tm012">
           Test tm012 type map with alias of @none
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tm012</dd>
             <dt>Type</dt>
@@ -7610,26 +7638,26 @@
             <dd>index on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/m012-in.jsonld'>expand/m012-in.jsonld</a>
+              <a href="expand/m012-in.jsonld">expand/m012-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/m012-out.jsonld'>expand/m012-out.jsonld</a>
+              <a href="expand/m012-out.jsonld">expand/m012-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tm013'>
+        <dt id="tm013">
           Test tm013 graph index map with @none
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tm013</dd>
             <dt>Type</dt>
@@ -7638,26 +7666,26 @@
             <dd>index on @graph and @index</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/m013-in.jsonld'>expand/m013-in.jsonld</a>
+              <a href="expand/m013-in.jsonld">expand/m013-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/m013-out.jsonld'>expand/m013-out.jsonld</a>
+              <a href="expand/m013-out.jsonld">expand/m013-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tm014'>
+        <dt id="tm014">
           Test tm014 graph index map with alias @none
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tm014</dd>
             <dt>Type</dt>
@@ -7666,26 +7694,26 @@
             <dd>index on @graph and @index</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/m014-in.jsonld'>expand/m014-in.jsonld</a>
+              <a href="expand/m014-in.jsonld">expand/m014-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/m014-out.jsonld'>expand/m014-out.jsonld</a>
+              <a href="expand/m014-out.jsonld">expand/m014-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tm015'>
+        <dt id="tm015">
           Test tm015 graph id index map with aliased @none
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tm015</dd>
             <dt>Type</dt>
@@ -7694,26 +7722,26 @@
             <dd>index on @graph and @id with @none</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/m015-in.jsonld'>expand/m015-in.jsonld</a>
+              <a href="expand/m015-in.jsonld">expand/m015-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/m015-out.jsonld'>expand/m015-out.jsonld</a>
+              <a href="expand/m015-out.jsonld">expand/m015-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tm016'>
+        <dt id="tm016">
           Test tm016 graph id index map with aliased @none
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tm016</dd>
             <dt>Type</dt>
@@ -7722,26 +7750,26 @@
             <dd>index on @graph and @id with @none</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/m016-in.jsonld'>expand/m016-in.jsonld</a>
+              <a href="expand/m016-in.jsonld">expand/m016-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/m016-out.jsonld'>expand/m016-out.jsonld</a>
+              <a href="expand/m016-out.jsonld">expand/m016-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tm017'>
+        <dt id="tm017">
           Test tm017 string value of type map expands to node reference
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tm017</dd>
             <dt>Type</dt>
@@ -7750,26 +7778,26 @@
             <dd>index on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/m017-in.jsonld'>expand/m017-in.jsonld</a>
+              <a href="expand/m017-in.jsonld">expand/m017-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/m017-out.jsonld'>expand/m017-out.jsonld</a>
+              <a href="expand/m017-out.jsonld">expand/m017-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tm018'>
+        <dt id="tm018">
           Test tm018 string value of type map expands to node reference with @type: @id
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tm018</dd>
             <dt>Type</dt>
@@ -7778,26 +7806,26 @@
             <dd>index on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/m018-in.jsonld'>expand/m018-in.jsonld</a>
+              <a href="expand/m018-in.jsonld">expand/m018-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/m018-out.jsonld'>expand/m018-out.jsonld</a>
+              <a href="expand/m018-out.jsonld">expand/m018-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tm019'>
+        <dt id="tm019">
           Test tm019 string value of type map expands to node reference with @type: @vocab
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tm019</dd>
             <dt>Type</dt>
@@ -7806,26 +7834,26 @@
             <dd>index on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/m019-in.jsonld'>expand/m019-in.jsonld</a>
+              <a href="expand/m019-in.jsonld">expand/m019-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/m019-out.jsonld'>expand/m019-out.jsonld</a>
+              <a href="expand/m019-out.jsonld">expand/m019-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tm020'>
+        <dt id="tm020">
           Test tm020 string value of type map must not be a literal
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tm020</dd>
             <dt>Type</dt>
@@ -7834,7 +7862,7 @@
             <dd>index on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/m020-in.jsonld'>expand/m020-in.jsonld</a>
+              <a href="expand/m020-in.jsonld">expand/m020-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -7842,18 +7870,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tn001'>
+        <dt id="tn001">
           Test tn001 Expands input using @nest
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tn001</dd>
             <dt>Type</dt>
@@ -7862,26 +7890,26 @@
             <dd>Expansion using @nest</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/n001-in.jsonld'>expand/n001-in.jsonld</a>
+              <a href="expand/n001-in.jsonld">expand/n001-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/n001-out.jsonld'>expand/n001-out.jsonld</a>
+              <a href="expand/n001-out.jsonld">expand/n001-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tn002'>
+        <dt id="tn002">
           Test tn002 Expands input using aliased @nest
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tn002</dd>
             <dt>Type</dt>
@@ -7890,26 +7918,26 @@
             <dd>Expansion using @nest</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/n002-in.jsonld'>expand/n002-in.jsonld</a>
+              <a href="expand/n002-in.jsonld">expand/n002-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/n002-out.jsonld'>expand/n002-out.jsonld</a>
+              <a href="expand/n002-out.jsonld">expand/n002-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tn003'>
+        <dt id="tn003">
           Test tn003 Appends nested values when property at base and nested
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tn003</dd>
             <dt>Type</dt>
@@ -7918,26 +7946,26 @@
             <dd>Expansion using @nest</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/n003-in.jsonld'>expand/n003-in.jsonld</a>
+              <a href="expand/n003-in.jsonld">expand/n003-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/n003-out.jsonld'>expand/n003-out.jsonld</a>
+              <a href="expand/n003-out.jsonld">expand/n003-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tn004'>
+        <dt id="tn004">
           Test tn004 Appends nested values from all @nest aliases
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tn004</dd>
             <dt>Type</dt>
@@ -7946,26 +7974,26 @@
             <dd>Expansion using @nest</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/n004-in.jsonld'>expand/n004-in.jsonld</a>
+              <a href="expand/n004-in.jsonld">expand/n004-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/n004-out.jsonld'>expand/n004-out.jsonld</a>
+              <a href="expand/n004-out.jsonld">expand/n004-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tn005'>
+        <dt id="tn005">
           Test tn005 Nested nested containers
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tn005</dd>
             <dt>Type</dt>
@@ -7974,26 +8002,26 @@
             <dd>Expansion using @nest</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/n005-in.jsonld'>expand/n005-in.jsonld</a>
+              <a href="expand/n005-in.jsonld">expand/n005-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/n005-out.jsonld'>expand/n005-out.jsonld</a>
+              <a href="expand/n005-out.jsonld">expand/n005-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tn006'>
+        <dt id="tn006">
           Test tn006 Arrays of nested values
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tn006</dd>
             <dt>Type</dt>
@@ -8002,26 +8030,26 @@
             <dd>Expansion using @nest</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/n006-in.jsonld'>expand/n006-in.jsonld</a>
+              <a href="expand/n006-in.jsonld">expand/n006-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/n006-out.jsonld'>expand/n006-out.jsonld</a>
+              <a href="expand/n006-out.jsonld">expand/n006-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tn007'>
+        <dt id="tn007">
           Test tn007 A nest of arrays
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tn007</dd>
             <dt>Type</dt>
@@ -8030,26 +8058,26 @@
             <dd>Expansion using @nest</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/n007-in.jsonld'>expand/n007-in.jsonld</a>
+              <a href="expand/n007-in.jsonld">expand/n007-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/n007-out.jsonld'>expand/n007-out.jsonld</a>
+              <a href="expand/n007-out.jsonld">expand/n007-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tn008'>
+        <dt id="tn008">
           Test tn008 Multiple keys may mapping to @type when nesting
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tn008</dd>
             <dt>Type</dt>
@@ -8058,26 +8086,26 @@
             <dd>Expansion using @nest</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/n008-in.jsonld'>expand/n008-in.jsonld</a>
+              <a href="expand/n008-in.jsonld">expand/n008-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/n008-out.jsonld'>expand/n008-out.jsonld</a>
+              <a href="expand/n008-out.jsonld">expand/n008-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tp001'>
+        <dt id="tp001">
           Test tp001 @version may be specified after first context
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tp001</dd>
             <dt>Type</dt>
@@ -8086,26 +8114,26 @@
             <dd>If processing mode is not set through API, it is set by the first context containing @version.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/p001-in.jsonld'>expand/p001-in.jsonld</a>
+              <a href="expand/p001-in.jsonld">expand/p001-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/p001-out.jsonld'>expand/p001-out.jsonld</a>
+              <a href="expand/p001-out.jsonld">expand/p001-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tp002'>
+        <dt id="tp002">
           Test tp002 @version setting [1.0, 1.1, 1.0]
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tp002</dd>
             <dt>Type</dt>
@@ -8114,26 +8142,26 @@
             <dd>If processing mode is not set through API, it is set by the first context containing @version.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/p002-in.jsonld'>expand/p002-in.jsonld</a>
+              <a href="expand/p002-in.jsonld">expand/p002-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/p002-out.jsonld'>expand/p002-out.jsonld</a>
+              <a href="expand/p002-out.jsonld">expand/p002-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tp003'>
+        <dt id="tp003">
           Test tp003 @version setting [1.1, 1.0]
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tp003</dd>
             <dt>Type</dt>
@@ -8142,26 +8170,26 @@
             <dd>If processing mode is not set through API, it is set by the first context containing @version.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/p003-in.jsonld'>expand/p003-in.jsonld</a>
+              <a href="expand/p003-in.jsonld">expand/p003-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/p003-out.jsonld'>expand/p003-out.jsonld</a>
+              <a href="expand/p003-out.jsonld">expand/p003-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tp004'>
+        <dt id="tp004">
           Test tp004 @version setting [1.1, 1.0, 1.1]
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tp004</dd>
             <dt>Type</dt>
@@ -8170,26 +8198,26 @@
             <dd>If processing mode is not set through API, it is set by the first context containing @version.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/p004-in.jsonld'>expand/p004-in.jsonld</a>
+              <a href="expand/p004-in.jsonld">expand/p004-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/p004-out.jsonld'>expand/p004-out.jsonld</a>
+              <a href="expand/p004-out.jsonld">expand/p004-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpi01'>
+        <dt id="tpi01">
           Test tpi01 error if @version is json-ld-1.0 for property-valued index
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpi01</dd>
             <dt>Type</dt>
@@ -8198,7 +8226,7 @@
             <dd>Expanding index maps where index is a property.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pi01-in.jsonld'>expand/pi01-in.jsonld</a>
+              <a href="expand/pi01-in.jsonld">expand/pi01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8206,7 +8234,7 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
                 <dt>processingMode</dt>
@@ -8215,11 +8243,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='tpi02'>
+        <dt id="tpi02">
           Test tpi02 error if @container does not include @index for property-valued index
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpi02</dd>
             <dt>Type</dt>
@@ -8228,7 +8256,7 @@
             <dd>Expanding index maps where index is a property.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pi02-in.jsonld'>expand/pi02-in.jsonld</a>
+              <a href="expand/pi02-in.jsonld">expand/pi02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8236,18 +8264,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpi03'>
+        <dt id="tpi03">
           Test tpi03 error if @index is a keyword for property-valued index
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpi03</dd>
             <dt>Type</dt>
@@ -8256,7 +8284,7 @@
             <dd>Expanding index maps where index is a property.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pi03-in.jsonld'>expand/pi03-in.jsonld</a>
+              <a href="expand/pi03-in.jsonld">expand/pi03-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8264,18 +8292,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpi04'>
+        <dt id="tpi04">
           Test tpi04 error if @index is not a string for property-valued index
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpi04</dd>
             <dt>Type</dt>
@@ -8284,7 +8312,7 @@
             <dd>Expanding index maps where index is a property.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pi04-in.jsonld'>expand/pi04-in.jsonld</a>
+              <a href="expand/pi04-in.jsonld">expand/pi04-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8292,18 +8320,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpi05'>
+        <dt id="tpi05">
           Test tpi05 error if attempting to add property to value object for property-valued index
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpi05</dd>
             <dt>Type</dt>
@@ -8312,7 +8340,7 @@
             <dd>Expanding index maps where index is a property.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pi05-in.jsonld'>expand/pi05-in.jsonld</a>
+              <a href="expand/pi05-in.jsonld">expand/pi05-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8320,18 +8348,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpi06'>
+        <dt id="tpi06">
           Test tpi06 property-valued index expands to property value, instead of @index (value)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpi06</dd>
             <dt>Type</dt>
@@ -8340,26 +8368,26 @@
             <dd>Expanding index maps where index is a property.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pi06-in.jsonld'>expand/pi06-in.jsonld</a>
+              <a href="expand/pi06-in.jsonld">expand/pi06-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pi06-out.jsonld'>expand/pi06-out.jsonld</a>
+              <a href="expand/pi06-out.jsonld">expand/pi06-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpi07'>
+        <dt id="tpi07">
           Test tpi07 property-valued index appends to property value, instead of @index (value)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpi07</dd>
             <dt>Type</dt>
@@ -8368,26 +8396,26 @@
             <dd>Expanding index maps where index is a property.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pi07-in.jsonld'>expand/pi07-in.jsonld</a>
+              <a href="expand/pi07-in.jsonld">expand/pi07-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pi07-out.jsonld'>expand/pi07-out.jsonld</a>
+              <a href="expand/pi07-out.jsonld">expand/pi07-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpi08'>
+        <dt id="tpi08">
           Test tpi08 property-valued index expands to property value, instead of @index (node)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpi08</dd>
             <dt>Type</dt>
@@ -8396,26 +8424,26 @@
             <dd>Expanding index maps where index is a property.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pi08-in.jsonld'>expand/pi08-in.jsonld</a>
+              <a href="expand/pi08-in.jsonld">expand/pi08-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pi08-out.jsonld'>expand/pi08-out.jsonld</a>
+              <a href="expand/pi08-out.jsonld">expand/pi08-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpi09'>
+        <dt id="tpi09">
           Test tpi09 property-valued index appends to property value, instead of @index (node)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpi09</dd>
             <dt>Type</dt>
@@ -8424,26 +8452,26 @@
             <dd>Expanding index maps where index is a property.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pi09-in.jsonld'>expand/pi09-in.jsonld</a>
+              <a href="expand/pi09-in.jsonld">expand/pi09-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pi09-out.jsonld'>expand/pi09-out.jsonld</a>
+              <a href="expand/pi09-out.jsonld">expand/pi09-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpi10'>
+        <dt id="tpi10">
           Test tpi10 property-valued index does not output property for @none
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpi10</dd>
             <dt>Type</dt>
@@ -8452,26 +8480,26 @@
             <dd>Expanding index maps where index is a property.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pi10-in.jsonld'>expand/pi10-in.jsonld</a>
+              <a href="expand/pi10-in.jsonld">expand/pi10-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pi10-out.jsonld'>expand/pi10-out.jsonld</a>
+              <a href="expand/pi10-out.jsonld">expand/pi10-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpi11'>
+        <dt id="tpi11">
           Test tpi11 property-valued index adds property to graph object
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpi11</dd>
             <dt>Type</dt>
@@ -8480,26 +8508,26 @@
             <dd>Expanding index maps where index is a property.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pi11-in.jsonld'>expand/pi11-in.jsonld</a>
+              <a href="expand/pi11-in.jsonld">expand/pi11-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pi11-out.jsonld'>expand/pi11-out.jsonld</a>
+              <a href="expand/pi11-out.jsonld">expand/pi11-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr01'>
+        <dt id="tpr01">
           Test tpr01 Protect a term
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr01</dd>
             <dt>Type</dt>
@@ -8508,7 +8536,7 @@
             <dd>Check error when overriding a protected term.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr01-in.jsonld'>expand/pr01-in.jsonld</a>
+              <a href="expand/pr01-in.jsonld">expand/pr01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8516,18 +8544,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr02'>
+        <dt id="tpr02">
           Test tpr02 Set a term to not be protected
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr02</dd>
             <dt>Type</dt>
@@ -8536,26 +8564,26 @@
             <dd>A term with @protected: false is not protected.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr02-in.jsonld'>expand/pr02-in.jsonld</a>
+              <a href="expand/pr02-in.jsonld">expand/pr02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pr02-out.jsonld'>expand/pr02-out.jsonld</a>
+              <a href="expand/pr02-out.jsonld">expand/pr02-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr03'>
+        <dt id="tpr03">
           Test tpr03 Protect all terms in context
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr03</dd>
             <dt>Type</dt>
@@ -8564,7 +8592,7 @@
             <dd>A protected context protects all term definitions.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr03-in.jsonld'>expand/pr03-in.jsonld</a>
+              <a href="expand/pr03-in.jsonld">expand/pr03-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8572,18 +8600,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr04'>
+        <dt id="tpr04">
           Test tpr04 Do not protect term with @protected: false
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr04</dd>
             <dt>Type</dt>
@@ -8592,7 +8620,7 @@
             <dd>A protected context does not protect terms with @protected: false.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr04-in.jsonld'>expand/pr04-in.jsonld</a>
+              <a href="expand/pr04-in.jsonld">expand/pr04-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8600,18 +8628,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr05'>
+        <dt id="tpr05">
           Test tpr05 Clear active context with protected terms from an embedded context
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr05</dd>
             <dt>Type</dt>
@@ -8620,7 +8648,7 @@
             <dd>The Active context be set to null from an embedded context.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr05-in.jsonld'>expand/pr05-in.jsonld</a>
+              <a href="expand/pr05-in.jsonld">expand/pr05-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8628,18 +8656,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr06'>
+        <dt id="tpr06">
           Test tpr06 Clear active context of protected terms from a term.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr06</dd>
             <dt>Type</dt>
@@ -8648,26 +8676,26 @@
             <dd>The Active context may be set to null from a scoped context of a term.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr06-in.jsonld'>expand/pr06-in.jsonld</a>
+              <a href="expand/pr06-in.jsonld">expand/pr06-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pr06-out.jsonld'>expand/pr06-out.jsonld</a>
+              <a href="expand/pr06-out.jsonld">expand/pr06-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr08'>
+        <dt id="tpr08">
           Test tpr08 Term with protected scoped context.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr08</dd>
             <dt>Type</dt>
@@ -8676,7 +8704,7 @@
             <dd>A scoped context can protect terms.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr08-in.jsonld'>expand/pr08-in.jsonld</a>
+              <a href="expand/pr08-in.jsonld">expand/pr08-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8684,18 +8712,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr09'>
+        <dt id="tpr09">
           Test tpr09 Attempt to redefine term in other protected context.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr09</dd>
             <dt>Type</dt>
@@ -8704,7 +8732,7 @@
             <dd>A protected term cannot redefine another protected term.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr09-in.jsonld'>expand/pr09-in.jsonld</a>
+              <a href="expand/pr09-in.jsonld">expand/pr09-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8712,18 +8740,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr10'>
+        <dt id="tpr10">
           Test tpr10 Simple protected and unprotected terms.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr10</dd>
             <dt>Type</dt>
@@ -8732,26 +8760,26 @@
             <dd>Simple protected and unprotected terms.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr10-in.jsonld'>expand/pr10-in.jsonld</a>
+              <a href="expand/pr10-in.jsonld">expand/pr10-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pr10-out.jsonld'>expand/pr10-out.jsonld</a>
+              <a href="expand/pr10-out.jsonld">expand/pr10-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr11'>
+        <dt id="tpr11">
           Test tpr11 Fail to override protected term.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr11</dd>
             <dt>Type</dt>
@@ -8760,7 +8788,7 @@
             <dd>Fail to override protected term.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr11-in.jsonld'>expand/pr11-in.jsonld</a>
+              <a href="expand/pr11-in.jsonld">expand/pr11-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8768,18 +8796,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr12'>
+        <dt id="tpr12">
           Test tpr12 Scoped context fail to override protected term.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr12</dd>
             <dt>Type</dt>
@@ -8788,7 +8816,7 @@
             <dd>Scoped context fail to override protected term.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr12-in.jsonld'>expand/pr12-in.jsonld</a>
+              <a href="expand/pr12-in.jsonld">expand/pr12-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8796,18 +8824,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr13'>
+        <dt id="tpr13">
           Test tpr13 Override unprotected term.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr13</dd>
             <dt>Type</dt>
@@ -8816,26 +8844,26 @@
             <dd>Override unprotected term.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr13-in.jsonld'>expand/pr13-in.jsonld</a>
+              <a href="expand/pr13-in.jsonld">expand/pr13-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pr13-out.jsonld'>expand/pr13-out.jsonld</a>
+              <a href="expand/pr13-out.jsonld">expand/pr13-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr14'>
+        <dt id="tpr14">
           Test tpr14 Clear protection with null context.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr14</dd>
             <dt>Type</dt>
@@ -8844,26 +8872,26 @@
             <dd>Clear protection with null context.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr14-in.jsonld'>expand/pr14-in.jsonld</a>
+              <a href="expand/pr14-in.jsonld">expand/pr14-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pr14-out.jsonld'>expand/pr14-out.jsonld</a>
+              <a href="expand/pr14-out.jsonld">expand/pr14-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr15'>
+        <dt id="tpr15">
           Test tpr15 Clear protection with array with null context
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr15</dd>
             <dt>Type</dt>
@@ -8872,26 +8900,26 @@
             <dd>Clear protection with array with null context</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr15-in.jsonld'>expand/pr15-in.jsonld</a>
+              <a href="expand/pr15-in.jsonld">expand/pr15-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pr15-out.jsonld'>expand/pr15-out.jsonld</a>
+              <a href="expand/pr15-out.jsonld">expand/pr15-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr16'>
+        <dt id="tpr16">
           Test tpr16 Override protected terms after null.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr16</dd>
             <dt>Type</dt>
@@ -8900,26 +8928,26 @@
             <dd>Override protected terms after null.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr16-in.jsonld'>expand/pr16-in.jsonld</a>
+              <a href="expand/pr16-in.jsonld">expand/pr16-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pr16-out.jsonld'>expand/pr16-out.jsonld</a>
+              <a href="expand/pr16-out.jsonld">expand/pr16-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr17'>
+        <dt id="tpr17">
           Test tpr17 Fail to override protected terms with type.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr17</dd>
             <dt>Type</dt>
@@ -8928,7 +8956,7 @@
             <dd>Fail to override protected terms with type.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr17-in.jsonld'>expand/pr17-in.jsonld</a>
+              <a href="expand/pr17-in.jsonld">expand/pr17-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8936,18 +8964,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr18'>
+        <dt id="tpr18">
           Test tpr18 Fail to override protected terms with type+null+ctx.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr18</dd>
             <dt>Type</dt>
@@ -8956,7 +8984,7 @@
             <dd>Fail to override protected terms with type+null+ctx.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr18-in.jsonld'>expand/pr18-in.jsonld</a>
+              <a href="expand/pr18-in.jsonld">expand/pr18-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8964,18 +8992,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr19'>
+        <dt id="tpr19">
           Test tpr19 Mix of protected and unprotected terms.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr19</dd>
             <dt>Type</dt>
@@ -8984,26 +9012,26 @@
             <dd>Mix of protected and unprotected terms.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr19-in.jsonld'>expand/pr19-in.jsonld</a>
+              <a href="expand/pr19-in.jsonld">expand/pr19-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pr19-out.jsonld'>expand/pr19-out.jsonld</a>
+              <a href="expand/pr19-out.jsonld">expand/pr19-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr20'>
+        <dt id="tpr20">
           Test tpr20 Fail with mix of protected and unprotected terms with type+null+ctx.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr20</dd>
             <dt>Type</dt>
@@ -9012,7 +9040,7 @@
             <dd>Fail with mix of protected and unprotected terms with type+null+ctx.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr20-in.jsonld'>expand/pr20-in.jsonld</a>
+              <a href="expand/pr20-in.jsonld">expand/pr20-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9020,18 +9048,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr21'>
+        <dt id="tpr21">
           Test tpr21 Fail with mix of protected and unprotected terms with type+null.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr21</dd>
             <dt>Type</dt>
@@ -9040,7 +9068,7 @@
             <dd>Fail with mix of protected and unprotected terms with type+null.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr21-in.jsonld'>expand/pr21-in.jsonld</a>
+              <a href="expand/pr21-in.jsonld">expand/pr21-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9048,18 +9076,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr22'>
+        <dt id="tpr22">
           Test tpr22 Check legal overriding of type-scoped protected term from nested node.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr22</dd>
             <dt>Type</dt>
@@ -9068,26 +9096,26 @@
             <dd>Check legal overriding of type-scoped protected term from nested node.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr22-in.jsonld'>expand/pr22-in.jsonld</a>
+              <a href="expand/pr22-in.jsonld">expand/pr22-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pr22-out.jsonld'>expand/pr22-out.jsonld</a>
+              <a href="expand/pr22-out.jsonld">expand/pr22-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr23'>
+        <dt id="tpr23">
           Test tpr23 Allows redefinition of protected alias term with same definition.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr23</dd>
             <dt>Type</dt>
@@ -9096,26 +9124,26 @@
             <dd>Allows redefinition of protected alias term with same definition.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr23-in.jsonld'>expand/pr23-in.jsonld</a>
+              <a href="expand/pr23-in.jsonld">expand/pr23-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pr23-out.jsonld'>expand/pr23-out.jsonld</a>
+              <a href="expand/pr23-out.jsonld">expand/pr23-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr24'>
+        <dt id="tpr24">
           Test tpr24 Allows redefinition of protected prefix term with same definition.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr24</dd>
             <dt>Type</dt>
@@ -9124,26 +9152,26 @@
             <dd>Allows redefinition of protected prefix term with same definition.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr24-in.jsonld'>expand/pr24-in.jsonld</a>
+              <a href="expand/pr24-in.jsonld">expand/pr24-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pr24-out.jsonld'>expand/pr24-out.jsonld</a>
+              <a href="expand/pr24-out.jsonld">expand/pr24-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr25'>
+        <dt id="tpr25">
           Test tpr25 Allows redefinition of terms with scoped contexts using same definitions.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr25</dd>
             <dt>Type</dt>
@@ -9152,26 +9180,26 @@
             <dd>Allows redefinition of terms with scoped contexts using same definitions.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr25-in.jsonld'>expand/pr25-in.jsonld</a>
+              <a href="expand/pr25-in.jsonld">expand/pr25-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pr25-out.jsonld'>expand/pr25-out.jsonld</a>
+              <a href="expand/pr25-out.jsonld">expand/pr25-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr26'>
+        <dt id="tpr26">
           Test tpr26 Fails on redefinition of terms with scoped contexts using different definitions.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr26</dd>
             <dt>Type</dt>
@@ -9180,7 +9208,7 @@
             <dd>Fails on redefinition of terms with scoped contexts using different definitions.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr26-in.jsonld'>expand/pr26-in.jsonld</a>
+              <a href="expand/pr26-in.jsonld">expand/pr26-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9188,18 +9216,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr27'>
+        <dt id="tpr27">
           Test tpr27 Allows redefinition of protected alias term with same definition modulo protected flag.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr27</dd>
             <dt>Type</dt>
@@ -9208,26 +9236,26 @@
             <dd>Allows redefinition of protected alias term with same definition modulo protected flag.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr27-in.jsonld'>expand/pr27-in.jsonld</a>
+              <a href="expand/pr27-in.jsonld">expand/pr27-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pr27-out.jsonld'>expand/pr27-out.jsonld</a>
+              <a href="expand/pr27-out.jsonld">expand/pr27-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr28'>
+        <dt id="tpr28">
           Test tpr28 Fails if trying to redefine a protected null term.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr28</dd>
             <dt>Type</dt>
@@ -9236,7 +9264,7 @@
             <dd>A protected term with a null IRI mapping cannot be redefined.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr28-in.jsonld'>expand/pr28-in.jsonld</a>
+              <a href="expand/pr28-in.jsonld">expand/pr28-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9244,18 +9272,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr29'>
+        <dt id="tpr29">
           Test tpr29 Does not expand a Compact IRI using a non-prefix term.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr29</dd>
             <dt>Type</dt>
@@ -9264,26 +9292,26 @@
             <dd>Expansion of Compact IRIs considers if the term can be used as a prefix.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr29-in.jsonld'>expand/pr29-in.jsonld</a>
+              <a href="expand/pr29-in.jsonld">expand/pr29-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pr29-out.jsonld'>expand/pr29-out.jsonld</a>
+              <a href="expand/pr29-out.jsonld">expand/pr29-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr30'>
+        <dt id="tpr30">
           Test tpr30 Keywords may be protected.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr30</dd>
             <dt>Type</dt>
@@ -9292,26 +9320,26 @@
             <dd>Keywords may not be redefined other than to protect them.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr30-in.jsonld'>expand/pr30-in.jsonld</a>
+              <a href="expand/pr30-in.jsonld">expand/pr30-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pr30-out.jsonld'>expand/pr30-out.jsonld</a>
+              <a href="expand/pr30-out.jsonld">expand/pr30-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr31'>
+        <dt id="tpr31">
           Test tpr31 Protected keyword aliases cannot be overridden.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr31</dd>
             <dt>Type</dt>
@@ -9320,7 +9348,7 @@
             <dd>Keywords may not be redefined other than to protect them.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr31-in.jsonld'>expand/pr31-in.jsonld</a>
+              <a href="expand/pr31-in.jsonld">expand/pr31-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9328,18 +9356,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr32'>
+        <dt id="tpr32">
           Test tpr32 Protected @type cannot be overridden.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr32</dd>
             <dt>Type</dt>
@@ -9348,7 +9376,7 @@
             <dd>Keywords may not be redefined other than to protect them.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr32-in.jsonld'>expand/pr32-in.jsonld</a>
+              <a href="expand/pr32-in.jsonld">expand/pr32-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9356,18 +9384,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr33'>
+        <dt id="tpr33">
           Test tpr33 Fails if trying to declare a keyword alias as prefix.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr33</dd>
             <dt>Type</dt>
@@ -9376,7 +9404,7 @@
             <dd>Keyword aliases can not be used as prefixes.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr33-in.jsonld'>expand/pr33-in.jsonld</a>
+              <a href="expand/pr33-in.jsonld">expand/pr33-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9384,18 +9412,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr34'>
+        <dt id="tpr34">
           Test tpr34 Ignores a non-keyword term starting with &#39;@&#39;
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr34</dd>
             <dt>Type</dt>
@@ -9404,26 +9432,26 @@
             <dd>Terms in the form of a keyword, which are not keywords, are ignored.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr34-in.jsonld'>expand/pr34-in.jsonld</a>
+              <a href="expand/pr34-in.jsonld">expand/pr34-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pr34-out.jsonld'>expand/pr34-out.jsonld</a>
+              <a href="expand/pr34-out.jsonld">expand/pr34-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr35'>
+        <dt id="tpr35">
           Test tpr35 Ignores a non-keyword term starting with &#39;@&#39; (with @vocab)
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr35</dd>
             <dt>Type</dt>
@@ -9432,26 +9460,26 @@
             <dd>Terms in the form of a keyword, which are not keywords, are ignored.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr35-in.jsonld'>expand/pr35-in.jsonld</a>
+              <a href="expand/pr35-in.jsonld">expand/pr35-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pr35-out.jsonld'>expand/pr35-out.jsonld</a>
+              <a href="expand/pr35-out.jsonld">expand/pr35-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr36'>
+        <dt id="tpr36">
           Test tpr36 Ignores a term mapping to a value in the form of a keyword.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr36</dd>
             <dt>Type</dt>
@@ -9460,26 +9488,26 @@
             <dd>Terms in the form of a keyword, which are not keywords, are ignored.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr36-in.jsonld'>expand/pr36-in.jsonld</a>
+              <a href="expand/pr36-in.jsonld">expand/pr36-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pr36-out.jsonld'>expand/pr36-out.jsonld</a>
+              <a href="expand/pr36-out.jsonld">expand/pr36-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr37'>
+        <dt id="tpr37">
           Test tpr37 Ignores a term mapping to a value in the form of a keyword (with @vocab).
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr37</dd>
             <dt>Type</dt>
@@ -9488,26 +9516,26 @@
             <dd>Terms in the form of a keyword, which are not keywords, are ignored.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr37-in.jsonld'>expand/pr37-in.jsonld</a>
+              <a href="expand/pr37-in.jsonld">expand/pr37-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pr37-out.jsonld'>expand/pr37-out.jsonld</a>
+              <a href="expand/pr37-out.jsonld">expand/pr37-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr38'>
+        <dt id="tpr38">
           Test tpr38 Ignores a term mapping to a value in the form of a keyword (@reverse).
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr38</dd>
             <dt>Type</dt>
@@ -9516,26 +9544,26 @@
             <dd>Terms in the form of a keyword, which are not keywords, are ignored.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr38-in.jsonld'>expand/pr38-in.jsonld</a>
+              <a href="expand/pr38-in.jsonld">expand/pr38-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pr38-out.jsonld'>expand/pr38-out.jsonld</a>
+              <a href="expand/pr38-out.jsonld">expand/pr38-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr39'>
+        <dt id="tpr39">
           Test tpr39 Ignores a term mapping to a value in the form of a keyword (@reverse with @vocab).
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr39</dd>
             <dt>Type</dt>
@@ -9544,26 +9572,26 @@
             <dd>Terms in the form of a keyword, which are not keywords, are ignored.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr39-in.jsonld'>expand/pr39-in.jsonld</a>
+              <a href="expand/pr39-in.jsonld">expand/pr39-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pr39-out.jsonld'>expand/pr39-out.jsonld</a>
+              <a href="expand/pr39-out.jsonld">expand/pr39-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr40'>
+        <dt id="tpr40">
           Test tpr40 Protected terms and property-scoped contexts
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr40</dd>
             <dt>Type</dt>
@@ -9572,26 +9600,26 @@
             <dd>Check overriding of protected term from property-scoped context.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr40-in.jsonld'>expand/pr40-in.jsonld</a>
+              <a href="expand/pr40-in.jsonld">expand/pr40-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pr40-out.jsonld'>expand/pr40-out.jsonld</a>
+              <a href="expand/pr40-out.jsonld">expand/pr40-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr41'>
+        <dt id="tpr41">
           Test tpr41 Allows protected redefinition of equivalent id terms
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr41</dd>
             <dt>Type</dt>
@@ -9600,26 +9628,26 @@
             <dd>Check protected redefinition of equivalent id terms in different forms.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr41-in.jsonld'>expand/pr41-in.jsonld</a>
+              <a href="expand/pr41-in.jsonld">expand/pr41-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pr41-out.jsonld'>expand/pr41-out.jsonld</a>
+              <a href="expand/pr41-out.jsonld">expand/pr41-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr42'>
+        <dt id="tpr42">
           Test tpr42 Fail if protected flag not retained during redefinition
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr42</dd>
             <dt>Type</dt>
@@ -9628,7 +9656,7 @@
             <dd>Check protected redefinition retains protected flag.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr42-in.jsonld'>expand/pr42-in.jsonld</a>
+              <a href="expand/pr42-in.jsonld">expand/pr42-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9636,18 +9664,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tpr43'>
+        <dt id="tpr43">
           Test tpr43 Clear protection in @graph @container with null context.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tpr43</dd>
             <dt>Type</dt>
@@ -9656,26 +9684,26 @@
             <dd>Clear protection in @graph @container with null context.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/pr43-in.jsonld'>expand/pr43-in.jsonld</a>
+              <a href="expand/pr43-in.jsonld">expand/pr43-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/pr43-out.jsonld'>expand/pr43-out.jsonld</a>
+              <a href="expand/pr43-out.jsonld">expand/pr43-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tso01'>
+        <dt id="tso01">
           Test tso01 @import is invalid in 1.0.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tso01</dd>
             <dt>Type</dt>
@@ -9684,7 +9712,7 @@
             <dd>@import is invalid in 1.0.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/so01-in.jsonld'>expand/so01-in.jsonld</a>
+              <a href="expand/so01-in.jsonld">expand/so01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9692,7 +9720,7 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
                 <dt>processingMode</dt>
@@ -9701,11 +9729,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='tso02'>
+        <dt id="tso02">
           Test tso02 @import must be a string
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tso02</dd>
             <dt>Type</dt>
@@ -9714,7 +9742,7 @@
             <dd>@import must be a string.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/so02-in.jsonld'>expand/so02-in.jsonld</a>
+              <a href="expand/so02-in.jsonld">expand/so02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9722,18 +9750,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tso03'>
+        <dt id="tso03">
           Test tso03 @import overflow
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tso03</dd>
             <dt>Type</dt>
@@ -9742,7 +9770,7 @@
             <dd>Processors must detect source contexts that include @import.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/so03-in.jsonld'>expand/so03-in.jsonld</a>
+              <a href="expand/so03-in.jsonld">expand/so03-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9750,18 +9778,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tso05'>
+        <dt id="tso05">
           Test tso05 @propagate: true on type-scoped context with @import
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tso05</dd>
             <dt>Type</dt>
@@ -9770,26 +9798,26 @@
             <dd>type-scoped context with @propagate: true survive node-objects (with @import)</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/so05-in.jsonld'>expand/so05-in.jsonld</a>
+              <a href="expand/so05-in.jsonld">expand/so05-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/so05-out.jsonld'>expand/so05-out.jsonld</a>
+              <a href="expand/so05-out.jsonld">expand/so05-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tso06'>
+        <dt id="tso06">
           Test tso06 @propagate: false on property-scoped context with @import
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tso06</dd>
             <dt>Type</dt>
@@ -9798,26 +9826,26 @@
             <dd>property-scoped context with @propagate: false do not survive node-objects (with @import)</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/so06-in.jsonld'>expand/so06-in.jsonld</a>
+              <a href="expand/so06-in.jsonld">expand/so06-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/so06-out.jsonld'>expand/so06-out.jsonld</a>
+              <a href="expand/so06-out.jsonld">expand/so06-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tso07'>
+        <dt id="tso07">
           Test tso07 Protect all terms in sourced context
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tso07</dd>
             <dt>Type</dt>
@@ -9826,7 +9854,7 @@
             <dd>A protected context protects all term definitions.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/so07-in.jsonld'>expand/so07-in.jsonld</a>
+              <a href="expand/so07-in.jsonld">expand/so07-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9834,18 +9862,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tso08'>
+        <dt id="tso08">
           Test tso08 Override term defined in sourced context
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tso08</dd>
             <dt>Type</dt>
@@ -9854,26 +9882,26 @@
             <dd>The containing context is merged into the source context.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/so08-in.jsonld'>expand/so08-in.jsonld</a>
+              <a href="expand/so08-in.jsonld">expand/so08-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/so08-out.jsonld'>expand/so08-out.jsonld</a>
+              <a href="expand/so08-out.jsonld">expand/so08-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tso09'>
+        <dt id="tso09">
           Test tso09 Override @vocab defined in sourced context
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tso09</dd>
             <dt>Type</dt>
@@ -9882,26 +9910,26 @@
             <dd>The containing context is merged into the source context.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/so09-in.jsonld'>expand/so09-in.jsonld</a>
+              <a href="expand/so09-in.jsonld">expand/so09-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/so09-out.jsonld'>expand/so09-out.jsonld</a>
+              <a href="expand/so09-out.jsonld">expand/so09-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tso10'>
+        <dt id="tso10">
           Test tso10 Protect terms in sourced context
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tso10</dd>
             <dt>Type</dt>
@@ -9910,7 +9938,7 @@
             <dd>The containing context is merged into the source context.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/so10-in.jsonld'>expand/so10-in.jsonld</a>
+              <a href="expand/so10-in.jsonld">expand/so10-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9918,18 +9946,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tso11'>
+        <dt id="tso11">
           Test tso11 Override protected terms in sourced context
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tso11</dd>
             <dt>Type</dt>
@@ -9938,26 +9966,26 @@
             <dd>The containing context is merged into the source context.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/so11-in.jsonld'>expand/so11-in.jsonld</a>
+              <a href="expand/so11-in.jsonld">expand/so11-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/so11-out.jsonld'>expand/so11-out.jsonld</a>
+              <a href="expand/so11-out.jsonld">expand/so11-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tso12'>
+        <dt id="tso12">
           Test tso12 @import may not be used in an imported context.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tso12</dd>
             <dt>Type</dt>
@@ -9966,7 +9994,7 @@
             <dd>@import only valid within a term definition.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/so12-in.jsonld'>expand/so12-in.jsonld</a>
+              <a href="expand/so12-in.jsonld">expand/so12-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9974,18 +10002,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='tso13'>
+        <dt id="tso13">
           Test tso13 @import can only reference a single context
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#tso13</dd>
             <dt>Type</dt>
@@ -9994,7 +10022,7 @@
             <dd>@import can only reference a single context.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/so13-in.jsonld'>expand/so13-in.jsonld</a>
+              <a href="expand/so13-in.jsonld">expand/so13-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -10002,18 +10030,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id='ttn01'>
+        <dt id="ttn01">
           Test ttn01 @type: @none is illegal in 1.0.
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ttn01</dd>
             <dt>Type</dt>
@@ -10022,7 +10050,7 @@
             <dd>@type: @none is illegal in json-ld-1.0.</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/tn01-in.jsonld'>expand/tn01-in.jsonld</a>
+              <a href="expand/tn01-in.jsonld">expand/tn01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -10030,7 +10058,7 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
                 <dt>processingMode</dt>
@@ -10039,11 +10067,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id='ttn02'>
+        <dt id="ttn02">
           Test ttn02 @type: @none expands strings as value objects
         </dt>
         <dd>
-          <dl class='entry'>
+          <dl class="entry">
             <dt>id</dt>
             <dd>#ttn02</dd>
             <dt>Type</dt>
@@ -10052,15 +10080,15 @@
             <dd>@type: @none leaves inputs other than strings alone</dd>
             <dt>input</dt>
             <dd>
-              <a href='expand/tn02-in.jsonld'>expand/tn02-in.jsonld</a>
+              <a href="expand/tn02-in.jsonld">expand/tn02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href='expand/tn02-out.jsonld'>expand/tn02-out.jsonld</a>
+              <a href="expand/tn02-out.jsonld">expand/tn02-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class='options'>
+              <dl class="options">
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -3227,7 +3227,7 @@
             <dt>Type</dt>
             <dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
             <dt>Purpose</dt>
-            <dd>Property keys are expanded vocabulary-relative (@vocab, term definitions, compact IRIs with a defined prefix). @base is for document-relative IRI resolution where the algorithms pass that flag (e.g., certain @id and @type values), not for unmapped simple keys. With only @base set, an unmapped key like name has no vocabulary mapping and must be dropped; a relative @type token still resolves against the base. See IRI Expansion in the JSON-LD 1.1 Processing Algorithms and API.</dd>
+            <dd>Property keys are expanded vocabulary-relative (`@vocab`, term definitions, compact IRIs with a defined prefix). `@base` is for document-relative IRI resolution where the algorithms pass that flag (e.g., certain `@id` and `@type` values), not for unmapped simple keys. With only `@base` set, an unmapped key like `name` has no vocabulary mapping and must be dropped; a relative `@type` token still resolves against the base. See IRI Expansion in the JSON-LD 1.1 Processing Algorithms and API.</dd>
             <dt>input</dt>
             <dd>
               <a href='expand/0132-in.jsonld'>expand/0132-in.jsonld</a>

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -3227,7 +3227,7 @@
             <dt>Type</dt>
             <dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
             <dt>Purpose</dt>
-            <dd>Property keys are expanded vocabulary-relative (@vocab, term definitions, compact IRIs with a defined prefix). @base is for document-relative IRI resolution where the algorithms pass that flag (e.g. certain @id and @type values), not for unmapped simple keys. With only @base set, an unmapped key like name has no vocabulary mapping and must be dropped; a relative @type token still resolves against the base. See IRI Expansion in the JSON-LD 1.1 Processing Algorithms and API.</dd>
+            <dd>Property keys are expanded vocabulary-relative (`@vocab`, term definitions, compact IRIs with a defined prefix). `@base` is for document-relative IRI resolution where the algorithms pass that flag (e.g., certain `@id` and `@type` values), not for unmapped simple keys. With only `@base` set, an unmapped key like `name` has no vocabulary mapping and must be dropped; a relative `@type` token still resolves against the `base`. See IRI Expansion in the JSON-LD 1.1 Processing Algorithms and API.</dd>
             <dt>input</dt>
             <dd>
               <a href='expand/0132-in.jsonld'>expand/0132-in.jsonld</a>

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -3227,7 +3227,7 @@
             <dt>Type</dt>
             <dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
             <dt>Purpose</dt>
-            <dd>Property keys are expanded vocabulary-relative (`@vocab`, term definitions, compact IRIs with a defined prefix). `@base` is for document-relative IRI resolution where the algorithms pass that flag (e.g., certain `@id` and `@type` values), not for unmapped simple keys. With only `@base` set, an unmapped key like `name` has no vocabulary mapping and must be dropped; a relative `@type` token still resolves against the `base`. See IRI Expansion in the JSON-LD 1.1 Processing Algorithms and API.</dd>
+            <dd>Property keys are expanded vocabulary-relative (@vocab, term definitions, compact IRIs with a defined prefix). @base is for document-relative IRI resolution where the algorithms pass that flag (e.g. certain @id and @type values), not for unmapped simple keys. With only @base set, an unmapped key like name has no vocabulary mapping and must be dropped; a relative @type token still resolves against the base. See IRI Expansion in the JSON-LD 1.1 Processing Algorithms and API.</dd>
             <dt>input</dt>
             <dd>
               <a href='expand/0132-in.jsonld'>expand/0132-in.jsonld</a>

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -3217,6 +3217,34 @@
             </dd>
           </dl>
         </dd>
+        <dt id='t0132'>
+          Test t0132 @base does not expand property keys
+        </dt>
+        <dd>
+          <dl class='entry'>
+            <dt>id</dt>
+            <dd>#t0132</dd>
+            <dt>Type</dt>
+            <dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+            <dt>Purpose</dt>
+            <dd>Property keys are expanded vocabulary-relative (`@vocab`, term definitions, compact IRIs with a defined prefix). `@base` is for document-relative IRI resolution where the algorithms pass that flag (e.g., certain `@id` and `@type` values), not for unmapped simple keys. With only `@base` set, an unmapped key like `name` has no vocabulary mapping and must be dropped; a relative `@type` token still resolves against the base. See IRI Expansion in the JSON-LD 1.1 Processing Algorithms and API.</dd>
+            <dt>input</dt>
+            <dd>
+              <a href='expand/0132-in.jsonld'>expand/0132-in.jsonld</a>
+            </dd>
+            <dt>expect</dt>
+            <dd>
+              <a href='expand/0132-out.jsonld'>expand/0132-out.jsonld</a>
+            </dd>
+            <dt>Options</dt>
+            <dd>
+              <dl class='options'>
+                <dt>specVersion</dt>
+                <dd>json-ld-1.1</dd>
+              </dl>
+            </dd>
+          </dl>
+        </dd>
         <dt id='tc001'>
           Test tc001 adding new term
         </dt>

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -3227,7 +3227,7 @@
             <dt>Type</dt>
             <dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
             <dt>Purpose</dt>
-            <dd>Property keys are expanded vocabulary-relative (@vocab, term definitions, compact IRIs with a defined prefix). @base is for document-relative IRI resolution where the algorithms pass that flag (e.g. certain @id and @type values), not for unmapped simple keys. With only @base set, an unmapped key like name has no vocabulary mapping and must be dropped; a relative @type token still resolves against the base. See IRI Expansion in the JSON-LD 1.1 Processing Algorithms and API.</dd>
+            <dd>Property keys are expanded vocabulary-relative (@vocab, term definitions, compact IRIs with a defined prefix). @base is for document-relative IRI resolution where the algorithms pass that flag (e.g., certain @id and @type values), not for unmapped simple keys. With only @base set, an unmapped key like name has no vocabulary mapping and must be dropped; a relative @type token still resolves against the base. See IRI Expansion in the JSON-LD 1.1 Processing Algorithms and API.</dd>
             <dt>input</dt>
             <dd>
               <a href='expand/0132-in.jsonld'>expand/0132-in.jsonld</a>

--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -1,17 +1,17 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+    <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
     <title>
       Expansion
     </title>
-    <link href="expand-manifest.jsonld" rel="alternate">
-    <link href="https://www.w3.org/StyleSheets/TR/base" rel="stylesheet">
+    <link href='expand-manifest.jsonld' rel='alternate'>
+    <link href='https://www.w3.org/StyleSheets/TR/base' rel='stylesheet'>
   </head>
   <body>
     <p>
-      <a href="http://www.w3.org/">
-        <img alt="W3C" height="48" src="http://www.w3.org/Icons/w3c_home" width="72">
+      <a href='http://www.w3.org/'>
+        <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
       </a>
     </p>
     <h1>Expansion</h1>
@@ -69,13 +69,13 @@
         that you will be creating a new test or fix and the purpose of the
         change.</li>
       <li>Clone the git repository: git://github.com/w3c/json-ld-api.git</li>
-      <li>Make your changes and submit them via github, or via a 'git format-patch'
+      <li>Make your changes and submit them via github, or via a &#39;git format-patch&#39;
         to the <a href="mailto:json-ld-wg@w3.org">JSON-LD Working Group mailing list</a>.</li>
     </ol>
     <h2>Distribution</h2>
-    <p>  Distributed under the <a href="http://www.w3.org/Consortium/Legal/2008/04-testsuite-license">W3C Test Suite License</a>. To contribute to a W3C Test Suite, see the <a href="http://www.w3.org/2004/10/27-testcases">policies and contribution forms</a>.</p>
+    <p>Distributed under the <a href="http://www.w3.org/Consortium/Legal/2008/04-testsuite-license">W3C Test Suite License</a>. To contribute to a W3C Test Suite, see the <a href="http://www.w3.org/2004/10/27-testcases">policies and contribution forms</a>.</p>
     <h2>Disclaimer</h2>
-    <p>  UNDER THE EXCLUSIVE LICENSE, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+    <p>UNDER THE EXCLUSIVE LICENSE, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED &quot;AS IS,&quot; AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
       COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
     <dl>
       <dt>baseIri</dt>
@@ -85,12 +85,12 @@
       <h2>
         Test sequence:
       </h2>
-      <dl class="entries">
-        <dt id="t0001">
+      <dl class='entries'>
+        <dt id='t0001'>
           Test t0001 drop free-floating nodes
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0001</dd>
             <dt>Type</dt>
@@ -99,19 +99,19 @@
             <dd>Expand drops unreferenced nodes having only @id</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0001-in.jsonld">expand/0001-in.jsonld</a>
+              <a href='expand/0001-in.jsonld'>expand/0001-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0001-out.jsonld">expand/0001-out.jsonld</a>
+              <a href='expand/0001-out.jsonld'>expand/0001-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0002">
+        <dt id='t0002'>
           Test t0002 basic
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0002</dd>
             <dt>Type</dt>
@@ -120,19 +120,19 @@
             <dd>Expanding terms with different types of values</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0002-in.jsonld">expand/0002-in.jsonld</a>
+              <a href='expand/0002-in.jsonld'>expand/0002-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0002-out.jsonld">expand/0002-out.jsonld</a>
+              <a href='expand/0002-out.jsonld'>expand/0002-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0003">
+        <dt id='t0003'>
           Test t0003 drop null and unmapped properties
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0003</dd>
             <dt>Type</dt>
@@ -141,19 +141,19 @@
             <dd>Verifies that null values and unmapped properties are removed from expanded output</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0003-in.jsonld">expand/0003-in.jsonld</a>
+              <a href='expand/0003-in.jsonld'>expand/0003-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0003-out.jsonld">expand/0003-out.jsonld</a>
+              <a href='expand/0003-out.jsonld'>expand/0003-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0004">
+        <dt id='t0004'>
           Test t0004 optimize @set, keep empty arrays
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0004</dd>
             <dt>Type</dt>
@@ -162,19 +162,19 @@
             <dd>Uses of @set are removed in expansion; values of @set, or just plain values which are empty arrays are retained</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0004-in.jsonld">expand/0004-in.jsonld</a>
+              <a href='expand/0004-in.jsonld'>expand/0004-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0004-out.jsonld">expand/0004-out.jsonld</a>
+              <a href='expand/0004-out.jsonld'>expand/0004-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0005">
+        <dt id='t0005'>
           Test t0005 do not expand aliased @id/@type
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0005</dd>
             <dt>Type</dt>
@@ -183,19 +183,19 @@
             <dd>If a keyword is aliased, it is not used when expanding</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0005-in.jsonld">expand/0005-in.jsonld</a>
+              <a href='expand/0005-in.jsonld'>expand/0005-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0005-out.jsonld">expand/0005-out.jsonld</a>
+              <a href='expand/0005-out.jsonld'>expand/0005-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0006">
+        <dt id='t0006'>
           Test t0006 alias keywords
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0006</dd>
             <dt>Type</dt>
@@ -204,19 +204,19 @@
             <dd>Aliased keywords expand in resulting document</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0006-in.jsonld">expand/0006-in.jsonld</a>
+              <a href='expand/0006-in.jsonld'>expand/0006-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0006-out.jsonld">expand/0006-out.jsonld</a>
+              <a href='expand/0006-out.jsonld'>expand/0006-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0007">
+        <dt id='t0007'>
           Test t0007 date type-coercion
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0007</dd>
             <dt>Type</dt>
@@ -225,19 +225,19 @@
             <dd>Expand strings to expanded value with @type: xsd:dateTime</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0007-in.jsonld">expand/0007-in.jsonld</a>
+              <a href='expand/0007-in.jsonld'>expand/0007-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0007-out.jsonld">expand/0007-out.jsonld</a>
+              <a href='expand/0007-out.jsonld'>expand/0007-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0008">
+        <dt id='t0008'>
           Test t0008 @value with @language
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0008</dd>
             <dt>Type</dt>
@@ -246,19 +246,19 @@
             <dd>Keep expanded values with @language, drop non-conforming value objects containing just @language</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0008-in.jsonld">expand/0008-in.jsonld</a>
+              <a href='expand/0008-in.jsonld'>expand/0008-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0008-out.jsonld">expand/0008-out.jsonld</a>
+              <a href='expand/0008-out.jsonld'>expand/0008-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0009">
+        <dt id='t0009'>
           Test t0009 @graph with terms
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0009</dd>
             <dt>Type</dt>
@@ -267,19 +267,19 @@
             <dd>Use of @graph to contain multiple nodes within array</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0009-in.jsonld">expand/0009-in.jsonld</a>
+              <a href='expand/0009-in.jsonld'>expand/0009-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0009-out.jsonld">expand/0009-out.jsonld</a>
+              <a href='expand/0009-out.jsonld'>expand/0009-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0010">
+        <dt id='t0010'>
           Test t0010 native types
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0010</dd>
             <dt>Type</dt>
@@ -288,19 +288,19 @@
             <dd>Expanding native scalar retains native scalar within expanded value</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0010-in.jsonld">expand/0010-in.jsonld</a>
+              <a href='expand/0010-in.jsonld'>expand/0010-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0010-out.jsonld">expand/0010-out.jsonld</a>
+              <a href='expand/0010-out.jsonld'>expand/0010-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0011">
+        <dt id='t0011'>
           Test t0011 coerced @id
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0011</dd>
             <dt>Type</dt>
@@ -309,19 +309,19 @@
             <dd>A value of a property with @type: @id coercion expands to a node reference</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0011-in.jsonld">expand/0011-in.jsonld</a>
+              <a href='expand/0011-in.jsonld'>expand/0011-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0011-out.jsonld">expand/0011-out.jsonld</a>
+              <a href='expand/0011-out.jsonld'>expand/0011-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0012">
+        <dt id='t0012'>
           Test t0012 @graph with embed
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0012</dd>
             <dt>Type</dt>
@@ -330,19 +330,19 @@
             <dd>Use of @graph to contain multiple nodes within array</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0012-in.jsonld">expand/0012-in.jsonld</a>
+              <a href='expand/0012-in.jsonld'>expand/0012-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0012-out.jsonld">expand/0012-out.jsonld</a>
+              <a href='expand/0012-out.jsonld'>expand/0012-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0013">
+        <dt id='t0013'>
           Test t0013 expand already expanded
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0013</dd>
             <dt>Type</dt>
@@ -351,19 +351,19 @@
             <dd>Expand does not mess up already expanded document</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0013-in.jsonld">expand/0013-in.jsonld</a>
+              <a href='expand/0013-in.jsonld'>expand/0013-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0013-out.jsonld">expand/0013-out.jsonld</a>
+              <a href='expand/0013-out.jsonld'>expand/0013-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0014">
+        <dt id='t0014'>
           Test t0014 @set of @value objects with keyword aliases
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0014</dd>
             <dt>Type</dt>
@@ -372,19 +372,19 @@
             <dd>Expanding aliased @set and @value</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0014-in.jsonld">expand/0014-in.jsonld</a>
+              <a href='expand/0014-in.jsonld'>expand/0014-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0014-out.jsonld">expand/0014-out.jsonld</a>
+              <a href='expand/0014-out.jsonld'>expand/0014-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0015">
+        <dt id='t0015'>
           Test t0015 collapse set of sets, keep empty lists
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0015</dd>
             <dt>Type</dt>
@@ -393,19 +393,19 @@
             <dd>An array of multiple @set nodes are collapsed into a single array</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0015-in.jsonld">expand/0015-in.jsonld</a>
+              <a href='expand/0015-in.jsonld'>expand/0015-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0015-out.jsonld">expand/0015-out.jsonld</a>
+              <a href='expand/0015-out.jsonld'>expand/0015-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0016">
+        <dt id='t0016'>
           Test t0016 context reset
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0016</dd>
             <dt>Type</dt>
@@ -414,19 +414,19 @@
             <dd>Setting @context to null within an embedded object resets back to initial context state</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0016-in.jsonld">expand/0016-in.jsonld</a>
+              <a href='expand/0016-in.jsonld'>expand/0016-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0016-out.jsonld">expand/0016-out.jsonld</a>
+              <a href='expand/0016-out.jsonld'>expand/0016-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0017">
+        <dt id='t0017'>
           Test t0017 @graph and @id aliased
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0017</dd>
             <dt>Type</dt>
@@ -435,19 +435,19 @@
             <dd>Expanding with @graph and @id aliases</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0017-in.jsonld">expand/0017-in.jsonld</a>
+              <a href='expand/0017-in.jsonld'>expand/0017-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0017-out.jsonld">expand/0017-out.jsonld</a>
+              <a href='expand/0017-out.jsonld'>expand/0017-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0018">
+        <dt id='t0018'>
           Test t0018 override default @language
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0018</dd>
             <dt>Type</dt>
@@ -456,19 +456,19 @@
             <dd>override default @language in terms; only language-tag strings</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0018-in.jsonld">expand/0018-in.jsonld</a>
+              <a href='expand/0018-in.jsonld'>expand/0018-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0018-out.jsonld">expand/0018-out.jsonld</a>
+              <a href='expand/0018-out.jsonld'>expand/0018-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0019">
+        <dt id='t0019'>
           Test t0019 remove @value = null
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0019</dd>
             <dt>Type</dt>
@@ -477,19 +477,19 @@
             <dd>Expanding a value of null removes the value</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0019-in.jsonld">expand/0019-in.jsonld</a>
+              <a href='expand/0019-in.jsonld'>expand/0019-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0019-out.jsonld">expand/0019-out.jsonld</a>
+              <a href='expand/0019-out.jsonld'>expand/0019-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0020">
+        <dt id='t0020'>
           Test t0020 do not remove @graph if not at top-level
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0020</dd>
             <dt>Type</dt>
@@ -498,19 +498,19 @@
             <dd>@graph used under a node is retained</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0020-in.jsonld">expand/0020-in.jsonld</a>
+              <a href='expand/0020-in.jsonld'>expand/0020-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0020-out.jsonld">expand/0020-out.jsonld</a>
+              <a href='expand/0020-out.jsonld'>expand/0020-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0021">
+        <dt id='t0021'>
           Test t0021 do not remove @graph at top-level if not only property
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0021</dd>
             <dt>Type</dt>
@@ -519,19 +519,19 @@
             <dd>@graph used at the top level is retained if there are other properties</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0021-in.jsonld">expand/0021-in.jsonld</a>
+              <a href='expand/0021-in.jsonld'>expand/0021-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0021-out.jsonld">expand/0021-out.jsonld</a>
+              <a href='expand/0021-out.jsonld'>expand/0021-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0022">
+        <dt id='t0022'>
           Test t0022 expand value with default language
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0022</dd>
             <dt>Type</dt>
@@ -540,19 +540,19 @@
             <dd>Expanding with a default language applies that language to string values</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0022-in.jsonld">expand/0022-in.jsonld</a>
+              <a href='expand/0022-in.jsonld'>expand/0022-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0022-out.jsonld">expand/0022-out.jsonld</a>
+              <a href='expand/0022-out.jsonld'>expand/0022-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0023">
+        <dt id='t0023'>
           Test t0023 Expanding list/set with coercion
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0023</dd>
             <dt>Type</dt>
@@ -561,19 +561,19 @@
             <dd>Expanding lists and sets with properties having coercion coerces list/set values</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0023-in.jsonld">expand/0023-in.jsonld</a>
+              <a href='expand/0023-in.jsonld'>expand/0023-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0023-out.jsonld">expand/0023-out.jsonld</a>
+              <a href='expand/0023-out.jsonld'>expand/0023-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0024">
+        <dt id='t0024'>
           Test t0024 Multiple contexts
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0024</dd>
             <dt>Type</dt>
@@ -582,19 +582,19 @@
             <dd>Tests that contexts in an array are merged</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0024-in.jsonld">expand/0024-in.jsonld</a>
+              <a href='expand/0024-in.jsonld'>expand/0024-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0024-out.jsonld">expand/0024-out.jsonld</a>
+              <a href='expand/0024-out.jsonld'>expand/0024-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0025">
+        <dt id='t0025'>
           Test t0025 Problematic IRI expansion tests
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0025</dd>
             <dt>Type</dt>
@@ -603,19 +603,19 @@
             <dd>Expanding different kinds of terms and Compact IRIs</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0025-in.jsonld">expand/0025-in.jsonld</a>
+              <a href='expand/0025-in.jsonld'>expand/0025-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0025-out.jsonld">expand/0025-out.jsonld</a>
+              <a href='expand/0025-out.jsonld'>expand/0025-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0026">
+        <dt id='t0026'>
           Test t0026 Term definition with @id: @type
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0026</dd>
             <dt>Type</dt>
@@ -624,26 +624,26 @@
             <dd>Expanding term mapping to @type uses @type syntax</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0026-in.jsonld">expand/0026-in.jsonld</a>
+              <a href='expand/0026-in.jsonld'>expand/0026-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0026-out.jsonld">expand/0026-out.jsonld</a>
+              <a href='expand/0026-out.jsonld'>expand/0026-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.0</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0027">
+        <dt id='t0027'>
           Test t0027 Duplicate values in @list and @set
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0027</dd>
             <dt>Type</dt>
@@ -652,19 +652,19 @@
             <dd>Duplicate values in @list and @set are not merged</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0027-in.jsonld">expand/0027-in.jsonld</a>
+              <a href='expand/0027-in.jsonld'>expand/0027-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0027-out.jsonld">expand/0027-out.jsonld</a>
+              <a href='expand/0027-out.jsonld'>expand/0027-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0028">
+        <dt id='t0028'>
           Test t0028 Use @vocab in properties and @type but not in @id
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0028</dd>
             <dt>Type</dt>
@@ -673,19 +673,19 @@
             <dd>@vocab is used to compact properties and @type, but is not used for @id</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0028-in.jsonld">expand/0028-in.jsonld</a>
+              <a href='expand/0028-in.jsonld'>expand/0028-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0028-out.jsonld">expand/0028-out.jsonld</a>
+              <a href='expand/0028-out.jsonld'>expand/0028-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0029">
+        <dt id='t0029'>
           Test t0029 Relative IRIs
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0029</dd>
             <dt>Type</dt>
@@ -694,19 +694,19 @@
             <dd>@base is used to compact @id; test with different relative IRIs</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0029-in.jsonld">expand/0029-in.jsonld</a>
+              <a href='expand/0029-in.jsonld'>expand/0029-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0029-out.jsonld">expand/0029-out.jsonld</a>
+              <a href='expand/0029-out.jsonld'>expand/0029-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0030">
+        <dt id='t0030'>
           Test t0030 Language maps
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0030</dd>
             <dt>Type</dt>
@@ -715,19 +715,19 @@
             <dd>Language Maps expand values to include @language</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0030-in.jsonld">expand/0030-in.jsonld</a>
+              <a href='expand/0030-in.jsonld'>expand/0030-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0030-out.jsonld">expand/0030-out.jsonld</a>
+              <a href='expand/0030-out.jsonld'>expand/0030-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0031">
+        <dt id='t0031'>
           Test t0031 type-coercion of native types
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0031</dd>
             <dt>Type</dt>
@@ -736,19 +736,19 @@
             <dd>Expanding native types with type coercion adds the coerced type to an expanded value representation and retains the native value representation</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0031-in.jsonld">expand/0031-in.jsonld</a>
+              <a href='expand/0031-in.jsonld'>expand/0031-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0031-out.jsonld">expand/0031-out.jsonld</a>
+              <a href='expand/0031-out.jsonld'>expand/0031-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0032">
+        <dt id='t0032'>
           Test t0032 Null term and @vocab
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0032</dd>
             <dt>Type</dt>
@@ -757,19 +757,19 @@
             <dd>Mapping a term to null decouples it from @vocab</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0032-in.jsonld">expand/0032-in.jsonld</a>
+              <a href='expand/0032-in.jsonld'>expand/0032-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0032-out.jsonld">expand/0032-out.jsonld</a>
+              <a href='expand/0032-out.jsonld'>expand/0032-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0033">
+        <dt id='t0033'>
           Test t0033 Using @vocab with with type-coercion
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0033</dd>
             <dt>Type</dt>
@@ -778,19 +778,19 @@
             <dd>Verifies that terms can be defined using @vocab</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0033-in.jsonld">expand/0033-in.jsonld</a>
+              <a href='expand/0033-in.jsonld'>expand/0033-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0033-out.jsonld">expand/0033-out.jsonld</a>
+              <a href='expand/0033-out.jsonld'>expand/0033-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0034">
+        <dt id='t0034'>
           Test t0034 Multiple properties expanding to the same IRI
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0034</dd>
             <dt>Type</dt>
@@ -799,19 +799,19 @@
             <dd>Verifies multiple values from separate terms are deterministically made multiple values of the IRI associated with the terms</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0034-in.jsonld">expand/0034-in.jsonld</a>
+              <a href='expand/0034-in.jsonld'>expand/0034-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0034-out.jsonld">expand/0034-out.jsonld</a>
+              <a href='expand/0034-out.jsonld'>expand/0034-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0035">
+        <dt id='t0035'>
           Test t0035 Language maps with @vocab, default language, and colliding property
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0035</dd>
             <dt>Type</dt>
@@ -820,19 +820,19 @@
             <dd>Pathological tests of language maps</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0035-in.jsonld">expand/0035-in.jsonld</a>
+              <a href='expand/0035-in.jsonld'>expand/0035-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0035-out.jsonld">expand/0035-out.jsonld</a>
+              <a href='expand/0035-out.jsonld'>expand/0035-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0036">
+        <dt id='t0036'>
           Test t0036 Expanding @index
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0036</dd>
             <dt>Type</dt>
@@ -841,19 +841,19 @@
             <dd>Expanding index maps for terms defined with @container: @index</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0036-in.jsonld">expand/0036-in.jsonld</a>
+              <a href='expand/0036-in.jsonld'>expand/0036-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0036-out.jsonld">expand/0036-out.jsonld</a>
+              <a href='expand/0036-out.jsonld'>expand/0036-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0037">
+        <dt id='t0037'>
           Test t0037 Expanding @reverse
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0037</dd>
             <dt>Type</dt>
@@ -862,19 +862,19 @@
             <dd>Expanding @reverse keeps @reverse</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0037-in.jsonld">expand/0037-in.jsonld</a>
+              <a href='expand/0037-in.jsonld'>expand/0037-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0037-out.jsonld">expand/0037-out.jsonld</a>
+              <a href='expand/0037-out.jsonld'>expand/0037-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0038">
+        <dt id='t0038'>
           Test t0038 Expanding blank node labels
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0038</dd>
             <dt>Type</dt>
@@ -883,26 +883,26 @@
             <dd>Blank nodes are not relabeled during expansion</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0038-in.jsonld">expand/0038-in.jsonld</a>
+              <a href='expand/0038-in.jsonld'>expand/0038-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0038-out.jsonld">expand/0038-out.jsonld</a>
+              <a href='expand/0038-out.jsonld'>expand/0038-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.0</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0039">
+        <dt id='t0039'>
           Test t0039 Using terms in a reverse-maps
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0039</dd>
             <dt>Type</dt>
@@ -911,19 +911,19 @@
             <dd>Terms within @reverse are expanded</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0039-in.jsonld">expand/0039-in.jsonld</a>
+              <a href='expand/0039-in.jsonld'>expand/0039-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0039-out.jsonld">expand/0039-out.jsonld</a>
+              <a href='expand/0039-out.jsonld'>expand/0039-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0040">
+        <dt id='t0040'>
           Test t0040 language and index expansion on non-objects
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0040</dd>
             <dt>Type</dt>
@@ -932,19 +932,19 @@
             <dd>Only invoke language and index map expansion if the value is a JSON object</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0040-in.jsonld">expand/0040-in.jsonld</a>
+              <a href='expand/0040-in.jsonld'>expand/0040-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0040-out.jsonld">expand/0040-out.jsonld</a>
+              <a href='expand/0040-out.jsonld'>expand/0040-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0041">
+        <dt id='t0041'>
           Test t0041 @language: null
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0041</dd>
             <dt>Type</dt>
@@ -953,19 +953,19 @@
             <dd>@language: null resets the default language</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0041-in.jsonld">expand/0041-in.jsonld</a>
+              <a href='expand/0041-in.jsonld'>expand/0041-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0041-out.jsonld">expand/0041-out.jsonld</a>
+              <a href='expand/0041-out.jsonld'>expand/0041-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0042">
+        <dt id='t0042'>
           Test t0042 Reverse properties
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0042</dd>
             <dt>Type</dt>
@@ -974,19 +974,19 @@
             <dd>Expanding terms defined as reverse properties uses @reverse in expanded document</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0042-in.jsonld">expand/0042-in.jsonld</a>
+              <a href='expand/0042-in.jsonld'>expand/0042-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0042-out.jsonld">expand/0042-out.jsonld</a>
+              <a href='expand/0042-out.jsonld'>expand/0042-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0043">
+        <dt id='t0043'>
           Test t0043 Using reverse properties inside a @reverse-container
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0043</dd>
             <dt>Type</dt>
@@ -995,19 +995,19 @@
             <dd>Expanding a reverse property within a @reverse undoes both reversals</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0043-in.jsonld">expand/0043-in.jsonld</a>
+              <a href='expand/0043-in.jsonld'>expand/0043-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0043-out.jsonld">expand/0043-out.jsonld</a>
+              <a href='expand/0043-out.jsonld'>expand/0043-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0044">
+        <dt id='t0044'>
           Test t0044 Index maps with language mappings
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0044</dd>
             <dt>Type</dt>
@@ -1016,19 +1016,19 @@
             <dd>Ensure index maps use language mapping</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0044-in.jsonld">expand/0044-in.jsonld</a>
+              <a href='expand/0044-in.jsonld'>expand/0044-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0044-out.jsonld">expand/0044-out.jsonld</a>
+              <a href='expand/0044-out.jsonld'>expand/0044-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0045">
+        <dt id='t0045'>
           Test t0045 Top-level value objects
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0045</dd>
             <dt>Type</dt>
@@ -1037,19 +1037,19 @@
             <dd>Expanding top-level value objects causes them to be removed</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0045-in.jsonld">expand/0045-in.jsonld</a>
+              <a href='expand/0045-in.jsonld'>expand/0045-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0045-out.jsonld">expand/0045-out.jsonld</a>
+              <a href='expand/0045-out.jsonld'>expand/0045-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0046">
+        <dt id='t0046'>
           Test t0046 Free-floating nodes
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0046</dd>
             <dt>Type</dt>
@@ -1058,19 +1058,19 @@
             <dd>Expanding free-floating nodes causes them to be removed</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0046-in.jsonld">expand/0046-in.jsonld</a>
+              <a href='expand/0046-in.jsonld'>expand/0046-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0046-out.jsonld">expand/0046-out.jsonld</a>
+              <a href='expand/0046-out.jsonld'>expand/0046-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0047">
+        <dt id='t0047'>
           Test t0047 Free-floating values in sets and free-floating lists
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0047</dd>
             <dt>Type</dt>
@@ -1079,19 +1079,19 @@
             <dd>Free-floating values in sets are removed, free-floating lists are removed completely</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0047-in.jsonld">expand/0047-in.jsonld</a>
+              <a href='expand/0047-in.jsonld'>expand/0047-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0047-out.jsonld">expand/0047-out.jsonld</a>
+              <a href='expand/0047-out.jsonld'>expand/0047-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0048">
+        <dt id='t0048'>
           Test t0048 Terms are ignored in @id
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0048</dd>
             <dt>Type</dt>
@@ -1100,19 +1100,19 @@
             <dd>Values of @id are not expanded as terms</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0048-in.jsonld">expand/0048-in.jsonld</a>
+              <a href='expand/0048-in.jsonld'>expand/0048-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0048-out.jsonld">expand/0048-out.jsonld</a>
+              <a href='expand/0048-out.jsonld'>expand/0048-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0049">
+        <dt id='t0049'>
           Test t0049 String values of reverse properties
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0049</dd>
             <dt>Type</dt>
@@ -1121,19 +1121,19 @@
             <dd>String values of a reverse property with @type: @id are treated as IRIs</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0049-in.jsonld">expand/0049-in.jsonld</a>
+              <a href='expand/0049-in.jsonld'>expand/0049-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0049-out.jsonld">expand/0049-out.jsonld</a>
+              <a href='expand/0049-out.jsonld'>expand/0049-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0050">
+        <dt id='t0050'>
           Test t0050 Term definitions with prefix separate from prefix definitions
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0050</dd>
             <dt>Type</dt>
@@ -1142,19 +1142,19 @@
             <dd>Term definitions using compact IRIs don&#39;t inherit the definitions of the prefix</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0050-in.jsonld">expand/0050-in.jsonld</a>
+              <a href='expand/0050-in.jsonld'>expand/0050-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0050-out.jsonld">expand/0050-out.jsonld</a>
+              <a href='expand/0050-out.jsonld'>expand/0050-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0051">
+        <dt id='t0051'>
           Test t0051 Expansion of keyword aliases in term definitions
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0051</dd>
             <dt>Type</dt>
@@ -1163,19 +1163,19 @@
             <dd>Expanding terms which are keyword aliases</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0051-in.jsonld">expand/0051-in.jsonld</a>
+              <a href='expand/0051-in.jsonld'>expand/0051-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0051-out.jsonld">expand/0051-out.jsonld</a>
+              <a href='expand/0051-out.jsonld'>expand/0051-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0052">
+        <dt id='t0052'>
           Test t0052 @vocab-relative IRIs in term definitions
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0052</dd>
             <dt>Type</dt>
@@ -1184,19 +1184,19 @@
             <dd>If @vocab is defined, term definitions are expanded relative to @vocab</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0052-in.jsonld">expand/0052-in.jsonld</a>
+              <a href='expand/0052-in.jsonld'>expand/0052-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0052-out.jsonld">expand/0052-out.jsonld</a>
+              <a href='expand/0052-out.jsonld'>expand/0052-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0053">
+        <dt id='t0053'>
           Test t0053 Expand absolute IRI with @type: @vocab
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0053</dd>
             <dt>Type</dt>
@@ -1205,19 +1205,19 @@
             <dd>Expanding values of properties of @type: @vocab does not further expand absolute IRIs</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0053-in.jsonld">expand/0053-in.jsonld</a>
+              <a href='expand/0053-in.jsonld'>expand/0053-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0053-out.jsonld">expand/0053-out.jsonld</a>
+              <a href='expand/0053-out.jsonld'>expand/0053-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0054">
+        <dt id='t0054'>
           Test t0054 Expand term with @type: @vocab
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0054</dd>
             <dt>Type</dt>
@@ -1226,19 +1226,19 @@
             <dd>Expanding values of properties of @type: @vocab does not expand term values</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0054-in.jsonld">expand/0054-in.jsonld</a>
+              <a href='expand/0054-in.jsonld'>expand/0054-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0054-out.jsonld">expand/0054-out.jsonld</a>
+              <a href='expand/0054-out.jsonld'>expand/0054-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0055">
+        <dt id='t0055'>
           Test t0055 Expand @vocab-relative term with @type: @vocab
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0055</dd>
             <dt>Type</dt>
@@ -1247,19 +1247,19 @@
             <dd>Expanding values of properties of @type: @vocab expands relative IRIs using @vocab</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0055-in.jsonld">expand/0055-in.jsonld</a>
+              <a href='expand/0055-in.jsonld'>expand/0055-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0055-out.jsonld">expand/0055-out.jsonld</a>
+              <a href='expand/0055-out.jsonld'>expand/0055-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0056">
+        <dt id='t0056'>
           Test t0056 Use terms with @type: @vocab but not with @type: @id
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0056</dd>
             <dt>Type</dt>
@@ -1268,19 +1268,19 @@
             <dd>Checks that expansion uses appropriate base depending on term definition having @type @id or @vocab</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0056-in.jsonld">expand/0056-in.jsonld</a>
+              <a href='expand/0056-in.jsonld'>expand/0056-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0056-out.jsonld">expand/0056-out.jsonld</a>
+              <a href='expand/0056-out.jsonld'>expand/0056-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0057">
+        <dt id='t0057'>
           Test t0057 Expand relative IRI with @type: @vocab
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0057</dd>
             <dt>Type</dt>
@@ -1289,19 +1289,19 @@
             <dd>Relative values of terms with @type: @vocab expand relative to @vocab</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0057-in.jsonld">expand/0057-in.jsonld</a>
+              <a href='expand/0057-in.jsonld'>expand/0057-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0057-out.jsonld">expand/0057-out.jsonld</a>
+              <a href='expand/0057-out.jsonld'>expand/0057-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0058">
+        <dt id='t0058'>
           Test t0058 Expand compact IRI with @type: @vocab
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0058</dd>
             <dt>Type</dt>
@@ -1310,19 +1310,19 @@
             <dd>Compact IRIs are expanded normally even if term has @type: @vocab</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0058-in.jsonld">expand/0058-in.jsonld</a>
+              <a href='expand/0058-in.jsonld'>expand/0058-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0058-out.jsonld">expand/0058-out.jsonld</a>
+              <a href='expand/0058-out.jsonld'>expand/0058-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0059">
+        <dt id='t0059'>
           Test t0059 Reset @vocab by setting it to null
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0059</dd>
             <dt>Type</dt>
@@ -1331,19 +1331,19 @@
             <dd>Setting @vocab to null removes a previous definition</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0059-in.jsonld">expand/0059-in.jsonld</a>
+              <a href='expand/0059-in.jsonld'>expand/0059-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0059-out.jsonld">expand/0059-out.jsonld</a>
+              <a href='expand/0059-out.jsonld'>expand/0059-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0060">
+        <dt id='t0060'>
           Test t0060 Overwrite document base with @base and reset it again
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0060</dd>
             <dt>Type</dt>
@@ -1352,19 +1352,19 @@
             <dd>Setting @base to an IRI and then resetting it to nil</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0060-in.jsonld">expand/0060-in.jsonld</a>
+              <a href='expand/0060-in.jsonld'>expand/0060-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0060-out.jsonld">expand/0060-out.jsonld</a>
+              <a href='expand/0060-out.jsonld'>expand/0060-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0061">
+        <dt id='t0061'>
           Test t0061 Coercing native types to arbitrary datatypes
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0061</dd>
             <dt>Type</dt>
@@ -1373,19 +1373,19 @@
             <dd>Expanding native types when coercing to arbitrary datatypes</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0061-in.jsonld">expand/0061-in.jsonld</a>
+              <a href='expand/0061-in.jsonld'>expand/0061-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0061-out.jsonld">expand/0061-out.jsonld</a>
+              <a href='expand/0061-out.jsonld'>expand/0061-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0062">
+        <dt id='t0062'>
           Test t0062 Various relative IRIs with with @base
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0062</dd>
             <dt>Type</dt>
@@ -1394,19 +1394,19 @@
             <dd>Pathological relative IRIs</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0062-in.jsonld">expand/0062-in.jsonld</a>
+              <a href='expand/0062-in.jsonld'>expand/0062-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0062-out.jsonld">expand/0062-out.jsonld</a>
+              <a href='expand/0062-out.jsonld'>expand/0062-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0063">
+        <dt id='t0063'>
           Test t0063 Reverse property and index container
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0063</dd>
             <dt>Type</dt>
@@ -1415,19 +1415,19 @@
             <dd>Expaning reverse properties with an index-container</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0063-in.jsonld">expand/0063-in.jsonld</a>
+              <a href='expand/0063-in.jsonld'>expand/0063-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0063-out.jsonld">expand/0063-out.jsonld</a>
+              <a href='expand/0063-out.jsonld'>expand/0063-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0064">
+        <dt id='t0064'>
           Test t0064 bnode values of reverse properties
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0064</dd>
             <dt>Type</dt>
@@ -1436,19 +1436,19 @@
             <dd>Expand reverse property whose values are unlabeled blank nodes</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0064-in.jsonld">expand/0064-in.jsonld</a>
+              <a href='expand/0064-in.jsonld'>expand/0064-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0064-out.jsonld">expand/0064-out.jsonld</a>
+              <a href='expand/0064-out.jsonld'>expand/0064-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0065">
+        <dt id='t0065'>
           Test t0065 Drop unmapped keys in reverse map
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0065</dd>
             <dt>Type</dt>
@@ -1457,19 +1457,19 @@
             <dd>Keys that are not mapped to an IRI in a reverse-map are dropped</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0065-in.jsonld">expand/0065-in.jsonld</a>
+              <a href='expand/0065-in.jsonld'>expand/0065-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0065-out.jsonld">expand/0065-out.jsonld</a>
+              <a href='expand/0065-out.jsonld'>expand/0065-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0066">
+        <dt id='t0066'>
           Test t0066 Reverse-map keys with @vocab
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0066</dd>
             <dt>Type</dt>
@@ -1478,19 +1478,19 @@
             <dd>Expand uses @vocab to expand keys in reverse-maps</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0066-in.jsonld">expand/0066-in.jsonld</a>
+              <a href='expand/0066-in.jsonld'>expand/0066-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0066-out.jsonld">expand/0066-out.jsonld</a>
+              <a href='expand/0066-out.jsonld'>expand/0066-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0067">
+        <dt id='t0067'>
           Test t0067 prefix://suffix not a compact IRI
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0067</dd>
             <dt>Type</dt>
@@ -1499,19 +1499,19 @@
             <dd>prefix:suffix values are not interpreted as compact IRIs if suffix begins with two slashes</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0067-in.jsonld">expand/0067-in.jsonld</a>
+              <a href='expand/0067-in.jsonld'>expand/0067-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0067-out.jsonld">expand/0067-out.jsonld</a>
+              <a href='expand/0067-out.jsonld'>expand/0067-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0068">
+        <dt id='t0068'>
           Test t0068 _:suffix values are not a compact IRI
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0068</dd>
             <dt>Type</dt>
@@ -1520,19 +1520,19 @@
             <dd>prefix:suffix values are not interpreted as compact IRIs if prefix is an underscore</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0068-in.jsonld">expand/0068-in.jsonld</a>
+              <a href='expand/0068-in.jsonld'>expand/0068-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0068-out.jsonld">expand/0068-out.jsonld</a>
+              <a href='expand/0068-out.jsonld'>expand/0068-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0069">
+        <dt id='t0069'>
           Test t0069 Compact IRI as term with type mapping
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0069</dd>
             <dt>Type</dt>
@@ -1541,19 +1541,19 @@
             <dd>Redefine compact IRI to define type mapping using the compact IRI itself as value of @id</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0069-in.jsonld">expand/0069-in.jsonld</a>
+              <a href='expand/0069-in.jsonld'>expand/0069-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0069-out.jsonld">expand/0069-out.jsonld</a>
+              <a href='expand/0069-out.jsonld'>expand/0069-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0070">
+        <dt id='t0070'>
           Test t0070 Compact IRI as term defined using equivalent compact IRI
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0070</dd>
             <dt>Type</dt>
@@ -1562,19 +1562,19 @@
             <dd>Redefine compact IRI to define type mapping using the compact IRI itself as string value</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0070-in.jsonld">expand/0070-in.jsonld</a>
+              <a href='expand/0070-in.jsonld'>expand/0070-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0070-out.jsonld">expand/0070-out.jsonld</a>
+              <a href='expand/0070-out.jsonld'>expand/0070-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0071">
+        <dt id='t0071'>
           Test t0071 Redefine terms looking like compact IRIs
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0071</dd>
             <dt>Type</dt>
@@ -1583,26 +1583,26 @@
             <dd>Term definitions may look like compact IRIs</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0071-in.jsonld">expand/0071-in.jsonld</a>
+              <a href='expand/0071-in.jsonld'>expand/0071-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0071-out.jsonld">expand/0071-out.jsonld</a>
+              <a href='expand/0071-out.jsonld'>expand/0071-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.0</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0072">
+        <dt id='t0072'>
           Test t0072 Redefine term using @vocab, not itself
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0072</dd>
             <dt>Type</dt>
@@ -1611,19 +1611,19 @@
             <dd>Redefining a term as itself when @vocab is defined uses @vocab, not previous term definition</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0072-in.jsonld">expand/0072-in.jsonld</a>
+              <a href='expand/0072-in.jsonld'>expand/0072-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0072-out.jsonld">expand/0072-out.jsonld</a>
+              <a href='expand/0072-out.jsonld'>expand/0072-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0073">
+        <dt id='t0073'>
           Test t0073 @context not first property
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0073</dd>
             <dt>Type</dt>
@@ -1632,19 +1632,19 @@
             <dd>Objects are unordered, so serialized node definition containing @context may have @context at the end of the node definition</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0073-in.jsonld">expand/0073-in.jsonld</a>
+              <a href='expand/0073-in.jsonld'>expand/0073-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0073-out.jsonld">expand/0073-out.jsonld</a>
+              <a href='expand/0073-out.jsonld'>expand/0073-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0074">
+        <dt id='t0074'>
           Test t0074 @id not first property
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0074</dd>
             <dt>Type</dt>
@@ -1653,19 +1653,19 @@
             <dd>Objects are unordered, so serialized node definition containing @id may have @id at the end of the node definition</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0074-in.jsonld">expand/0074-in.jsonld</a>
+              <a href='expand/0074-in.jsonld'>expand/0074-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0074-out.jsonld">expand/0074-out.jsonld</a>
+              <a href='expand/0074-out.jsonld'>expand/0074-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0075">
+        <dt id='t0075'>
           Test t0075 @vocab as blank node identifier
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0075</dd>
             <dt>Type</dt>
@@ -1674,26 +1674,26 @@
             <dd>Use @vocab to map all properties to blank node identifiers</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0075-in.jsonld">expand/0075-in.jsonld</a>
+              <a href='expand/0075-in.jsonld'>expand/0075-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0075-out.jsonld">expand/0075-out.jsonld</a>
+              <a href='expand/0075-out.jsonld'>expand/0075-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>processingMode</dt>
                 <dd>json-ld-1.0</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0076">
+        <dt id='t0076'>
           Test t0076 base option overrides document location
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0076</dd>
             <dt>Type</dt>
@@ -1702,26 +1702,26 @@
             <dd>Use of the base option overrides the document location</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0076-in.jsonld">expand/0076-in.jsonld</a>
+              <a href='expand/0076-in.jsonld'>expand/0076-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0076-out.jsonld">expand/0076-out.jsonld</a>
+              <a href='expand/0076-out.jsonld'>expand/0076-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>base</dt>
                 <dd>http://example/base/</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0077">
+        <dt id='t0077'>
           Test t0077 expandContext option
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0077</dd>
             <dt>Type</dt>
@@ -1730,26 +1730,26 @@
             <dd>Use of the expandContext option to expand the input document</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0077-in.jsonld">expand/0077-in.jsonld</a>
+              <a href='expand/0077-in.jsonld'>expand/0077-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0077-out.jsonld">expand/0077-out.jsonld</a>
+              <a href='expand/0077-out.jsonld'>expand/0077-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>expandContext</dt>
                 <dd>expand/0077-context.jsonld</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0078">
+        <dt id='t0078'>
           Test t0078 multiple reverse properties
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0078</dd>
             <dt>Type</dt>
@@ -1758,19 +1758,19 @@
             <dd>Use of multiple reverse properties</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0078-in.jsonld">expand/0078-in.jsonld</a>
+              <a href='expand/0078-in.jsonld'>expand/0078-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0078-out.jsonld">expand/0078-out.jsonld</a>
+              <a href='expand/0078-out.jsonld'>expand/0078-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0079">
+        <dt id='t0079'>
           Test t0079 expand @graph container
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0079</dd>
             <dt>Type</dt>
@@ -1779,26 +1779,26 @@
             <dd>Use of @graph containers</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0079-in.jsonld">expand/0079-in.jsonld</a>
+              <a href='expand/0079-in.jsonld'>expand/0079-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0079-out.jsonld">expand/0079-out.jsonld</a>
+              <a href='expand/0079-out.jsonld'>expand/0079-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0080">
+        <dt id='t0080'>
           Test t0080 expand [@graph, @set] container
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0080</dd>
             <dt>Type</dt>
@@ -1807,26 +1807,26 @@
             <dd>Use of [@graph, @set] containers</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0080-in.jsonld">expand/0080-in.jsonld</a>
+              <a href='expand/0080-in.jsonld'>expand/0080-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0080-out.jsonld">expand/0080-out.jsonld</a>
+              <a href='expand/0080-out.jsonld'>expand/0080-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0081">
+        <dt id='t0081'>
           Test t0081 Creates an @graph container if value is a graph
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0081</dd>
             <dt>Type</dt>
@@ -1835,26 +1835,26 @@
             <dd>Don&#39;t double-expand an already expanded graph</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0081-in.jsonld">expand/0081-in.jsonld</a>
+              <a href='expand/0081-in.jsonld'>expand/0081-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0081-out.jsonld">expand/0081-out.jsonld</a>
+              <a href='expand/0081-out.jsonld'>expand/0081-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0082">
+        <dt id='t0082'>
           Test t0082 expand [@graph, @index] container
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0082</dd>
             <dt>Type</dt>
@@ -1863,26 +1863,26 @@
             <dd>Use of @graph containers with @index</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0082-in.jsonld">expand/0082-in.jsonld</a>
+              <a href='expand/0082-in.jsonld'>expand/0082-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0082-out.jsonld">expand/0082-out.jsonld</a>
+              <a href='expand/0082-out.jsonld'>expand/0082-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0083">
+        <dt id='t0083'>
           Test t0083 expand [@graph, @index, @set] container
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0083</dd>
             <dt>Type</dt>
@@ -1891,26 +1891,26 @@
             <dd>Use of @graph containers with @index and @set</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0083-in.jsonld">expand/0083-in.jsonld</a>
+              <a href='expand/0083-in.jsonld'>expand/0083-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0083-out.jsonld">expand/0083-out.jsonld</a>
+              <a href='expand/0083-out.jsonld'>expand/0083-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0084">
+        <dt id='t0084'>
           Test t0084 Do not expand [@graph, @index] container if value is a graph
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0084</dd>
             <dt>Type</dt>
@@ -1919,26 +1919,26 @@
             <dd>Does not create a new graph object if indexed value is already a graph object</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0084-in.jsonld">expand/0084-in.jsonld</a>
+              <a href='expand/0084-in.jsonld'>expand/0084-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0084-out.jsonld">expand/0084-out.jsonld</a>
+              <a href='expand/0084-out.jsonld'>expand/0084-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0085">
+        <dt id='t0085'>
           Test t0085 expand [@graph, @id] container
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0085</dd>
             <dt>Type</dt>
@@ -1947,26 +1947,26 @@
             <dd>Use of @graph containers with @id</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0085-in.jsonld">expand/0085-in.jsonld</a>
+              <a href='expand/0085-in.jsonld'>expand/0085-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0085-out.jsonld">expand/0085-out.jsonld</a>
+              <a href='expand/0085-out.jsonld'>expand/0085-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0086">
+        <dt id='t0086'>
           Test t0086 expand [@graph, @id, @set] container
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0086</dd>
             <dt>Type</dt>
@@ -1975,26 +1975,26 @@
             <dd>Use of @graph containers with @id and @set</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0086-in.jsonld">expand/0086-in.jsonld</a>
+              <a href='expand/0086-in.jsonld'>expand/0086-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0086-out.jsonld">expand/0086-out.jsonld</a>
+              <a href='expand/0086-out.jsonld'>expand/0086-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0087">
+        <dt id='t0087'>
           Test t0087 Do not expand [@graph, @id] container if value is a graph
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0087</dd>
             <dt>Type</dt>
@@ -2003,26 +2003,26 @@
             <dd>Does not create a new graph object if indexed value is already a graph object</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0087-in.jsonld">expand/0087-in.jsonld</a>
+              <a href='expand/0087-in.jsonld'>expand/0087-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0087-out.jsonld">expand/0087-out.jsonld</a>
+              <a href='expand/0087-out.jsonld'>expand/0087-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0088">
+        <dt id='t0088'>
           Test t0088 Do not expand native values to IRIs
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0088</dd>
             <dt>Type</dt>
@@ -2031,19 +2031,19 @@
             <dd>Value Expansion does not expand native values, such as booleans, to a node object</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0088-in.jsonld">expand/0088-in.jsonld</a>
+              <a href='expand/0088-in.jsonld'>expand/0088-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0088-out.jsonld">expand/0088-out.jsonld</a>
+              <a href='expand/0088-out.jsonld'>expand/0088-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0089">
+        <dt id='t0089'>
           Test t0089 empty @base applied to the base option
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0089</dd>
             <dt>Type</dt>
@@ -2052,26 +2052,26 @@
             <dd>Use of an empty @base is applied to the base option</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0089-in.jsonld">expand/0089-in.jsonld</a>
+              <a href='expand/0089-in.jsonld'>expand/0089-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0089-out.jsonld">expand/0089-out.jsonld</a>
+              <a href='expand/0089-out.jsonld'>expand/0089-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>base</dt>
                 <dd>http://example/base/</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0090">
+        <dt id='t0090'>
           Test t0090 relative @base overrides base option and document location
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0090</dd>
             <dt>Type</dt>
@@ -2080,26 +2080,26 @@
             <dd>Use of a relative @base overrides base option and document location</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0090-in.jsonld">expand/0090-in.jsonld</a>
+              <a href='expand/0090-in.jsonld'>expand/0090-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0090-out.jsonld">expand/0090-out.jsonld</a>
+              <a href='expand/0090-out.jsonld'>expand/0090-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>base</dt>
                 <dd>http://example/base/</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0091">
+        <dt id='t0091'>
           Test t0091 relative and absolute @base overrides base option and document location
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0091</dd>
             <dt>Type</dt>
@@ -2108,26 +2108,26 @@
             <dd>Use of a relative and absolute @base overrides base option and document location</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0091-in.jsonld">expand/0091-in.jsonld</a>
+              <a href='expand/0091-in.jsonld'>expand/0091-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0091-out.jsonld">expand/0091-out.jsonld</a>
+              <a href='expand/0091-out.jsonld'>expand/0091-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>base</dt>
                 <dd>http://example/base/</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0092">
+        <dt id='t0092'>
           Test t0092 Various relative IRIs as properties with with @vocab: &#39;&#39;
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0092</dd>
             <dt>Type</dt>
@@ -2136,26 +2136,26 @@
             <dd>Pathological relative property IRIs</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0092-in.jsonld">expand/0092-in.jsonld</a>
+              <a href='expand/0092-in.jsonld'>expand/0092-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0092-out.jsonld">expand/0092-out.jsonld</a>
+              <a href='expand/0092-out.jsonld'>expand/0092-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0093">
+        <dt id='t0093'>
           Test t0093 expand @graph container (multiple objects)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0093</dd>
             <dt>Type</dt>
@@ -2164,26 +2164,26 @@
             <dd>Use of @graph containers</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0093-in.jsonld">expand/0093-in.jsonld</a>
+              <a href='expand/0093-in.jsonld'>expand/0093-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0093-out.jsonld">expand/0093-out.jsonld</a>
+              <a href='expand/0093-out.jsonld'>expand/0093-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0094">
+        <dt id='t0094'>
           Test t0094 expand [@graph, @set] container (multiple objects)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0094</dd>
             <dt>Type</dt>
@@ -2192,26 +2192,26 @@
             <dd>Use of [@graph, @set] containers</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0094-in.jsonld">expand/0094-in.jsonld</a>
+              <a href='expand/0094-in.jsonld'>expand/0094-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0094-out.jsonld">expand/0094-out.jsonld</a>
+              <a href='expand/0094-out.jsonld'>expand/0094-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0095">
+        <dt id='t0095'>
           Test t0095 Creates an @graph container if value is a graph (multiple objects)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0095</dd>
             <dt>Type</dt>
@@ -2220,26 +2220,26 @@
             <dd>Double-expand an already expanded graph</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0095-in.jsonld">expand/0095-in.jsonld</a>
+              <a href='expand/0095-in.jsonld'>expand/0095-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0095-out.jsonld">expand/0095-out.jsonld</a>
+              <a href='expand/0095-out.jsonld'>expand/0095-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0096">
+        <dt id='t0096'>
           Test t0096 expand [@graph, @index] container (multiple indexed objects)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0096</dd>
             <dt>Type</dt>
@@ -2248,26 +2248,26 @@
             <dd>Use of @graph containers with @index</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0096-in.jsonld">expand/0096-in.jsonld</a>
+              <a href='expand/0096-in.jsonld'>expand/0096-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0096-out.jsonld">expand/0096-out.jsonld</a>
+              <a href='expand/0096-out.jsonld'>expand/0096-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0097">
+        <dt id='t0097'>
           Test t0097 expand [@graph, @index, @set] container (multiple objects)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0097</dd>
             <dt>Type</dt>
@@ -2276,26 +2276,26 @@
             <dd>Use of @graph containers with @index and @set</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0097-in.jsonld">expand/0097-in.jsonld</a>
+              <a href='expand/0097-in.jsonld'>expand/0097-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0097-out.jsonld">expand/0097-out.jsonld</a>
+              <a href='expand/0097-out.jsonld'>expand/0097-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0098">
+        <dt id='t0098'>
           Test t0098 Do not expand [@graph, @index] container if value is a graph (multiple objects)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0098</dd>
             <dt>Type</dt>
@@ -2304,26 +2304,26 @@
             <dd>Does not create a new graph object if indexed value is already a graph object</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0098-in.jsonld">expand/0098-in.jsonld</a>
+              <a href='expand/0098-in.jsonld'>expand/0098-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0098-out.jsonld">expand/0098-out.jsonld</a>
+              <a href='expand/0098-out.jsonld'>expand/0098-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0099">
+        <dt id='t0099'>
           Test t0099 expand [@graph, @id] container (multiple objects)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0099</dd>
             <dt>Type</dt>
@@ -2332,26 +2332,26 @@
             <dd>Use of @graph containers with @id</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0099-in.jsonld">expand/0099-in.jsonld</a>
+              <a href='expand/0099-in.jsonld'>expand/0099-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0099-out.jsonld">expand/0099-out.jsonld</a>
+              <a href='expand/0099-out.jsonld'>expand/0099-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0100">
+        <dt id='t0100'>
           Test t0100 expand [@graph, @id, @set] container (multiple objects)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0100</dd>
             <dt>Type</dt>
@@ -2360,26 +2360,26 @@
             <dd>Use of @graph containers with @id and @set</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0100-in.jsonld">expand/0100-in.jsonld</a>
+              <a href='expand/0100-in.jsonld'>expand/0100-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0100-out.jsonld">expand/0100-out.jsonld</a>
+              <a href='expand/0100-out.jsonld'>expand/0100-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0101">
+        <dt id='t0101'>
           Test t0101 Do not expand [@graph, @id] container if value is a graph (multiple objects)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0101</dd>
             <dt>Type</dt>
@@ -2388,26 +2388,26 @@
             <dd>Does not create a new graph object if indexed value is already a graph object</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0101-in.jsonld">expand/0101-in.jsonld</a>
+              <a href='expand/0101-in.jsonld'>expand/0101-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0101-out.jsonld">expand/0101-out.jsonld</a>
+              <a href='expand/0101-out.jsonld'>expand/0101-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0102">
+        <dt id='t0102'>
           Test t0102 Expand @graph container if value is a graph (multiple objects)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0102</dd>
             <dt>Type</dt>
@@ -2416,26 +2416,26 @@
             <dd>Creates a new graph object if indexed value is already a graph object</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0102-in.jsonld">expand/0102-in.jsonld</a>
+              <a href='expand/0102-in.jsonld'>expand/0102-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0102-out.jsonld">expand/0102-out.jsonld</a>
+              <a href='expand/0102-out.jsonld'>expand/0102-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0103">
+        <dt id='t0103'>
           Test t0103 Expand @graph container if value is a graph (multiple graphs)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0103</dd>
             <dt>Type</dt>
@@ -2444,26 +2444,26 @@
             <dd>Creates a new graph object if indexed value is already a graph object</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0103-in.jsonld">expand/0103-in.jsonld</a>
+              <a href='expand/0103-in.jsonld'>expand/0103-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0103-out.jsonld">expand/0103-out.jsonld</a>
+              <a href='expand/0103-out.jsonld'>expand/0103-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0104">
+        <dt id='t0104'>
           Test t0104 Creates an @graph container if value is a graph (mixed graph and object)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0104</dd>
             <dt>Type</dt>
@@ -2472,26 +2472,26 @@
             <dd>Double-expand an already expanded graph</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0104-in.jsonld">expand/0104-in.jsonld</a>
+              <a href='expand/0104-in.jsonld'>expand/0104-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0104-out.jsonld">expand/0104-out.jsonld</a>
+              <a href='expand/0104-out.jsonld'>expand/0104-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0105">
+        <dt id='t0105'>
           Test t0105 Do not expand [@graph, @index] container if value is a graph (mixed graph and object)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0105</dd>
             <dt>Type</dt>
@@ -2500,26 +2500,26 @@
             <dd>Does not create a new graph object if indexed value is already a graph object</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0105-in.jsonld">expand/0105-in.jsonld</a>
+              <a href='expand/0105-in.jsonld'>expand/0105-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0105-out.jsonld">expand/0105-out.jsonld</a>
+              <a href='expand/0105-out.jsonld'>expand/0105-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0106">
+        <dt id='t0106'>
           Test t0106 Do not expand [@graph, @id] container if value is a graph (mixed graph and object)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0106</dd>
             <dt>Type</dt>
@@ -2528,26 +2528,26 @@
             <dd>Does not create a new graph object if indexed value is already a graph object</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0106-in.jsonld">expand/0106-in.jsonld</a>
+              <a href='expand/0106-in.jsonld'>expand/0106-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0106-out.jsonld">expand/0106-out.jsonld</a>
+              <a href='expand/0106-out.jsonld'>expand/0106-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0107">
+        <dt id='t0107'>
           Test t0107 expand [@graph, @index] container (indexes with multiple objects)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0107</dd>
             <dt>Type</dt>
@@ -2556,26 +2556,26 @@
             <dd>Use of @graph containers with @index</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0107-in.jsonld">expand/0107-in.jsonld</a>
+              <a href='expand/0107-in.jsonld'>expand/0107-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0107-out.jsonld">expand/0107-out.jsonld</a>
+              <a href='expand/0107-out.jsonld'>expand/0107-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0108">
+        <dt id='t0108'>
           Test t0108 expand [@graph, @id] container (multiple ids and objects)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0108</dd>
             <dt>Type</dt>
@@ -2584,26 +2584,26 @@
             <dd>Use of @graph containers with @id</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0108-in.jsonld">expand/0108-in.jsonld</a>
+              <a href='expand/0108-in.jsonld'>expand/0108-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0108-out.jsonld">expand/0108-out.jsonld</a>
+              <a href='expand/0108-out.jsonld'>expand/0108-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0109">
+        <dt id='t0109'>
           Test t0109 IRI expansion of fragments including &#39;:&#39;
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0109</dd>
             <dt>Type</dt>
@@ -2612,19 +2612,19 @@
             <dd>Do not treat as absolute IRIs values that look like compact IRIs if they&#39;re not absolute</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0109-in.jsonld">expand/0109-in.jsonld</a>
+              <a href='expand/0109-in.jsonld'>expand/0109-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0109-out.jsonld">expand/0109-out.jsonld</a>
+              <a href='expand/0109-out.jsonld'>expand/0109-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0110">
+        <dt id='t0110'>
           Test t0110 Various relative IRIs as properties with with relative @vocab
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0110</dd>
             <dt>Type</dt>
@@ -2633,26 +2633,26 @@
             <dd>Pathological relative property IRIs</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0110-in.jsonld">expand/0110-in.jsonld</a>
+              <a href='expand/0110-in.jsonld'>expand/0110-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0110-out.jsonld">expand/0110-out.jsonld</a>
+              <a href='expand/0110-out.jsonld'>expand/0110-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0111">
+        <dt id='t0111'>
           Test t0111 Various relative IRIs as properties with with relative @vocab itself relative to an existing vocabulary base
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0111</dd>
             <dt>Type</dt>
@@ -2661,26 +2661,26 @@
             <dd>Pathological relative property IRIs</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0111-in.jsonld">expand/0111-in.jsonld</a>
+              <a href='expand/0111-in.jsonld'>expand/0111-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0111-out.jsonld">expand/0111-out.jsonld</a>
+              <a href='expand/0111-out.jsonld'>expand/0111-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0112">
+        <dt id='t0112'>
           Test t0112 Various relative IRIs as properties with with relative @vocab relative to another relative vocabulary base
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0112</dd>
             <dt>Type</dt>
@@ -2689,26 +2689,26 @@
             <dd>Pathological relative property IRIs</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0112-in.jsonld">expand/0112-in.jsonld</a>
+              <a href='expand/0112-in.jsonld'>expand/0112-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0112-out.jsonld">expand/0112-out.jsonld</a>
+              <a href='expand/0112-out.jsonld'>expand/0112-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0113">
+        <dt id='t0113'>
           Test t0113 context with JavaScript Object property names
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0113</dd>
             <dt>Type</dt>
@@ -2717,19 +2717,19 @@
             <dd>Expand with context including JavaScript Object property names</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0113-in.jsonld">expand/0113-in.jsonld</a>
+              <a href='expand/0113-in.jsonld'>expand/0113-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0113-out.jsonld">expand/0113-out.jsonld</a>
+              <a href='expand/0113-out.jsonld'>expand/0113-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0114">
+        <dt id='t0114'>
           Test t0114 Expansion allows multiple properties expanding to @type
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0114</dd>
             <dt>Type</dt>
@@ -2738,26 +2738,26 @@
             <dd>An exception for the colliding keywords error is made for @type</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0114-in.jsonld">expand/0114-in.jsonld</a>
+              <a href='expand/0114-in.jsonld'>expand/0114-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0114-out.jsonld">expand/0114-out.jsonld</a>
+              <a href='expand/0114-out.jsonld'>expand/0114-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0115">
+        <dt id='t0115'>
           Test t0115 Verifies that relative IRIs as properties with @vocab: &#39;&#39; in 1.0 generate an error
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0115</dd>
             <dt>Type</dt>
@@ -2766,7 +2766,7 @@
             <dd>Relative property IRIs with relative @vocab in 1.0</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0115-in.jsonld">expand/0115-in.jsonld</a>
+              <a href='expand/0115-in.jsonld'>expand/0115-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -2774,18 +2774,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.0</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0116">
+        <dt id='t0116'>
           Test t0116 Verifies that relative IRIs as properties with relative @vocab in 1.0 generate an error
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0116</dd>
             <dt>Type</dt>
@@ -2794,7 +2794,7 @@
             <dd>Relative property IRIs with relative @vocab in 1.0</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0116-in.jsonld">expand/0116-in.jsonld</a>
+              <a href='expand/0116-in.jsonld'>expand/0116-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -2802,18 +2802,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.0</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0117">
+        <dt id='t0117'>
           Test t0117 A term starting with a colon can expand to a different IRI
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0117</dd>
             <dt>Type</dt>
@@ -2822,26 +2822,26 @@
             <dd>Terms may begin with a colon and not be treated as IRIs.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0117-in.jsonld">expand/0117-in.jsonld</a>
+              <a href='expand/0117-in.jsonld'>expand/0117-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0117-out.jsonld">expand/0117-out.jsonld</a>
+              <a href='expand/0117-out.jsonld'>expand/0117-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0118">
+        <dt id='t0118'>
           Test t0118 Expanding a value staring with a colon does not treat that value as an IRI
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0118</dd>
             <dt>Type</dt>
@@ -2850,26 +2850,26 @@
             <dd>Terms may begin with a colon and not be treated as IRIs.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0118-in.jsonld">expand/0118-in.jsonld</a>
+              <a href='expand/0118-in.jsonld'>expand/0118-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0118-out.jsonld">expand/0118-out.jsonld</a>
+              <a href='expand/0118-out.jsonld'>expand/0118-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0119">
+        <dt id='t0119'>
           Test t0119 Ignore some terms with @, allow others.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0119</dd>
             <dt>Type</dt>
@@ -2878,26 +2878,26 @@
             <dd>Processors SHOULD generate a warning and MUST ignore terms having the form of a keyword.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0119-in.jsonld">expand/0119-in.jsonld</a>
+              <a href='expand/0119-in.jsonld'>expand/0119-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0119-out.jsonld">expand/0119-out.jsonld</a>
+              <a href='expand/0119-out.jsonld'>expand/0119-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0120">
+        <dt id='t0120'>
           Test t0120 Ignore some values of @id with @, allow others.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0120</dd>
             <dt>Type</dt>
@@ -2906,26 +2906,26 @@
             <dd>Processors SHOULD generate a warning and MUST ignore values of @id having the form of a keyword.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0120-in.jsonld">expand/0120-in.jsonld</a>
+              <a href='expand/0120-in.jsonld'>expand/0120-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0120-out.jsonld">expand/0120-out.jsonld</a>
+              <a href='expand/0120-out.jsonld'>expand/0120-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0121">
+        <dt id='t0121'>
           Test t0121 Ignore some values of @reverse with @, allow others.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0121</dd>
             <dt>Type</dt>
@@ -2934,26 +2934,26 @@
             <dd>Processors SHOULD generate a warning and MUST ignore values of @reverse having the form of a keyword.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0121-in.jsonld">expand/0121-in.jsonld</a>
+              <a href='expand/0121-in.jsonld'>expand/0121-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0121-out.jsonld">expand/0121-out.jsonld</a>
+              <a href='expand/0121-out.jsonld'>expand/0121-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0122">
+        <dt id='t0122'>
           Test t0122 Ignore some IRIs when that start with @ when expanding.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0122</dd>
             <dt>Type</dt>
@@ -2962,15 +2962,15 @@
             <dd>Processors SHOULD generate a warning and MUST ignore IRIs having the form of a keyword. (Note: the resulting document will not be valid JSON-LD, due to the `null` value for `@id`)</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0122-in.jsonld">expand/0122-in.jsonld</a>
+              <a href='expand/0122-in.jsonld'>expand/0122-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0122-out.jsonld">expand/0122-out.jsonld</a>
+              <a href='expand/0122-out.jsonld'>expand/0122-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
                 <dt>normative</dt>
@@ -2979,11 +2979,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="t0123">
+        <dt id='t0123'>
           Test t0123 Value objects including invalid literal datatype IRIs are rejected
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0123</dd>
             <dt>Type</dt>
@@ -2992,7 +2992,7 @@
             <dd>Processors MUST validate datatype IRIs.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0123-in.jsonld">expand/0123-in.jsonld</a>
+              <a href='expand/0123-in.jsonld'>expand/0123-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -3000,18 +3000,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0124">
+        <dt id='t0124'>
           Test t0124 compact IRI as @vocab
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0124</dd>
             <dt>Type</dt>
@@ -3020,26 +3020,26 @@
             <dd>Verifies that @vocab defined as a compact IRI expands properly</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0124-in.jsonld">expand/0124-in.jsonld</a>
+              <a href='expand/0124-in.jsonld'>expand/0124-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0124-out.jsonld">expand/0124-out.jsonld</a>
+              <a href='expand/0124-out.jsonld'>expand/0124-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0125">
+        <dt id='t0125'>
           Test t0125 term as @vocab
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0125</dd>
             <dt>Type</dt>
@@ -3048,26 +3048,26 @@
             <dd>Verifies that @vocab defined as a term expands properly</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0125-in.jsonld">expand/0125-in.jsonld</a>
+              <a href='expand/0125-in.jsonld'>expand/0125-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0125-out.jsonld">expand/0125-out.jsonld</a>
+              <a href='expand/0125-out.jsonld'>expand/0125-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0126">
+        <dt id='t0126'>
           Test t0126 A scoped context may include itself recursively (direct)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0126</dd>
             <dt>Type</dt>
@@ -3076,26 +3076,26 @@
             <dd>Verifies that no exception is raised on expansion when processing a scoped context referencing itself directly</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0126-in.jsonld">expand/0126-in.jsonld</a>
+              <a href='expand/0126-in.jsonld'>expand/0126-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0126-out.jsonld">expand/0126-out.jsonld</a>
+              <a href='expand/0126-out.jsonld'>expand/0126-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0127">
+        <dt id='t0127'>
           Test t0127 A scoped context may include itself recursively (indirect)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0127</dd>
             <dt>Type</dt>
@@ -3104,26 +3104,26 @@
             <dd>Verifies that no exception is raised on expansion when processing a scoped context referencing itself indirectly</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0127-in.jsonld">expand/0127-in.jsonld</a>
+              <a href='expand/0127-in.jsonld'>expand/0127-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0127-out.jsonld">expand/0127-out.jsonld</a>
+              <a href='expand/0127-out.jsonld'>expand/0127-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0128">
+        <dt id='t0128'>
           Test t0128 Two scoped context may include a shared context
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0128</dd>
             <dt>Type</dt>
@@ -3132,26 +3132,26 @@
             <dd>Verifies that no exception is raised on expansion when processing two scoped contexts referencing a shared context</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0128-in.jsonld">expand/0128-in.jsonld</a>
+              <a href='expand/0128-in.jsonld'>expand/0128-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0128-out.jsonld">expand/0128-out.jsonld</a>
+              <a href='expand/0128-out.jsonld'>expand/0128-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0129">
+        <dt id='t0129'>
           Test t0129 Base without trailing slash, without path
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0129</dd>
             <dt>Type</dt>
@@ -3160,19 +3160,19 @@
             <dd>Verify URI resolution relative to base (without trailing slash, without path) according to RFC 3986</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0129-in.jsonld">expand/0129-in.jsonld</a>
+              <a href='expand/0129-in.jsonld'>expand/0129-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0129-out.jsonld">expand/0129-out.jsonld</a>
+              <a href='expand/0129-out.jsonld'>expand/0129-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0130">
+        <dt id='t0130'>
           Test t0130 Base without trailing slash, with path
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0130</dd>
             <dt>Type</dt>
@@ -3181,19 +3181,19 @@
             <dd>Verify URI resolution relative to base (without trailing slash, with path) according to RFC 3986</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0130-in.jsonld">expand/0130-in.jsonld</a>
+              <a href='expand/0130-in.jsonld'>expand/0130-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0130-out.jsonld">expand/0130-out.jsonld</a>
+              <a href='expand/0130-out.jsonld'>expand/0130-out.jsonld</a>
             </dd>
           </dl>
         </dd>
-        <dt id="t0131">
+        <dt id='t0131'>
           Test t0131 Reverse term with property based indexed container
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0131</dd>
             <dt>Type</dt>
@@ -3202,26 +3202,26 @@
             <dd>Expanding a reverse term using @container: @index and @index set to a property</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0131-in.jsonld">expand/0131-in.jsonld</a>
+              <a href='expand/0131-in.jsonld'>expand/0131-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0131-out.jsonld">expand/0131-out.jsonld</a>
+              <a href='expand/0131-out.jsonld'>expand/0131-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="t0132">
+        <dt id='t0132'>
           Test t0132 @base does not expand property keys
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#t0132</dd>
             <dt>Type</dt>
@@ -3230,26 +3230,26 @@
             <dd>Property keys are expanded vocabulary-relative (@vocab, term definitions, compact IRIs with a defined prefix). @base is for document-relative IRI resolution where the algorithms pass that flag (e.g. certain @id and @type values), not for unmapped simple keys. With only @base set, an unmapped key like name has no vocabulary mapping and must be dropped; a relative @type token still resolves against the base. See IRI Expansion in the JSON-LD 1.1 Processing Algorithms and API.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/0132-in.jsonld">expand/0132-in.jsonld</a>
+              <a href='expand/0132-in.jsonld'>expand/0132-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/0132-out.jsonld">expand/0132-out.jsonld</a>
+              <a href='expand/0132-out.jsonld'>expand/0132-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc001">
+        <dt id='tc001'>
           Test tc001 adding new term
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc001</dd>
             <dt>Type</dt>
@@ -3258,26 +3258,26 @@
             <dd>Expansion using a scoped context uses term scope for selecting proper term</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c001-in.jsonld">expand/c001-in.jsonld</a>
+              <a href='expand/c001-in.jsonld'>expand/c001-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c001-out.jsonld">expand/c001-out.jsonld</a>
+              <a href='expand/c001-out.jsonld'>expand/c001-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc002">
+        <dt id='tc002'>
           Test tc002 overriding a term
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc002</dd>
             <dt>Type</dt>
@@ -3286,26 +3286,26 @@
             <dd>Expansion using a scoped context uses term scope for selecting proper term</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c002-in.jsonld">expand/c002-in.jsonld</a>
+              <a href='expand/c002-in.jsonld'>expand/c002-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c002-out.jsonld">expand/c002-out.jsonld</a>
+              <a href='expand/c002-out.jsonld'>expand/c002-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc003">
+        <dt id='tc003'>
           Test tc003 property and value with different terms mapping to the same expanded property
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc003</dd>
             <dt>Type</dt>
@@ -3314,26 +3314,26 @@
             <dd>Expansion using a scoped context uses term scope for selecting proper term</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c003-in.jsonld">expand/c003-in.jsonld</a>
+              <a href='expand/c003-in.jsonld'>expand/c003-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c003-out.jsonld">expand/c003-out.jsonld</a>
+              <a href='expand/c003-out.jsonld'>expand/c003-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc004">
+        <dt id='tc004'>
           Test tc004 deep @context affects nested nodes
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc004</dd>
             <dt>Type</dt>
@@ -3342,26 +3342,26 @@
             <dd>Expansion using a scoped context uses term scope for selecting proper term</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c004-in.jsonld">expand/c004-in.jsonld</a>
+              <a href='expand/c004-in.jsonld'>expand/c004-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c004-out.jsonld">expand/c004-out.jsonld</a>
+              <a href='expand/c004-out.jsonld'>expand/c004-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc005">
+        <dt id='tc005'>
           Test tc005 scoped context layers on intemediate contexts
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc005</dd>
             <dt>Type</dt>
@@ -3370,26 +3370,26 @@
             <dd>Expansion using a scoped context uses term scope for selecting proper term</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c005-in.jsonld">expand/c005-in.jsonld</a>
+              <a href='expand/c005-in.jsonld'>expand/c005-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c005-out.jsonld">expand/c005-out.jsonld</a>
+              <a href='expand/c005-out.jsonld'>expand/c005-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc006">
+        <dt id='tc006'>
           Test tc006 adding new term
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc006</dd>
             <dt>Type</dt>
@@ -3398,26 +3398,26 @@
             <dd>scoped context on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c006-in.jsonld">expand/c006-in.jsonld</a>
+              <a href='expand/c006-in.jsonld'>expand/c006-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c006-out.jsonld">expand/c006-out.jsonld</a>
+              <a href='expand/c006-out.jsonld'>expand/c006-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc007">
+        <dt id='tc007'>
           Test tc007 overriding a term
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc007</dd>
             <dt>Type</dt>
@@ -3426,26 +3426,26 @@
             <dd>scoped context on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c007-in.jsonld">expand/c007-in.jsonld</a>
+              <a href='expand/c007-in.jsonld'>expand/c007-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c007-out.jsonld">expand/c007-out.jsonld</a>
+              <a href='expand/c007-out.jsonld'>expand/c007-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc008">
+        <dt id='tc008'>
           Test tc008 alias of @type
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc008</dd>
             <dt>Type</dt>
@@ -3454,26 +3454,26 @@
             <dd>scoped context on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c008-in.jsonld">expand/c008-in.jsonld</a>
+              <a href='expand/c008-in.jsonld'>expand/c008-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c008-out.jsonld">expand/c008-out.jsonld</a>
+              <a href='expand/c008-out.jsonld'>expand/c008-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc009">
+        <dt id='tc009'>
           Test tc009 deep @type-scoped @context does NOT affect nested nodes
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc009</dd>
             <dt>Type</dt>
@@ -3482,26 +3482,26 @@
             <dd>scoped context on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c009-in.jsonld">expand/c009-in.jsonld</a>
+              <a href='expand/c009-in.jsonld'>expand/c009-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c009-out.jsonld">expand/c009-out.jsonld</a>
+              <a href='expand/c009-out.jsonld'>expand/c009-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc010">
+        <dt id='tc010'>
           Test tc010 scoped context layers on intemediate contexts
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc010</dd>
             <dt>Type</dt>
@@ -3510,26 +3510,26 @@
             <dd>scoped context on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c010-in.jsonld">expand/c010-in.jsonld</a>
+              <a href='expand/c010-in.jsonld'>expand/c010-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c010-out.jsonld">expand/c010-out.jsonld</a>
+              <a href='expand/c010-out.jsonld'>expand/c010-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc011">
+        <dt id='tc011'>
           Test tc011 orders @type terms when applying scoped contexts
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc011</dd>
             <dt>Type</dt>
@@ -3538,26 +3538,26 @@
             <dd>scoped context on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c011-in.jsonld">expand/c011-in.jsonld</a>
+              <a href='expand/c011-in.jsonld'>expand/c011-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c011-out.jsonld">expand/c011-out.jsonld</a>
+              <a href='expand/c011-out.jsonld'>expand/c011-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc012">
+        <dt id='tc012'>
           Test tc012 deep property-term scoped @context in @type-scoped @context affects nested nodes
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc012</dd>
             <dt>Type</dt>
@@ -3566,26 +3566,26 @@
             <dd>scoped context on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c012-in.jsonld">expand/c012-in.jsonld</a>
+              <a href='expand/c012-in.jsonld'>expand/c012-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c012-out.jsonld">expand/c012-out.jsonld</a>
+              <a href='expand/c012-out.jsonld'>expand/c012-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc013">
+        <dt id='tc013'>
           Test tc013 type maps use scoped context from type index and not scoped context from containing
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc013</dd>
             <dt>Type</dt>
@@ -3594,26 +3594,26 @@
             <dd>scoped context on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c013-in.jsonld">expand/c013-in.jsonld</a>
+              <a href='expand/c013-in.jsonld'>expand/c013-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c013-out.jsonld">expand/c013-out.jsonld</a>
+              <a href='expand/c013-out.jsonld'>expand/c013-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc014">
+        <dt id='tc014'>
           Test tc014 type-scoped context nullification
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc014</dd>
             <dt>Type</dt>
@@ -3622,26 +3622,26 @@
             <dd>type-scoped context nullification</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c014-in.jsonld">expand/c014-in.jsonld</a>
+              <a href='expand/c014-in.jsonld'>expand/c014-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c014-out.jsonld">expand/c014-out.jsonld</a>
+              <a href='expand/c014-out.jsonld'>expand/c014-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc015">
+        <dt id='tc015'>
           Test tc015 type-scoped base
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc015</dd>
             <dt>Type</dt>
@@ -3650,26 +3650,26 @@
             <dd>type-scoped base</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c015-in.jsonld">expand/c015-in.jsonld</a>
+              <a href='expand/c015-in.jsonld'>expand/c015-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c015-out.jsonld">expand/c015-out.jsonld</a>
+              <a href='expand/c015-out.jsonld'>expand/c015-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc016">
+        <dt id='tc016'>
           Test tc016 type-scoped vocab
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc016</dd>
             <dt>Type</dt>
@@ -3678,26 +3678,26 @@
             <dd>type-scoped vocab</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c016-in.jsonld">expand/c016-in.jsonld</a>
+              <a href='expand/c016-in.jsonld'>expand/c016-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c016-out.jsonld">expand/c016-out.jsonld</a>
+              <a href='expand/c016-out.jsonld'>expand/c016-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc017">
+        <dt id='tc017'>
           Test tc017 multiple type-scoped contexts are properly reverted
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc017</dd>
             <dt>Type</dt>
@@ -3706,26 +3706,26 @@
             <dd>multiple type-scoped contexts are property reverted</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c017-in.jsonld">expand/c017-in.jsonld</a>
+              <a href='expand/c017-in.jsonld'>expand/c017-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c017-out.jsonld">expand/c017-out.jsonld</a>
+              <a href='expand/c017-out.jsonld'>expand/c017-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc018">
+        <dt id='tc018'>
           Test tc018 multiple type-scoped types resolved against previous context
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc018</dd>
             <dt>Type</dt>
@@ -3734,26 +3734,26 @@
             <dd>multiple type-scoped types resolved against previous context</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c018-in.jsonld">expand/c018-in.jsonld</a>
+              <a href='expand/c018-in.jsonld'>expand/c018-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c018-out.jsonld">expand/c018-out.jsonld</a>
+              <a href='expand/c018-out.jsonld'>expand/c018-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc019">
+        <dt id='tc019'>
           Test tc019 type-scoped context with multiple property scoped terms
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc019</dd>
             <dt>Type</dt>
@@ -3762,26 +3762,26 @@
             <dd>type-scoped context with multiple property scoped terms</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c019-in.jsonld">expand/c019-in.jsonld</a>
+              <a href='expand/c019-in.jsonld'>expand/c019-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c019-out.jsonld">expand/c019-out.jsonld</a>
+              <a href='expand/c019-out.jsonld'>expand/c019-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc020">
+        <dt id='tc020'>
           Test tc020 type-scoped value
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc020</dd>
             <dt>Type</dt>
@@ -3790,26 +3790,26 @@
             <dd>type-scoped value</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c020-in.jsonld">expand/c020-in.jsonld</a>
+              <a href='expand/c020-in.jsonld'>expand/c020-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c020-out.jsonld">expand/c020-out.jsonld</a>
+              <a href='expand/c020-out.jsonld'>expand/c020-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc021">
+        <dt id='tc021'>
           Test tc021 type-scoped value mix
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc021</dd>
             <dt>Type</dt>
@@ -3818,26 +3818,26 @@
             <dd>type-scoped value mix</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c021-in.jsonld">expand/c021-in.jsonld</a>
+              <a href='expand/c021-in.jsonld'>expand/c021-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c021-out.jsonld">expand/c021-out.jsonld</a>
+              <a href='expand/c021-out.jsonld'>expand/c021-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc022">
+        <dt id='tc022'>
           Test tc022 type-scoped property-scoped contexts including @type:@vocab
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc022</dd>
             <dt>Type</dt>
@@ -3846,26 +3846,26 @@
             <dd>type-scoped property-scoped contexts including @type:@vocab</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c022-in.jsonld">expand/c022-in.jsonld</a>
+              <a href='expand/c022-in.jsonld'>expand/c022-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c022-out.jsonld">expand/c022-out.jsonld</a>
+              <a href='expand/c022-out.jsonld'>expand/c022-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc023">
+        <dt id='tc023'>
           Test tc023 composed type-scoped property-scoped contexts including @type:@vocab
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc023</dd>
             <dt>Type</dt>
@@ -3874,26 +3874,26 @@
             <dd>composed type-scoped property-scoped contexts including @type:@vocab</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c023-in.jsonld">expand/c023-in.jsonld</a>
+              <a href='expand/c023-in.jsonld'>expand/c023-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c023-out.jsonld">expand/c023-out.jsonld</a>
+              <a href='expand/c023-out.jsonld'>expand/c023-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc024">
+        <dt id='tc024'>
           Test tc024 type-scoped + property-scoped + values evaluates against previous context
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc024</dd>
             <dt>Type</dt>
@@ -3902,26 +3902,26 @@
             <dd>type-scoped + property-scoped + values evaluates against previous context</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c024-in.jsonld">expand/c024-in.jsonld</a>
+              <a href='expand/c024-in.jsonld'>expand/c024-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c024-out.jsonld">expand/c024-out.jsonld</a>
+              <a href='expand/c024-out.jsonld'>expand/c024-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc025">
+        <dt id='tc025'>
           Test tc025 type-scoped + graph container
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc025</dd>
             <dt>Type</dt>
@@ -3930,26 +3930,26 @@
             <dd>type-scoped + graph container</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c025-in.jsonld">expand/c025-in.jsonld</a>
+              <a href='expand/c025-in.jsonld'>expand/c025-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c025-out.jsonld">expand/c025-out.jsonld</a>
+              <a href='expand/c025-out.jsonld'>expand/c025-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc026">
+        <dt id='tc026'>
           Test tc026 @propagate: true on type-scoped context
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc026</dd>
             <dt>Type</dt>
@@ -3958,26 +3958,26 @@
             <dd>type-scoped context with @propagate: true survive node-objects</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c026-in.jsonld">expand/c026-in.jsonld</a>
+              <a href='expand/c026-in.jsonld'>expand/c026-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c026-out.jsonld">expand/c026-out.jsonld</a>
+              <a href='expand/c026-out.jsonld'>expand/c026-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc027">
+        <dt id='tc027'>
           Test tc027 @propagate: false on property-scoped context
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc027</dd>
             <dt>Type</dt>
@@ -3986,26 +3986,26 @@
             <dd>property-scoped context with @propagate: false do not survive node-objects</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c027-in.jsonld">expand/c027-in.jsonld</a>
+              <a href='expand/c027-in.jsonld'>expand/c027-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c027-out.jsonld">expand/c027-out.jsonld</a>
+              <a href='expand/c027-out.jsonld'>expand/c027-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc028">
+        <dt id='tc028'>
           Test tc028 @propagate: false on embedded context
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc028</dd>
             <dt>Type</dt>
@@ -4014,26 +4014,26 @@
             <dd>embedded context with @propagate: false do not survive node-objects</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c028-in.jsonld">expand/c028-in.jsonld</a>
+              <a href='expand/c028-in.jsonld'>expand/c028-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c028-out.jsonld">expand/c028-out.jsonld</a>
+              <a href='expand/c028-out.jsonld'>expand/c028-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc029">
+        <dt id='tc029'>
           Test tc029 @propagate is invalid in 1.0
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc029</dd>
             <dt>Type</dt>
@@ -4042,7 +4042,7 @@
             <dd>@propagate is invalid in 1.0</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c029-in.jsonld">expand/c029-in.jsonld</a>
+              <a href='expand/c029-in.jsonld'>expand/c029-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4050,7 +4050,7 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
                 <dt>processingMode</dt>
@@ -4059,11 +4059,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="tc030">
+        <dt id='tc030'>
           Test tc030 @propagate must be boolean valued
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc030</dd>
             <dt>Type</dt>
@@ -4072,7 +4072,7 @@
             <dd>@propagate must be boolean valued</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c030-in.jsonld">expand/c030-in.jsonld</a>
+              <a href='expand/c030-in.jsonld'>expand/c030-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4080,18 +4080,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc031">
+        <dt id='tc031'>
           Test tc031 @context resolutions respects relative URLs.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc031</dd>
             <dt>Type</dt>
@@ -4100,26 +4100,26 @@
             <dd>URL resolution follows RFC3986</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c031-in.jsonld">expand/c031-in.jsonld</a>
+              <a href='expand/c031-in.jsonld'>expand/c031-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c031-out.jsonld">expand/c031-out.jsonld</a>
+              <a href='expand/c031-out.jsonld'>expand/c031-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc032">
+        <dt id='tc032'>
           Test tc032 Unused embedded context with error.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc032</dd>
             <dt>Type</dt>
@@ -4128,7 +4128,7 @@
             <dd>An embedded context which is never used should still be checked.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c032-in.jsonld">expand/c032-in.jsonld</a>
+              <a href='expand/c032-in.jsonld'>expand/c032-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4136,18 +4136,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc033">
+        <dt id='tc033'>
           Test tc033 Unused context with an embedded context error.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc033</dd>
             <dt>Type</dt>
@@ -4156,7 +4156,7 @@
             <dd>An unused context with an embedded context should still be checked.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c033-in.jsonld">expand/c033-in.jsonld</a>
+              <a href='expand/c033-in.jsonld'>expand/c033-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4164,18 +4164,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc034">
+        <dt id='tc034'>
           Test tc034 Remote scoped context.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc034</dd>
             <dt>Type</dt>
@@ -4184,26 +4184,26 @@
             <dd>Scoped contexts may be externally loaded.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c034-in.jsonld">expand/c034-in.jsonld</a>
+              <a href='expand/c034-in.jsonld'>expand/c034-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c034-out.jsonld">expand/c034-out.jsonld</a>
+              <a href='expand/c034-out.jsonld'>expand/c034-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc035">
+        <dt id='tc035'>
           Test tc035 Term scoping with embedded contexts.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc035</dd>
             <dt>Type</dt>
@@ -4212,26 +4212,26 @@
             <dd>Terms should make use of @vocab relative to the scope in which the term was defined.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c035-in.jsonld">expand/c035-in.jsonld</a>
+              <a href='expand/c035-in.jsonld'>expand/c035-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c035-out.jsonld">expand/c035-out.jsonld</a>
+              <a href='expand/c035-out.jsonld'>expand/c035-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc036">
+        <dt id='tc036'>
           Test tc036 Expansion with empty property-scoped context.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc036</dd>
             <dt>Type</dt>
@@ -4240,26 +4240,26 @@
             <dd>Adding a minimal/empty property-scoped context should not affect expansion of terms defined in the outer scope.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c036-in.jsonld">expand/c036-in.jsonld</a>
+              <a href='expand/c036-in.jsonld'>expand/c036-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c036-out.jsonld">expand/c036-out.jsonld</a>
+              <a href='expand/c036-out.jsonld'>expand/c036-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc037">
+        <dt id='tc037'>
           Test tc037 property-scoped contexts which are alias of @nest
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc037</dd>
             <dt>Type</dt>
@@ -4268,26 +4268,26 @@
             <dd>Nesting terms may have property-scoped contexts defined.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c037-in.jsonld">expand/c037-in.jsonld</a>
+              <a href='expand/c037-in.jsonld'>expand/c037-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c037-out.jsonld">expand/c037-out.jsonld</a>
+              <a href='expand/c037-out.jsonld'>expand/c037-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tc038">
+        <dt id='tc038'>
           Test tc038 Bibframe example (poor-mans inferrence)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tc038</dd>
             <dt>Type</dt>
@@ -4296,26 +4296,26 @@
             <dd>Nesting terms may have property-scoped contexts defined.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/c038-in.jsonld">expand/c038-in.jsonld</a>
+              <a href='expand/c038-in.jsonld'>expand/c038-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/c038-out.jsonld">expand/c038-out.jsonld</a>
+              <a href='expand/c038-out.jsonld'>expand/c038-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tdi01">
+        <dt id='tdi01'>
           Test tdi01 Expand string using default and term directions
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tdi01</dd>
             <dt>Type</dt>
@@ -4324,26 +4324,26 @@
             <dd>Strings are coerced to have @direction based on default and term direction.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/di01-in.jsonld">expand/di01-in.jsonld</a>
+              <a href='expand/di01-in.jsonld'>expand/di01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/di01-out.jsonld">expand/di01-out.jsonld</a>
+              <a href='expand/di01-out.jsonld'>expand/di01-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tdi02">
+        <dt id='tdi02'>
           Test tdi02 Expand string using default and term directions and languages
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tdi02</dd>
             <dt>Type</dt>
@@ -4352,26 +4352,26 @@
             <dd>Strings are coerced to have @direction based on default and term direction.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/di02-in.jsonld">expand/di02-in.jsonld</a>
+              <a href='expand/di02-in.jsonld'>expand/di02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/di02-out.jsonld">expand/di02-out.jsonld</a>
+              <a href='expand/di02-out.jsonld'>expand/di02-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tdi03">
+        <dt id='tdi03'>
           Test tdi03 expand list values with @direction
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tdi03</dd>
             <dt>Type</dt>
@@ -4380,26 +4380,26 @@
             <dd>List values where the term has @direction are used in expansion.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/di03-in.jsonld">expand/di03-in.jsonld</a>
+              <a href='expand/di03-in.jsonld'>expand/di03-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/di03-out.jsonld">expand/di03-out.jsonld</a>
+              <a href='expand/di03-out.jsonld'>expand/di03-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tdi04">
+        <dt id='tdi04'>
           Test tdi04 simple language map with term direction
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tdi04</dd>
             <dt>Type</dt>
@@ -4408,26 +4408,26 @@
             <dd>Term selection with language maps and @direction.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/di04-in.jsonld">expand/di04-in.jsonld</a>
+              <a href='expand/di04-in.jsonld'>expand/di04-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/di04-out.jsonld">expand/di04-out.jsonld</a>
+              <a href='expand/di04-out.jsonld'>expand/di04-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tdi05">
+        <dt id='tdi05'>
           Test tdi05 simple language mapwith overriding term direction
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tdi05</dd>
             <dt>Type</dt>
@@ -4436,26 +4436,26 @@
             <dd>Term selection with language maps and @direction.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/di05-in.jsonld">expand/di05-in.jsonld</a>
+              <a href='expand/di05-in.jsonld'>expand/di05-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/di05-out.jsonld">expand/di05-out.jsonld</a>
+              <a href='expand/di05-out.jsonld'>expand/di05-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tdi06">
+        <dt id='tdi06'>
           Test tdi06 simple language mapwith overriding null direction
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tdi06</dd>
             <dt>Type</dt>
@@ -4464,26 +4464,26 @@
             <dd>Term selection with language maps and @direction.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/di06-in.jsonld">expand/di06-in.jsonld</a>
+              <a href='expand/di06-in.jsonld'>expand/di06-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/di06-out.jsonld">expand/di06-out.jsonld</a>
+              <a href='expand/di06-out.jsonld'>expand/di06-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tdi07">
+        <dt id='tdi07'>
           Test tdi07 simple language map with mismatching term direction
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tdi07</dd>
             <dt>Type</dt>
@@ -4492,26 +4492,26 @@
             <dd>Term selection with language maps and @direction.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/di07-in.jsonld">expand/di07-in.jsonld</a>
+              <a href='expand/di07-in.jsonld'>expand/di07-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/di07-out.jsonld">expand/di07-out.jsonld</a>
+              <a href='expand/di07-out.jsonld'>expand/di07-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tdi08">
+        <dt id='tdi08'>
           Test tdi08 @direction must be one of ltr or rtl
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tdi08</dd>
             <dt>Type</dt>
@@ -4520,7 +4520,7 @@
             <dd>Generate an error if @direction has illegal value.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/di08-in.jsonld">expand/di08-in.jsonld</a>
+              <a href='expand/di08-in.jsonld'>expand/di08-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4528,18 +4528,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tdi09">
+        <dt id='tdi09'>
           Test tdi09 @direction is incompatible with @type
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tdi09</dd>
             <dt>Type</dt>
@@ -4548,7 +4548,7 @@
             <dd>Value objects can have either @type but not @language or @direction.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/di09-in.jsonld">expand/di09-in.jsonld</a>
+              <a href='expand/di09-in.jsonld'>expand/di09-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4556,18 +4556,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tec01">
+        <dt id='tec01'>
           Test tec01 Invalid keyword in term definition
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tec01</dd>
             <dt>Type</dt>
@@ -4576,7 +4576,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid term definition is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/ec01-in.jsonld">expand/ec01-in.jsonld</a>
+              <a href='expand/ec01-in.jsonld'>expand/ec01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4584,18 +4584,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tec02">
+        <dt id='tec02'>
           Test tec02 Term definition on @type with empty map
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tec02</dd>
             <dt>Type</dt>
@@ -4604,7 +4604,7 @@
             <dd>Verifies that an exception is raised if @type is defined as a term with an empty map</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/ec02-in.jsonld">expand/ec02-in.jsonld</a>
+              <a href='expand/ec02-in.jsonld'>expand/ec02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4612,18 +4612,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tem01">
+        <dt id='tem01'>
           Test tem01 Invalid container mapping
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tem01</dd>
             <dt>Type</dt>
@@ -4632,7 +4632,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid container mapping is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/em01-in.jsonld">expand/em01-in.jsonld</a>
+              <a href='expand/em01-in.jsonld'>expand/em01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4640,18 +4640,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="ten01">
+        <dt id='ten01'>
           Test ten01 @nest MUST NOT have a string value
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ten01</dd>
             <dt>Type</dt>
@@ -4660,7 +4660,7 @@
             <dd>container: @nest</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/en01-in.jsonld">expand/en01-in.jsonld</a>
+              <a href='expand/en01-in.jsonld'>expand/en01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4668,18 +4668,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="ten02">
+        <dt id='ten02'>
           Test ten02 @nest MUST NOT have a boolen value
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ten02</dd>
             <dt>Type</dt>
@@ -4688,7 +4688,7 @@
             <dd>Transparent Nesting</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/en02-in.jsonld">expand/en02-in.jsonld</a>
+              <a href='expand/en02-in.jsonld'>expand/en02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4696,18 +4696,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="ten03">
+        <dt id='ten03'>
           Test ten03 @nest MUST NOT have a numeric value
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ten03</dd>
             <dt>Type</dt>
@@ -4716,7 +4716,7 @@
             <dd>Transparent Nesting</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/en03-in.jsonld">expand/en03-in.jsonld</a>
+              <a href='expand/en03-in.jsonld'>expand/en03-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4724,18 +4724,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="ten04">
+        <dt id='ten04'>
           Test ten04 @nest MUST NOT have a value object value
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ten04</dd>
             <dt>Type</dt>
@@ -4744,7 +4744,7 @@
             <dd>Transparent Nesting</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/en04-in.jsonld">expand/en04-in.jsonld</a>
+              <a href='expand/en04-in.jsonld'>expand/en04-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4752,18 +4752,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="ten05">
+        <dt id='ten05'>
           Test ten05 does not allow a keyword other than @nest for the value of @nest
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ten05</dd>
             <dt>Type</dt>
@@ -4772,7 +4772,7 @@
             <dd>Transparent Nesting</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/en05-in.jsonld">expand/en05-in.jsonld</a>
+              <a href='expand/en05-in.jsonld'>expand/en05-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4780,18 +4780,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="ten06">
+        <dt id='ten06'>
           Test ten06 does not allow @nest with @reverse
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ten06</dd>
             <dt>Type</dt>
@@ -4800,7 +4800,7 @@
             <dd>Transparent Nesting</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/en06-in.jsonld">expand/en06-in.jsonld</a>
+              <a href='expand/en06-in.jsonld'>expand/en06-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4808,18 +4808,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tep02">
+        <dt id='tep02'>
           Test tep02 processingMode json-ld-1.0 conflicts with @version: 1.1
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tep02</dd>
             <dt>Type</dt>
@@ -4828,7 +4828,7 @@
             <dd>If processingMode is explicitly json-ld-1.0, it will conflict with 1.1 features.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/ep02-in.jsonld">expand/ep02-in.jsonld</a>
+              <a href='expand/ep02-in.jsonld'>expand/ep02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4836,7 +4836,7 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>processingMode</dt>
                 <dd>json-ld-1.0</dd>
                 <dt>specVersion</dt>
@@ -4845,11 +4845,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="tep03">
+        <dt id='tep03'>
           Test tep03 @version must be 1.1
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tep03</dd>
             <dt>Type</dt>
@@ -4858,7 +4858,7 @@
             <dd>If @version is specified, it must be 1.1</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/ep03-in.jsonld">expand/ep03-in.jsonld</a>
+              <a href='expand/ep03-in.jsonld'>expand/ep03-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4866,18 +4866,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="ter01">
+        <dt id='ter01'>
           Test ter01 Keywords cannot be aliased to other keywords
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter01</dd>
             <dt>Type</dt>
@@ -4886,7 +4886,7 @@
             <dd>Verifies that an exception is raised on expansion when processing an invalid context aliasing a keyword to another keyword</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er01-in.jsonld">expand/er01-in.jsonld</a>
+              <a href='expand/er01-in.jsonld'>expand/er01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4894,11 +4894,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter02">
+        <dt id='ter02'>
           Test ter02 A context may not include itself recursively (direct)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter02</dd>
             <dt>Type</dt>
@@ -4907,7 +4907,7 @@
             <dd>Verifies that an exception is raised on expansion when processing a context referencing itself</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er02-in.jsonld">expand/er02-in.jsonld</a>
+              <a href='expand/er02-in.jsonld'>expand/er02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4915,18 +4915,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.0</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="ter03">
+        <dt id='ter03'>
           Test ter03 A context may not include itself recursively (indirect)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter03</dd>
             <dt>Type</dt>
@@ -4935,7 +4935,7 @@
             <dd>Verifies that an exception is raised on expansion when processing a context referencing itself indirectly</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er03-in.jsonld">expand/er03-in.jsonld</a>
+              <a href='expand/er03-in.jsonld'>expand/er03-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4943,18 +4943,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.0</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="ter04">
+        <dt id='ter04'>
           Test ter04 Error dereferencing a remote context
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter04</dd>
             <dt>Type</dt>
@@ -4963,7 +4963,7 @@
             <dd>Verifies that an exception is raised on expansion when a context dereference results in an error</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er04-in.jsonld">expand/er04-in.jsonld</a>
+              <a href='expand/er04-in.jsonld'>expand/er04-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4971,11 +4971,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter05">
+        <dt id='ter05'>
           Test ter05 Invalid remote context
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter05</dd>
             <dt>Type</dt>
@@ -4984,7 +4984,7 @@
             <dd>Verifies that an exception is raised on expansion when a remote context is not an object containing @context</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er05-in.jsonld">expand/er05-in.jsonld</a>
+              <a href='expand/er05-in.jsonld'>expand/er05-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -4992,18 +4992,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="ter06">
+        <dt id='ter06'>
           Test ter06 Invalid local context
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter06</dd>
             <dt>Type</dt>
@@ -5012,7 +5012,7 @@
             <dd>Verifies that an exception is raised on expansion when a context is not a string or object</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er06-in.jsonld">expand/er06-in.jsonld</a>
+              <a href='expand/er06-in.jsonld'>expand/er06-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5020,11 +5020,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter07">
+        <dt id='ter07'>
           Test ter07 Invalid base IRI
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter07</dd>
             <dt>Type</dt>
@@ -5033,7 +5033,7 @@
             <dd>Verifies that an exception is raised on expansion when a context contains an invalid @base</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er07-in.jsonld">expand/er07-in.jsonld</a>
+              <a href='expand/er07-in.jsonld'>expand/er07-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5041,11 +5041,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter08">
+        <dt id='ter08'>
           Test ter08 Invalid vocab mapping
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter08</dd>
             <dt>Type</dt>
@@ -5054,7 +5054,7 @@
             <dd>Verifies that an exception is raised on expansion when a context contains an invalid @vocab mapping</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er08-in.jsonld">expand/er08-in.jsonld</a>
+              <a href='expand/er08-in.jsonld'>expand/er08-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5062,11 +5062,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter09">
+        <dt id='ter09'>
           Test ter09 Invalid default language
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter09</dd>
             <dt>Type</dt>
@@ -5075,7 +5075,7 @@
             <dd>Verifies that an exception is raised on expansion when a context contains an invalid @language</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er09-in.jsonld">expand/er09-in.jsonld</a>
+              <a href='expand/er09-in.jsonld'>expand/er09-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5083,11 +5083,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter10">
+        <dt id='ter10'>
           Test ter10 Cyclic IRI mapping
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter10</dd>
             <dt>Type</dt>
@@ -5096,7 +5096,7 @@
             <dd>Verifies that an exception is raised on expansion when a cyclic IRI mapping is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er10-in.jsonld">expand/er10-in.jsonld</a>
+              <a href='expand/er10-in.jsonld'>expand/er10-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5104,11 +5104,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter11">
+        <dt id='ter11'>
           Test ter11 Invalid term definition
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter11</dd>
             <dt>Type</dt>
@@ -5117,7 +5117,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid term definition is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er11-in.jsonld">expand/er11-in.jsonld</a>
+              <a href='expand/er11-in.jsonld'>expand/er11-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5125,11 +5125,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter12">
+        <dt id='ter12'>
           Test ter12 Invalid type mapping (not a string)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter12</dd>
             <dt>Type</dt>
@@ -5138,7 +5138,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid type mapping is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er12-in.jsonld">expand/er12-in.jsonld</a>
+              <a href='expand/er12-in.jsonld'>expand/er12-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5146,11 +5146,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter13">
+        <dt id='ter13'>
           Test ter13 Invalid type mapping (not absolute IRI)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter13</dd>
             <dt>Type</dt>
@@ -5159,7 +5159,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid type mapping is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er13-in.jsonld">expand/er13-in.jsonld</a>
+              <a href='expand/er13-in.jsonld'>expand/er13-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5167,11 +5167,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter14">
+        <dt id='ter14'>
           Test ter14 Invalid reverse property (contains @id)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter14</dd>
             <dt>Type</dt>
@@ -5180,7 +5180,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid reverse property is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er14-in.jsonld">expand/er14-in.jsonld</a>
+              <a href='expand/er14-in.jsonld'>expand/er14-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5188,11 +5188,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter15">
+        <dt id='ter15'>
           Test ter15 Invalid IRI mapping (@reverse not a string)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter15</dd>
             <dt>Type</dt>
@@ -5201,7 +5201,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid IRI mapping is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er15-in.jsonld">expand/er15-in.jsonld</a>
+              <a href='expand/er15-in.jsonld'>expand/er15-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5209,11 +5209,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter17">
+        <dt id='ter17'>
           Test ter17 Invalid reverse property (invalid @container)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter17</dd>
             <dt>Type</dt>
@@ -5222,7 +5222,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid reverse property is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er17-in.jsonld">expand/er17-in.jsonld</a>
+              <a href='expand/er17-in.jsonld'>expand/er17-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5230,11 +5230,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter18">
+        <dt id='ter18'>
           Test ter18 Invalid IRI mapping (@id not a string)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter18</dd>
             <dt>Type</dt>
@@ -5243,7 +5243,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid IRI mapping is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er18-in.jsonld">expand/er18-in.jsonld</a>
+              <a href='expand/er18-in.jsonld'>expand/er18-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5251,11 +5251,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter19">
+        <dt id='ter19'>
           Test ter19 Invalid keyword alias (@context)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter19</dd>
             <dt>Type</dt>
@@ -5264,7 +5264,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid keyword alias is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er19-in.jsonld">expand/er19-in.jsonld</a>
+              <a href='expand/er19-in.jsonld'>expand/er19-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5272,11 +5272,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter20">
+        <dt id='ter20'>
           Test ter20 Invalid IRI mapping (no vocab mapping)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter20</dd>
             <dt>Type</dt>
@@ -5285,7 +5285,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid IRI mapping is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er20-in.jsonld">expand/er20-in.jsonld</a>
+              <a href='expand/er20-in.jsonld'>expand/er20-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5293,11 +5293,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter21">
+        <dt id='ter21'>
           Test ter21 Invalid container mapping
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter21</dd>
             <dt>Type</dt>
@@ -5306,7 +5306,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid container mapping is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er21-in.jsonld">expand/er21-in.jsonld</a>
+              <a href='expand/er21-in.jsonld'>expand/er21-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5314,7 +5314,7 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>processingMode</dt>
                 <dd>json-ld-1.0</dd>
                 <dt>specVersion</dt>
@@ -5323,11 +5323,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter22">
+        <dt id='ter22'>
           Test ter22 Invalid language mapping
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter22</dd>
             <dt>Type</dt>
@@ -5336,7 +5336,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid language mapping is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er22-in.jsonld">expand/er22-in.jsonld</a>
+              <a href='expand/er22-in.jsonld'>expand/er22-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5344,11 +5344,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter23">
+        <dt id='ter23'>
           Test ter23 Invalid IRI mapping (relative IRI in @type)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter23</dd>
             <dt>Type</dt>
@@ -5357,7 +5357,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid type mapping is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er23-in.jsonld">expand/er23-in.jsonld</a>
+              <a href='expand/er23-in.jsonld'>expand/er23-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5365,11 +5365,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter24">
+        <dt id='ter24'>
           Test ter24 List of lists (from array)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter24</dd>
             <dt>Type</dt>
@@ -5378,7 +5378,7 @@
             <dd>Verifies that an exception is raised in Expansion when a list of lists is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er24-in.jsonld">expand/er24-in.jsonld</a>
+              <a href='expand/er24-in.jsonld'>expand/er24-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5386,18 +5386,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.0</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="ter25">
+        <dt id='ter25'>
           Test ter25 Invalid reverse property map
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter25</dd>
             <dt>Type</dt>
@@ -5406,7 +5406,7 @@
             <dd>Verifies that an exception is raised in Expansion when a invalid reverse property map is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er25-in.jsonld">expand/er25-in.jsonld</a>
+              <a href='expand/er25-in.jsonld'>expand/er25-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5414,11 +5414,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter26">
+        <dt id='ter26'>
           Test ter26 Colliding keywords
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter26</dd>
             <dt>Type</dt>
@@ -5427,7 +5427,7 @@
             <dd>Verifies that an exception is raised in Expansion when colliding keywords are found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er26-in.jsonld">expand/er26-in.jsonld</a>
+              <a href='expand/er26-in.jsonld'>expand/er26-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5435,11 +5435,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter27">
+        <dt id='ter27'>
           Test ter27 Invalid @id value
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter27</dd>
             <dt>Type</dt>
@@ -5448,7 +5448,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid @id value is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er27-in.jsonld">expand/er27-in.jsonld</a>
+              <a href='expand/er27-in.jsonld'>expand/er27-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5456,11 +5456,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter28">
+        <dt id='ter28'>
           Test ter28 Invalid type value
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter28</dd>
             <dt>Type</dt>
@@ -5469,7 +5469,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid type value is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er28-in.jsonld">expand/er28-in.jsonld</a>
+              <a href='expand/er28-in.jsonld'>expand/er28-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5477,11 +5477,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter29">
+        <dt id='ter29'>
           Test ter29 Invalid value object value
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter29</dd>
             <dt>Type</dt>
@@ -5490,7 +5490,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid value object value is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er29-in.jsonld">expand/er29-in.jsonld</a>
+              <a href='expand/er29-in.jsonld'>expand/er29-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5498,11 +5498,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter30">
+        <dt id='ter30'>
           Test ter30 Invalid language-tagged string
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter30</dd>
             <dt>Type</dt>
@@ -5511,7 +5511,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid language-tagged string value is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er30-in.jsonld">expand/er30-in.jsonld</a>
+              <a href='expand/er30-in.jsonld'>expand/er30-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5519,11 +5519,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter31">
+        <dt id='ter31'>
           Test ter31 Invalid @index value
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter31</dd>
             <dt>Type</dt>
@@ -5532,7 +5532,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid @index value value is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er31-in.jsonld">expand/er31-in.jsonld</a>
+              <a href='expand/er31-in.jsonld'>expand/er31-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5540,11 +5540,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter32">
+        <dt id='ter32'>
           Test ter32 List of lists (from array)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter32</dd>
             <dt>Type</dt>
@@ -5553,7 +5553,7 @@
             <dd>Verifies that an exception is raised in Expansion when a list of lists is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er32-in.jsonld">expand/er32-in.jsonld</a>
+              <a href='expand/er32-in.jsonld'>expand/er32-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5561,18 +5561,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.0</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="ter33">
+        <dt id='ter33'>
           Test ter33 Invalid @reverse value
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter33</dd>
             <dt>Type</dt>
@@ -5581,7 +5581,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid @reverse value is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er33-in.jsonld">expand/er33-in.jsonld</a>
+              <a href='expand/er33-in.jsonld'>expand/er33-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5589,11 +5589,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter34">
+        <dt id='ter34'>
           Test ter34 Invalid reverse property value (in @reverse)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter34</dd>
             <dt>Type</dt>
@@ -5602,7 +5602,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid reverse property value is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er34-in.jsonld">expand/er34-in.jsonld</a>
+              <a href='expand/er34-in.jsonld'>expand/er34-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5610,11 +5610,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter35">
+        <dt id='ter35'>
           Test ter35 Invalid language map value
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter35</dd>
             <dt>Type</dt>
@@ -5623,7 +5623,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid language map value is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er35-in.jsonld">expand/er35-in.jsonld</a>
+              <a href='expand/er35-in.jsonld'>expand/er35-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5631,11 +5631,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter36">
+        <dt id='ter36'>
           Test ter36 Invalid reverse property value (through coercion)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter36</dd>
             <dt>Type</dt>
@@ -5644,7 +5644,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid reverse property value is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er36-in.jsonld">expand/er36-in.jsonld</a>
+              <a href='expand/er36-in.jsonld'>expand/er36-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5652,11 +5652,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter37">
+        <dt id='ter37'>
           Test ter37 Invalid value object (unexpected keyword)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter37</dd>
             <dt>Type</dt>
@@ -5665,7 +5665,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid value object is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er37-in.jsonld">expand/er37-in.jsonld</a>
+              <a href='expand/er37-in.jsonld'>expand/er37-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5673,11 +5673,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter38">
+        <dt id='ter38'>
           Test ter38 Invalid value object (@type and @language)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter38</dd>
             <dt>Type</dt>
@@ -5686,7 +5686,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid value object is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er38-in.jsonld">expand/er38-in.jsonld</a>
+              <a href='expand/er38-in.jsonld'>expand/er38-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5694,11 +5694,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter39">
+        <dt id='ter39'>
           Test ter39 Invalid language-tagged value
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter39</dd>
             <dt>Type</dt>
@@ -5707,7 +5707,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid language-tagged value is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er39-in.jsonld">expand/er39-in.jsonld</a>
+              <a href='expand/er39-in.jsonld'>expand/er39-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5715,11 +5715,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter40">
+        <dt id='ter40'>
           Test ter40 Invalid typed value
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter40</dd>
             <dt>Type</dt>
@@ -5728,7 +5728,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid typed value is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er40-in.jsonld">expand/er40-in.jsonld</a>
+              <a href='expand/er40-in.jsonld'>expand/er40-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5736,11 +5736,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter41">
+        <dt id='ter41'>
           Test ter41 Invalid set or list object
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter41</dd>
             <dt>Type</dt>
@@ -5749,7 +5749,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid set or list object is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er41-in.jsonld">expand/er41-in.jsonld</a>
+              <a href='expand/er41-in.jsonld'>expand/er41-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5757,11 +5757,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter42">
+        <dt id='ter42'>
           Test ter42 Keywords may not be redefined in 1.0
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter42</dd>
             <dt>Type</dt>
@@ -5770,7 +5770,7 @@
             <dd>Verifies that an exception is raised on expansion when processing an invalid context attempting to define @container on a keyword</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er42-in.jsonld">expand/er42-in.jsonld</a>
+              <a href='expand/er42-in.jsonld'>expand/er42-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5778,7 +5778,7 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
                 <dt>processingMode</dt>
@@ -5787,11 +5787,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter43">
+        <dt id='ter43'>
           Test ter43 Term definition with @id: @type
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter43</dd>
             <dt>Type</dt>
@@ -5800,7 +5800,7 @@
             <dd>Expanding term mapping to @type uses @type syntax now illegal</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er43-in.jsonld">expand/er43-in.jsonld</a>
+              <a href='expand/er43-in.jsonld'>expand/er43-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5808,18 +5808,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="ter44">
+        <dt id='ter44'>
           Test ter44 Redefine terms looking like compact IRIs
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter44</dd>
             <dt>Type</dt>
@@ -5828,7 +5828,7 @@
             <dd>Term definitions may look like compact IRIs, but must be consistent.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er44-in.jsonld">expand/er44-in.jsonld</a>
+              <a href='expand/er44-in.jsonld'>expand/er44-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5836,18 +5836,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="ter48">
+        <dt id='ter48'>
           Test ter48 Invalid term as relative IRI
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter48</dd>
             <dt>Type</dt>
@@ -5856,7 +5856,7 @@
             <dd>Verifies that a relative IRI cannot be used as a term.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er48-in.jsonld">expand/er48-in.jsonld</a>
+              <a href='expand/er48-in.jsonld'>expand/er48-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5864,18 +5864,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="ter49">
+        <dt id='ter49'>
           Test ter49 A relative IRI cannot be used as a prefix
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter49</dd>
             <dt>Type</dt>
@@ -5884,7 +5884,7 @@
             <dd>Verifies that a relative IRI cannot be used as a term.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er49-in.jsonld">expand/er49-in.jsonld</a>
+              <a href='expand/er49-in.jsonld'>expand/er49-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5892,18 +5892,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="ter50">
+        <dt id='ter50'>
           Test ter50 Invalid reverse id
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter50</dd>
             <dt>Type</dt>
@@ -5912,7 +5912,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid IRI is used for @reverse.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er50-in.jsonld">expand/er50-in.jsonld</a>
+              <a href='expand/er50-in.jsonld'>expand/er50-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5920,11 +5920,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter51">
+        <dt id='ter51'>
           Test ter51 Invalid value object value using a value alias
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter51</dd>
             <dt>Type</dt>
@@ -5933,7 +5933,7 @@
             <dd>Verifies that an exception is raised in Expansion when an invalid value object value is found using a value alias</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er51-in.jsonld">expand/er51-in.jsonld</a>
+              <a href='expand/er51-in.jsonld'>expand/er51-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5941,11 +5941,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter52">
+        <dt id='ter52'>
           Test ter52 Definition for the empty term
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter52</dd>
             <dt>Type</dt>
@@ -5954,7 +5954,7 @@
             <dd>Verifies that an exception is raised on expansion when a context contains a definition for the empty term</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er52-in.jsonld">expand/er52-in.jsonld</a>
+              <a href='expand/er52-in.jsonld'>expand/er52-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5962,11 +5962,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter53">
+        <dt id='ter53'>
           Test ter53 Invalid prefix value
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter53</dd>
             <dt>Type</dt>
@@ -5975,7 +5975,7 @@
             <dd>Verifies that an exception is raised on expansion when a context contains an invalid @prefix value</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er53-in.jsonld">expand/er53-in.jsonld</a>
+              <a href='expand/er53-in.jsonld'>expand/er53-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -5983,18 +5983,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="ter54">
+        <dt id='ter54'>
           Test ter54 Invalid value object, multiple values for @type.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter54</dd>
             <dt>Type</dt>
@@ -6003,7 +6003,7 @@
             <dd>The value of @type in a value object MUST be a string or null.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er54-in.jsonld">expand/er54-in.jsonld</a>
+              <a href='expand/er54-in.jsonld'>expand/er54-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -6011,11 +6011,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter55">
+        <dt id='ter55'>
           Test ter55 Invalid term definition, multiple values for @type.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter55</dd>
             <dt>Type</dt>
@@ -6024,7 +6024,7 @@
             <dd>The value of @type in an expanded term definition object MUST be a string or null.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er55-in.jsonld">expand/er55-in.jsonld</a>
+              <a href='expand/er55-in.jsonld'>expand/er55-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -6032,11 +6032,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ter56">
+        <dt id='ter56'>
           Test ter56 Invalid redefinition of @context keyword.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ter56</dd>
             <dt>Type</dt>
@@ -6045,7 +6045,7 @@
             <dd>Verifies that an exception is raised when attempting to redefine @context.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/er56-in.jsonld">expand/er56-in.jsonld</a>
+              <a href='expand/er56-in.jsonld'>expand/er56-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -6053,11 +6053,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="tes01">
+        <dt id='tes01'>
           Test tes01 Using an array value for @context is illegal in JSON-LD 1.0
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tes01</dd>
             <dt>Type</dt>
@@ -6066,7 +6066,7 @@
             <dd>Verifies that an exception is raised on expansion when a invalid container mapping is found</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/es01-in.jsonld">expand/es01-in.jsonld</a>
+              <a href='expand/es01-in.jsonld'>expand/es01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -6074,7 +6074,7 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>processingMode</dt>
                 <dd>json-ld-1.0</dd>
                 <dt>specVersion</dt>
@@ -6083,11 +6083,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="tes02">
+        <dt id='tes02'>
           Test tes02 Mapping @container: [@list, @set] is invalid
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tes02</dd>
             <dt>Type</dt>
@@ -6096,7 +6096,7 @@
             <dd>Testing legal combinations of @set with other container values</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/es02-in.jsonld">expand/es02-in.jsonld</a>
+              <a href='expand/es02-in.jsonld'>expand/es02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -6104,18 +6104,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tin01">
+        <dt id='tin01'>
           Test tin01 Basic Included array
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tin01</dd>
             <dt>Type</dt>
@@ -6124,26 +6124,26 @@
             <dd>Tests included blocks.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/in01-in.jsonld">expand/in01-in.jsonld</a>
+              <a href='expand/in01-in.jsonld'>expand/in01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/in01-out.jsonld">expand/in01-out.jsonld</a>
+              <a href='expand/in01-out.jsonld'>expand/in01-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tin02">
+        <dt id='tin02'>
           Test tin02 Basic Included object
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tin02</dd>
             <dt>Type</dt>
@@ -6152,26 +6152,26 @@
             <dd>Tests included blocks.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/in02-in.jsonld">expand/in02-in.jsonld</a>
+              <a href='expand/in02-in.jsonld'>expand/in02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/in02-out.jsonld">expand/in02-out.jsonld</a>
+              <a href='expand/in02-out.jsonld'>expand/in02-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tin03">
+        <dt id='tin03'>
           Test tin03 Multiple properties mapping to @included are folded together
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tin03</dd>
             <dt>Type</dt>
@@ -6180,26 +6180,26 @@
             <dd>Tests included blocks.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/in03-in.jsonld">expand/in03-in.jsonld</a>
+              <a href='expand/in03-in.jsonld'>expand/in03-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/in03-out.jsonld">expand/in03-out.jsonld</a>
+              <a href='expand/in03-out.jsonld'>expand/in03-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tin04">
+        <dt id='tin04'>
           Test tin04 Included containing @included
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tin04</dd>
             <dt>Type</dt>
@@ -6208,26 +6208,26 @@
             <dd>Tests included blocks.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/in04-in.jsonld">expand/in04-in.jsonld</a>
+              <a href='expand/in04-in.jsonld'>expand/in04-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/in04-out.jsonld">expand/in04-out.jsonld</a>
+              <a href='expand/in04-out.jsonld'>expand/in04-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tin05">
+        <dt id='tin05'>
           Test tin05 Property value with @included
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tin05</dd>
             <dt>Type</dt>
@@ -6236,26 +6236,26 @@
             <dd>Tests included blocks.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/in05-in.jsonld">expand/in05-in.jsonld</a>
+              <a href='expand/in05-in.jsonld'>expand/in05-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/in05-out.jsonld">expand/in05-out.jsonld</a>
+              <a href='expand/in05-out.jsonld'>expand/in05-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tin06">
+        <dt id='tin06'>
           Test tin06 json.api example
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tin06</dd>
             <dt>Type</dt>
@@ -6264,26 +6264,26 @@
             <dd>Tests included blocks.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/in06-in.jsonld">expand/in06-in.jsonld</a>
+              <a href='expand/in06-in.jsonld'>expand/in06-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/in06-out.jsonld">expand/in06-out.jsonld</a>
+              <a href='expand/in06-out.jsonld'>expand/in06-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tin07">
+        <dt id='tin07'>
           Test tin07 Error if @included value is a string
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tin07</dd>
             <dt>Type</dt>
@@ -6292,7 +6292,7 @@
             <dd>Tests included blocks.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/in07-in.jsonld">expand/in07-in.jsonld</a>
+              <a href='expand/in07-in.jsonld'>expand/in07-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -6300,18 +6300,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tin08">
+        <dt id='tin08'>
           Test tin08 Error if @included value is a value object
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tin08</dd>
             <dt>Type</dt>
@@ -6320,7 +6320,7 @@
             <dd>Tests included blocks.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/in08-in.jsonld">expand/in08-in.jsonld</a>
+              <a href='expand/in08-in.jsonld'>expand/in08-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -6328,18 +6328,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tin09">
+        <dt id='tin09'>
           Test tin09 Error if @included value is a list object
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tin09</dd>
             <dt>Type</dt>
@@ -6348,7 +6348,7 @@
             <dd>Tests included blocks.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/in09-in.jsonld">expand/in09-in.jsonld</a>
+              <a href='expand/in09-in.jsonld'>expand/in09-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -6356,18 +6356,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tjs01">
+        <dt id='tjs01'>
           Test tjs01 Expand JSON literal (boolean true)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tjs01</dd>
             <dt>Type</dt>
@@ -6376,26 +6376,26 @@
             <dd>Tests expanding property with @type @json to a JSON literal (boolean true).</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/js01-in.jsonld">expand/js01-in.jsonld</a>
+              <a href='expand/js01-in.jsonld'>expand/js01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/js01-out.jsonld">expand/js01-out.jsonld</a>
+              <a href='expand/js01-out.jsonld'>expand/js01-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tjs02">
+        <dt id='tjs02'>
           Test tjs02 Expand JSON literal (boolean false)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tjs02</dd>
             <dt>Type</dt>
@@ -6404,26 +6404,26 @@
             <dd>Tests expanding property with @type @json to a JSON literal (boolean false).</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/js02-in.jsonld">expand/js02-in.jsonld</a>
+              <a href='expand/js02-in.jsonld'>expand/js02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/js02-out.jsonld">expand/js02-out.jsonld</a>
+              <a href='expand/js02-out.jsonld'>expand/js02-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tjs03">
+        <dt id='tjs03'>
           Test tjs03 Expand JSON literal (double)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tjs03</dd>
             <dt>Type</dt>
@@ -6432,26 +6432,26 @@
             <dd>Tests expanding property with @type @json to a JSON literal (double).</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/js03-in.jsonld">expand/js03-in.jsonld</a>
+              <a href='expand/js03-in.jsonld'>expand/js03-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/js03-out.jsonld">expand/js03-out.jsonld</a>
+              <a href='expand/js03-out.jsonld'>expand/js03-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tjs04">
+        <dt id='tjs04'>
           Test tjs04 Expand JSON literal (double-zero)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tjs04</dd>
             <dt>Type</dt>
@@ -6460,26 +6460,26 @@
             <dd>Tests expanding property with @type @json to a JSON literal (double-zero).</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/js04-in.jsonld">expand/js04-in.jsonld</a>
+              <a href='expand/js04-in.jsonld'>expand/js04-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/js04-out.jsonld">expand/js04-out.jsonld</a>
+              <a href='expand/js04-out.jsonld'>expand/js04-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tjs05">
+        <dt id='tjs05'>
           Test tjs05 Expand JSON literal (integer)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tjs05</dd>
             <dt>Type</dt>
@@ -6488,26 +6488,26 @@
             <dd>Tests expanding property with @type @json to a JSON literal (integer).</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/js05-in.jsonld">expand/js05-in.jsonld</a>
+              <a href='expand/js05-in.jsonld'>expand/js05-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/js05-out.jsonld">expand/js05-out.jsonld</a>
+              <a href='expand/js05-out.jsonld'>expand/js05-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tjs06">
+        <dt id='tjs06'>
           Test tjs06 Expand JSON literal (object)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tjs06</dd>
             <dt>Type</dt>
@@ -6516,26 +6516,26 @@
             <dd>Tests expanding property with @type @json to a JSON literal (object).</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/js06-in.jsonld">expand/js06-in.jsonld</a>
+              <a href='expand/js06-in.jsonld'>expand/js06-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/js06-out.jsonld">expand/js06-out.jsonld</a>
+              <a href='expand/js06-out.jsonld'>expand/js06-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tjs07">
+        <dt id='tjs07'>
           Test tjs07 Expand JSON literal (array)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tjs07</dd>
             <dt>Type</dt>
@@ -6544,26 +6544,26 @@
             <dd>Tests expanding property with @type @json to a JSON literal (array).</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/js07-in.jsonld">expand/js07-in.jsonld</a>
+              <a href='expand/js07-in.jsonld'>expand/js07-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/js07-out.jsonld">expand/js07-out.jsonld</a>
+              <a href='expand/js07-out.jsonld'>expand/js07-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tjs08">
+        <dt id='tjs08'>
           Test tjs08 Expand JSON literal with array canonicalization
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tjs08</dd>
             <dt>Type</dt>
@@ -6572,26 +6572,26 @@
             <dd>Tests expanding JSON literal with array canonicalization.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/js08-in.jsonld">expand/js08-in.jsonld</a>
+              <a href='expand/js08-in.jsonld'>expand/js08-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/js08-out.jsonld">expand/js08-out.jsonld</a>
+              <a href='expand/js08-out.jsonld'>expand/js08-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tjs09">
+        <dt id='tjs09'>
           Test tjs09 Transform JSON literal with string canonicalization
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tjs09</dd>
             <dt>Type</dt>
@@ -6600,26 +6600,26 @@
             <dd>Tests expanding JSON literal with string canonicalization.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/js09-in.jsonld">expand/js09-in.jsonld</a>
+              <a href='expand/js09-in.jsonld'>expand/js09-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/js09-out.jsonld">expand/js09-out.jsonld</a>
+              <a href='expand/js09-out.jsonld'>expand/js09-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tjs10">
+        <dt id='tjs10'>
           Test tjs10 Expand JSON literal with structural canonicalization
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tjs10</dd>
             <dt>Type</dt>
@@ -6628,26 +6628,26 @@
             <dd>Tests expanding JSON literal with structural canonicalization.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/js10-in.jsonld">expand/js10-in.jsonld</a>
+              <a href='expand/js10-in.jsonld'>expand/js10-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/js10-out.jsonld">expand/js10-out.jsonld</a>
+              <a href='expand/js10-out.jsonld'>expand/js10-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tjs11">
+        <dt id='tjs11'>
           Test tjs11 Expand JSON literal with unicode canonicalization
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tjs11</dd>
             <dt>Type</dt>
@@ -6656,26 +6656,26 @@
             <dd>Tests expanding JSON literal with unicode canonicalization.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/js11-in.jsonld">expand/js11-in.jsonld</a>
+              <a href='expand/js11-in.jsonld'>expand/js11-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/js11-out.jsonld">expand/js11-out.jsonld</a>
+              <a href='expand/js11-out.jsonld'>expand/js11-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tjs12">
+        <dt id='tjs12'>
           Test tjs12 Expand JSON literal with value canonicalization
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tjs12</dd>
             <dt>Type</dt>
@@ -6684,26 +6684,26 @@
             <dd>Tests expanding JSON literal with value canonicalization.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/js12-in.jsonld">expand/js12-in.jsonld</a>
+              <a href='expand/js12-in.jsonld'>expand/js12-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/js12-out.jsonld">expand/js12-out.jsonld</a>
+              <a href='expand/js12-out.jsonld'>expand/js12-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tjs13">
+        <dt id='tjs13'>
           Test tjs13 Expand JSON literal with wierd canonicalization
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tjs13</dd>
             <dt>Type</dt>
@@ -6712,26 +6712,26 @@
             <dd>Tests expanding JSON literal with wierd canonicalization.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/js13-in.jsonld">expand/js13-in.jsonld</a>
+              <a href='expand/js13-in.jsonld'>expand/js13-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/js13-out.jsonld">expand/js13-out.jsonld</a>
+              <a href='expand/js13-out.jsonld'>expand/js13-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tjs14">
+        <dt id='tjs14'>
           Test tjs14 Expand JSON literal without expanding contents
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tjs14</dd>
             <dt>Type</dt>
@@ -6740,26 +6740,26 @@
             <dd>Tests expanding JSON literal does not expand terms inside json.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/js14-in.jsonld">expand/js14-in.jsonld</a>
+              <a href='expand/js14-in.jsonld'>expand/js14-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/js14-out.jsonld">expand/js14-out.jsonld</a>
+              <a href='expand/js14-out.jsonld'>expand/js14-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tjs15">
+        <dt id='tjs15'>
           Test tjs15 Expand JSON literal aleady in expanded form
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tjs15</dd>
             <dt>Type</dt>
@@ -6768,26 +6768,26 @@
             <dd>Tests expanding JSON literal in expanded form.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/js15-in.jsonld">expand/js15-in.jsonld</a>
+              <a href='expand/js15-in.jsonld'>expand/js15-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/js15-out.jsonld">expand/js15-out.jsonld</a>
+              <a href='expand/js15-out.jsonld'>expand/js15-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tjs16">
+        <dt id='tjs16'>
           Test tjs16 Expand JSON literal aleady in expanded form with aliased keys
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tjs16</dd>
             <dt>Type</dt>
@@ -6796,26 +6796,26 @@
             <dd>Tests expanding JSON literal in expanded form with aliased keys in value object.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/js16-in.jsonld">expand/js16-in.jsonld</a>
+              <a href='expand/js16-in.jsonld'>expand/js16-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/js16-out.jsonld">expand/js16-out.jsonld</a>
+              <a href='expand/js16-out.jsonld'>expand/js16-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tjs17">
+        <dt id='tjs17'>
           Test tjs17 Expand JSON literal (string)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tjs17</dd>
             <dt>Type</dt>
@@ -6824,26 +6824,26 @@
             <dd>Tests expanding property with @type @json to a JSON literal (string).</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/js17-in.jsonld">expand/js17-in.jsonld</a>
+              <a href='expand/js17-in.jsonld'>expand/js17-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/js17-out.jsonld">expand/js17-out.jsonld</a>
+              <a href='expand/js17-out.jsonld'>expand/js17-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tjs18">
+        <dt id='tjs18'>
           Test tjs18 Expand JSON literal (null)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tjs18</dd>
             <dt>Type</dt>
@@ -6852,26 +6852,26 @@
             <dd>Tests expanding property with @type @json to a JSON literal (null).</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/js18-in.jsonld">expand/js18-in.jsonld</a>
+              <a href='expand/js18-in.jsonld'>expand/js18-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/js18-out.jsonld">expand/js18-out.jsonld</a>
+              <a href='expand/js18-out.jsonld'>expand/js18-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tjs19">
+        <dt id='tjs19'>
           Test tjs19 Expand JSON literal with aliased @type
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tjs19</dd>
             <dt>Type</dt>
@@ -6880,26 +6880,26 @@
             <dd>Tests expanding JSON literal with aliased @type.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/js19-in.jsonld">expand/js19-in.jsonld</a>
+              <a href='expand/js19-in.jsonld'>expand/js19-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/js19-out.jsonld">expand/js19-out.jsonld</a>
+              <a href='expand/js19-out.jsonld'>expand/js19-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tjs20">
+        <dt id='tjs20'>
           Test tjs20 Expand JSON literal with aliased @value
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tjs20</dd>
             <dt>Type</dt>
@@ -6908,26 +6908,26 @@
             <dd>Tests expanding JSON literal with aliased @value.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/js20-in.jsonld">expand/js20-in.jsonld</a>
+              <a href='expand/js20-in.jsonld'>expand/js20-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/js20-out.jsonld">expand/js20-out.jsonld</a>
+              <a href='expand/js20-out.jsonld'>expand/js20-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tjs21">
+        <dt id='tjs21'>
           Test tjs21 Expand JSON literal with @context
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tjs21</dd>
             <dt>Type</dt>
@@ -6936,26 +6936,26 @@
             <dd>Tests expanding JSON literal with a @context.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/js21-in.jsonld">expand/js21-in.jsonld</a>
+              <a href='expand/js21-in.jsonld'>expand/js21-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/js21-out.jsonld">expand/js21-out.jsonld</a>
+              <a href='expand/js21-out.jsonld'>expand/js21-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tjs22">
+        <dt id='tjs22'>
           Test tjs22 Expand JSON literal (null) aleady in expanded form.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tjs22</dd>
             <dt>Type</dt>
@@ -6964,26 +6964,26 @@
             <dd>Tests expanding property with @type @json to a JSON literal (null).</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/js22-in.jsonld">expand/js22-in.jsonld</a>
+              <a href='expand/js22-in.jsonld'>expand/js22-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/js22-out.jsonld">expand/js22-out.jsonld</a>
+              <a href='expand/js22-out.jsonld'>expand/js22-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tjs23">
+        <dt id='tjs23'>
           Test tjs23 Expand JSON literal (empty array).
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tjs23</dd>
             <dt>Type</dt>
@@ -6992,26 +6992,26 @@
             <dd>Tests expanding property with @type @json to a JSON literal (empty array).</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/js23-in.jsonld">expand/js23-in.jsonld</a>
+              <a href='expand/js23-in.jsonld'>expand/js23-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/js23-out.jsonld">expand/js23-out.jsonld</a>
+              <a href='expand/js23-out.jsonld'>expand/js23-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tl001">
+        <dt id='tl001'>
           Test tl001 Language map with null value
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tl001</dd>
             <dt>Type</dt>
@@ -7020,26 +7020,26 @@
             <dd>A language map may have a null value, which is ignored</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/l001-in.jsonld">expand/l001-in.jsonld</a>
+              <a href='expand/l001-in.jsonld'>expand/l001-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/l001-out.jsonld">expand/l001-out.jsonld</a>
+              <a href='expand/l001-out.jsonld'>expand/l001-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tli01">
+        <dt id='tli01'>
           Test tli01 @list containing @list
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tli01</dd>
             <dt>Type</dt>
@@ -7048,26 +7048,26 @@
             <dd>List of lists</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/li01-in.jsonld">expand/li01-in.jsonld</a>
+              <a href='expand/li01-in.jsonld'>expand/li01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/li01-out.jsonld">expand/li01-out.jsonld</a>
+              <a href='expand/li01-out.jsonld'>expand/li01-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tli02">
+        <dt id='tli02'>
           Test tli02 @list containing empty @list
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tli02</dd>
             <dt>Type</dt>
@@ -7076,26 +7076,26 @@
             <dd>List of lists</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/li02-in.jsonld">expand/li02-in.jsonld</a>
+              <a href='expand/li02-in.jsonld'>expand/li02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/li02-out.jsonld">expand/li02-out.jsonld</a>
+              <a href='expand/li02-out.jsonld'>expand/li02-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tli03">
+        <dt id='tli03'>
           Test tli03 @list containing @list (with coercion)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tli03</dd>
             <dt>Type</dt>
@@ -7104,26 +7104,26 @@
             <dd>List of lists</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/li03-in.jsonld">expand/li03-in.jsonld</a>
+              <a href='expand/li03-in.jsonld'>expand/li03-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/li03-out.jsonld">expand/li03-out.jsonld</a>
+              <a href='expand/li03-out.jsonld'>expand/li03-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tli04">
+        <dt id='tli04'>
           Test tli04 @list containing empty @list (with coercion)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tli04</dd>
             <dt>Type</dt>
@@ -7132,26 +7132,26 @@
             <dd>List of lists</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/li04-in.jsonld">expand/li04-in.jsonld</a>
+              <a href='expand/li04-in.jsonld'>expand/li04-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/li04-out.jsonld">expand/li04-out.jsonld</a>
+              <a href='expand/li04-out.jsonld'>expand/li04-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tli05">
+        <dt id='tli05'>
           Test tli05 coerced @list containing an array
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tli05</dd>
             <dt>Type</dt>
@@ -7160,26 +7160,26 @@
             <dd>List of lists</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/li05-in.jsonld">expand/li05-in.jsonld</a>
+              <a href='expand/li05-in.jsonld'>expand/li05-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/li05-out.jsonld">expand/li05-out.jsonld</a>
+              <a href='expand/li05-out.jsonld'>expand/li05-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tli06">
+        <dt id='tli06'>
           Test tli06 coerced @list containing an empty array
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tli06</dd>
             <dt>Type</dt>
@@ -7188,26 +7188,26 @@
             <dd>List of lists</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/li06-in.jsonld">expand/li06-in.jsonld</a>
+              <a href='expand/li06-in.jsonld'>expand/li06-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/li06-out.jsonld">expand/li06-out.jsonld</a>
+              <a href='expand/li06-out.jsonld'>expand/li06-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tli07">
+        <dt id='tli07'>
           Test tli07 coerced @list containing deep arrays
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tli07</dd>
             <dt>Type</dt>
@@ -7216,26 +7216,26 @@
             <dd>List of lists</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/li07-in.jsonld">expand/li07-in.jsonld</a>
+              <a href='expand/li07-in.jsonld'>expand/li07-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/li07-out.jsonld">expand/li07-out.jsonld</a>
+              <a href='expand/li07-out.jsonld'>expand/li07-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tli08">
+        <dt id='tli08'>
           Test tli08 coerced @list containing deep empty arrays
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tli08</dd>
             <dt>Type</dt>
@@ -7244,26 +7244,26 @@
             <dd>List of lists</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/li08-in.jsonld">expand/li08-in.jsonld</a>
+              <a href='expand/li08-in.jsonld'>expand/li08-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/li08-out.jsonld">expand/li08-out.jsonld</a>
+              <a href='expand/li08-out.jsonld'>expand/li08-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tli09">
+        <dt id='tli09'>
           Test tli09 coerced @list containing multiple lists
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tli09</dd>
             <dt>Type</dt>
@@ -7272,26 +7272,26 @@
             <dd>List of lists</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/li09-in.jsonld">expand/li09-in.jsonld</a>
+              <a href='expand/li09-in.jsonld'>expand/li09-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/li09-out.jsonld">expand/li09-out.jsonld</a>
+              <a href='expand/li09-out.jsonld'>expand/li09-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tli10">
+        <dt id='tli10'>
           Test tli10 coerced @list containing mixed list values
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tli10</dd>
             <dt>Type</dt>
@@ -7300,26 +7300,26 @@
             <dd>List of lists</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/li10-in.jsonld">expand/li10-in.jsonld</a>
+              <a href='expand/li10-in.jsonld'>expand/li10-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/li10-out.jsonld">expand/li10-out.jsonld</a>
+              <a href='expand/li10-out.jsonld'>expand/li10-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tm001">
+        <dt id='tm001'>
           Test tm001 Adds @id to object not having an @id
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tm001</dd>
             <dt>Type</dt>
@@ -7328,26 +7328,26 @@
             <dd>Expansion using @container: @id</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/m001-in.jsonld">expand/m001-in.jsonld</a>
+              <a href='expand/m001-in.jsonld'>expand/m001-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/m001-out.jsonld">expand/m001-out.jsonld</a>
+              <a href='expand/m001-out.jsonld'>expand/m001-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tm002">
+        <dt id='tm002'>
           Test tm002 Retains @id in object already having an @id
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tm002</dd>
             <dt>Type</dt>
@@ -7356,26 +7356,26 @@
             <dd>Expansion using @container: @id</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/m002-in.jsonld">expand/m002-in.jsonld</a>
+              <a href='expand/m002-in.jsonld'>expand/m002-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/m002-out.jsonld">expand/m002-out.jsonld</a>
+              <a href='expand/m002-out.jsonld'>expand/m002-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tm003">
+        <dt id='tm003'>
           Test tm003 Adds @type to object not having an @type
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tm003</dd>
             <dt>Type</dt>
@@ -7384,26 +7384,26 @@
             <dd>Expansion using @container: @type</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/m003-in.jsonld">expand/m003-in.jsonld</a>
+              <a href='expand/m003-in.jsonld'>expand/m003-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/m003-out.jsonld">expand/m003-out.jsonld</a>
+              <a href='expand/m003-out.jsonld'>expand/m003-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tm004">
+        <dt id='tm004'>
           Test tm004 Prepends @type in object already having an @type
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tm004</dd>
             <dt>Type</dt>
@@ -7412,26 +7412,26 @@
             <dd>Expansion using @container: @type</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/m004-in.jsonld">expand/m004-in.jsonld</a>
+              <a href='expand/m004-in.jsonld'>expand/m004-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/m004-out.jsonld">expand/m004-out.jsonld</a>
+              <a href='expand/m004-out.jsonld'>expand/m004-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tm005">
+        <dt id='tm005'>
           Test tm005 Adds expanded @id to object
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tm005</dd>
             <dt>Type</dt>
@@ -7440,15 +7440,15 @@
             <dd>Expansion using @container: @id</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/m005-in.jsonld">expand/m005-in.jsonld</a>
+              <a href='expand/m005-in.jsonld'>expand/m005-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/m005-out.jsonld">expand/m005-out.jsonld</a>
+              <a href='expand/m005-out.jsonld'>expand/m005-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>base</dt>
                 <dd>http://example.org/</dd>
                 <dt>specVersion</dt>
@@ -7457,11 +7457,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="tm006">
+        <dt id='tm006'>
           Test tm006 Adds vocabulary expanded @type to object
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tm006</dd>
             <dt>Type</dt>
@@ -7470,26 +7470,26 @@
             <dd>Expansion using @container: @type</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/m006-in.jsonld">expand/m006-in.jsonld</a>
+              <a href='expand/m006-in.jsonld'>expand/m006-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/m006-out.jsonld">expand/m006-out.jsonld</a>
+              <a href='expand/m006-out.jsonld'>expand/m006-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tm007">
+        <dt id='tm007'>
           Test tm007 Adds document expanded @type to object
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tm007</dd>
             <dt>Type</dt>
@@ -7498,26 +7498,26 @@
             <dd>Expansion using @container: @type</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/m007-in.jsonld">expand/m007-in.jsonld</a>
+              <a href='expand/m007-in.jsonld'>expand/m007-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/m007-out.jsonld">expand/m007-out.jsonld</a>
+              <a href='expand/m007-out.jsonld'>expand/m007-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tm008">
+        <dt id='tm008'>
           Test tm008 When type is in a type map
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tm008</dd>
             <dt>Type</dt>
@@ -7526,26 +7526,26 @@
             <dd>scoped context on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/m008-in.jsonld">expand/m008-in.jsonld</a>
+              <a href='expand/m008-in.jsonld'>expand/m008-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/m008-out.jsonld">expand/m008-out.jsonld</a>
+              <a href='expand/m008-out.jsonld'>expand/m008-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tm009">
+        <dt id='tm009'>
           Test tm009 language map with @none
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tm009</dd>
             <dt>Type</dt>
@@ -7554,26 +7554,26 @@
             <dd>index on @language</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/m009-in.jsonld">expand/m009-in.jsonld</a>
+              <a href='expand/m009-in.jsonld'>expand/m009-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/m009-out.jsonld">expand/m009-out.jsonld</a>
+              <a href='expand/m009-out.jsonld'>expand/m009-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tm010">
+        <dt id='tm010'>
           Test tm010 language map with alias of @none
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tm010</dd>
             <dt>Type</dt>
@@ -7582,26 +7582,26 @@
             <dd>index on @language</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/m010-in.jsonld">expand/m010-in.jsonld</a>
+              <a href='expand/m010-in.jsonld'>expand/m010-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/m010-out.jsonld">expand/m010-out.jsonld</a>
+              <a href='expand/m010-out.jsonld'>expand/m010-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tm011">
+        <dt id='tm011'>
           Test tm011 id map with @none
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tm011</dd>
             <dt>Type</dt>
@@ -7610,26 +7610,26 @@
             <dd>index on @id</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/m011-in.jsonld">expand/m011-in.jsonld</a>
+              <a href='expand/m011-in.jsonld'>expand/m011-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/m011-out.jsonld">expand/m011-out.jsonld</a>
+              <a href='expand/m011-out.jsonld'>expand/m011-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tm012">
+        <dt id='tm012'>
           Test tm012 type map with alias of @none
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tm012</dd>
             <dt>Type</dt>
@@ -7638,26 +7638,26 @@
             <dd>index on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/m012-in.jsonld">expand/m012-in.jsonld</a>
+              <a href='expand/m012-in.jsonld'>expand/m012-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/m012-out.jsonld">expand/m012-out.jsonld</a>
+              <a href='expand/m012-out.jsonld'>expand/m012-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tm013">
+        <dt id='tm013'>
           Test tm013 graph index map with @none
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tm013</dd>
             <dt>Type</dt>
@@ -7666,26 +7666,26 @@
             <dd>index on @graph and @index</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/m013-in.jsonld">expand/m013-in.jsonld</a>
+              <a href='expand/m013-in.jsonld'>expand/m013-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/m013-out.jsonld">expand/m013-out.jsonld</a>
+              <a href='expand/m013-out.jsonld'>expand/m013-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tm014">
+        <dt id='tm014'>
           Test tm014 graph index map with alias @none
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tm014</dd>
             <dt>Type</dt>
@@ -7694,26 +7694,26 @@
             <dd>index on @graph and @index</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/m014-in.jsonld">expand/m014-in.jsonld</a>
+              <a href='expand/m014-in.jsonld'>expand/m014-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/m014-out.jsonld">expand/m014-out.jsonld</a>
+              <a href='expand/m014-out.jsonld'>expand/m014-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tm015">
+        <dt id='tm015'>
           Test tm015 graph id index map with aliased @none
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tm015</dd>
             <dt>Type</dt>
@@ -7722,26 +7722,26 @@
             <dd>index on @graph and @id with @none</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/m015-in.jsonld">expand/m015-in.jsonld</a>
+              <a href='expand/m015-in.jsonld'>expand/m015-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/m015-out.jsonld">expand/m015-out.jsonld</a>
+              <a href='expand/m015-out.jsonld'>expand/m015-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tm016">
+        <dt id='tm016'>
           Test tm016 graph id index map with aliased @none
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tm016</dd>
             <dt>Type</dt>
@@ -7750,26 +7750,26 @@
             <dd>index on @graph and @id with @none</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/m016-in.jsonld">expand/m016-in.jsonld</a>
+              <a href='expand/m016-in.jsonld'>expand/m016-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/m016-out.jsonld">expand/m016-out.jsonld</a>
+              <a href='expand/m016-out.jsonld'>expand/m016-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tm017">
+        <dt id='tm017'>
           Test tm017 string value of type map expands to node reference
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tm017</dd>
             <dt>Type</dt>
@@ -7778,26 +7778,26 @@
             <dd>index on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/m017-in.jsonld">expand/m017-in.jsonld</a>
+              <a href='expand/m017-in.jsonld'>expand/m017-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/m017-out.jsonld">expand/m017-out.jsonld</a>
+              <a href='expand/m017-out.jsonld'>expand/m017-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tm018">
+        <dt id='tm018'>
           Test tm018 string value of type map expands to node reference with @type: @id
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tm018</dd>
             <dt>Type</dt>
@@ -7806,26 +7806,26 @@
             <dd>index on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/m018-in.jsonld">expand/m018-in.jsonld</a>
+              <a href='expand/m018-in.jsonld'>expand/m018-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/m018-out.jsonld">expand/m018-out.jsonld</a>
+              <a href='expand/m018-out.jsonld'>expand/m018-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tm019">
+        <dt id='tm019'>
           Test tm019 string value of type map expands to node reference with @type: @vocab
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tm019</dd>
             <dt>Type</dt>
@@ -7834,26 +7834,26 @@
             <dd>index on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/m019-in.jsonld">expand/m019-in.jsonld</a>
+              <a href='expand/m019-in.jsonld'>expand/m019-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/m019-out.jsonld">expand/m019-out.jsonld</a>
+              <a href='expand/m019-out.jsonld'>expand/m019-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tm020">
+        <dt id='tm020'>
           Test tm020 string value of type map must not be a literal
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tm020</dd>
             <dt>Type</dt>
@@ -7862,7 +7862,7 @@
             <dd>index on @type</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/m020-in.jsonld">expand/m020-in.jsonld</a>
+              <a href='expand/m020-in.jsonld'>expand/m020-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -7870,18 +7870,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tn001">
+        <dt id='tn001'>
           Test tn001 Expands input using @nest
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tn001</dd>
             <dt>Type</dt>
@@ -7890,26 +7890,26 @@
             <dd>Expansion using @nest</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/n001-in.jsonld">expand/n001-in.jsonld</a>
+              <a href='expand/n001-in.jsonld'>expand/n001-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/n001-out.jsonld">expand/n001-out.jsonld</a>
+              <a href='expand/n001-out.jsonld'>expand/n001-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tn002">
+        <dt id='tn002'>
           Test tn002 Expands input using aliased @nest
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tn002</dd>
             <dt>Type</dt>
@@ -7918,26 +7918,26 @@
             <dd>Expansion using @nest</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/n002-in.jsonld">expand/n002-in.jsonld</a>
+              <a href='expand/n002-in.jsonld'>expand/n002-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/n002-out.jsonld">expand/n002-out.jsonld</a>
+              <a href='expand/n002-out.jsonld'>expand/n002-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tn003">
+        <dt id='tn003'>
           Test tn003 Appends nested values when property at base and nested
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tn003</dd>
             <dt>Type</dt>
@@ -7946,26 +7946,26 @@
             <dd>Expansion using @nest</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/n003-in.jsonld">expand/n003-in.jsonld</a>
+              <a href='expand/n003-in.jsonld'>expand/n003-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/n003-out.jsonld">expand/n003-out.jsonld</a>
+              <a href='expand/n003-out.jsonld'>expand/n003-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tn004">
+        <dt id='tn004'>
           Test tn004 Appends nested values from all @nest aliases
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tn004</dd>
             <dt>Type</dt>
@@ -7974,26 +7974,26 @@
             <dd>Expansion using @nest</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/n004-in.jsonld">expand/n004-in.jsonld</a>
+              <a href='expand/n004-in.jsonld'>expand/n004-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/n004-out.jsonld">expand/n004-out.jsonld</a>
+              <a href='expand/n004-out.jsonld'>expand/n004-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tn005">
+        <dt id='tn005'>
           Test tn005 Nested nested containers
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tn005</dd>
             <dt>Type</dt>
@@ -8002,26 +8002,26 @@
             <dd>Expansion using @nest</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/n005-in.jsonld">expand/n005-in.jsonld</a>
+              <a href='expand/n005-in.jsonld'>expand/n005-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/n005-out.jsonld">expand/n005-out.jsonld</a>
+              <a href='expand/n005-out.jsonld'>expand/n005-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tn006">
+        <dt id='tn006'>
           Test tn006 Arrays of nested values
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tn006</dd>
             <dt>Type</dt>
@@ -8030,26 +8030,26 @@
             <dd>Expansion using @nest</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/n006-in.jsonld">expand/n006-in.jsonld</a>
+              <a href='expand/n006-in.jsonld'>expand/n006-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/n006-out.jsonld">expand/n006-out.jsonld</a>
+              <a href='expand/n006-out.jsonld'>expand/n006-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tn007">
+        <dt id='tn007'>
           Test tn007 A nest of arrays
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tn007</dd>
             <dt>Type</dt>
@@ -8058,26 +8058,26 @@
             <dd>Expansion using @nest</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/n007-in.jsonld">expand/n007-in.jsonld</a>
+              <a href='expand/n007-in.jsonld'>expand/n007-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/n007-out.jsonld">expand/n007-out.jsonld</a>
+              <a href='expand/n007-out.jsonld'>expand/n007-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tn008">
+        <dt id='tn008'>
           Test tn008 Multiple keys may mapping to @type when nesting
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tn008</dd>
             <dt>Type</dt>
@@ -8086,26 +8086,26 @@
             <dd>Expansion using @nest</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/n008-in.jsonld">expand/n008-in.jsonld</a>
+              <a href='expand/n008-in.jsonld'>expand/n008-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/n008-out.jsonld">expand/n008-out.jsonld</a>
+              <a href='expand/n008-out.jsonld'>expand/n008-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tp001">
+        <dt id='tp001'>
           Test tp001 @version may be specified after first context
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tp001</dd>
             <dt>Type</dt>
@@ -8114,26 +8114,26 @@
             <dd>If processing mode is not set through API, it is set by the first context containing @version.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/p001-in.jsonld">expand/p001-in.jsonld</a>
+              <a href='expand/p001-in.jsonld'>expand/p001-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/p001-out.jsonld">expand/p001-out.jsonld</a>
+              <a href='expand/p001-out.jsonld'>expand/p001-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tp002">
+        <dt id='tp002'>
           Test tp002 @version setting [1.0, 1.1, 1.0]
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tp002</dd>
             <dt>Type</dt>
@@ -8142,26 +8142,26 @@
             <dd>If processing mode is not set through API, it is set by the first context containing @version.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/p002-in.jsonld">expand/p002-in.jsonld</a>
+              <a href='expand/p002-in.jsonld'>expand/p002-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/p002-out.jsonld">expand/p002-out.jsonld</a>
+              <a href='expand/p002-out.jsonld'>expand/p002-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tp003">
+        <dt id='tp003'>
           Test tp003 @version setting [1.1, 1.0]
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tp003</dd>
             <dt>Type</dt>
@@ -8170,26 +8170,26 @@
             <dd>If processing mode is not set through API, it is set by the first context containing @version.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/p003-in.jsonld">expand/p003-in.jsonld</a>
+              <a href='expand/p003-in.jsonld'>expand/p003-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/p003-out.jsonld">expand/p003-out.jsonld</a>
+              <a href='expand/p003-out.jsonld'>expand/p003-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tp004">
+        <dt id='tp004'>
           Test tp004 @version setting [1.1, 1.0, 1.1]
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tp004</dd>
             <dt>Type</dt>
@@ -8198,26 +8198,26 @@
             <dd>If processing mode is not set through API, it is set by the first context containing @version.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/p004-in.jsonld">expand/p004-in.jsonld</a>
+              <a href='expand/p004-in.jsonld'>expand/p004-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/p004-out.jsonld">expand/p004-out.jsonld</a>
+              <a href='expand/p004-out.jsonld'>expand/p004-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpi01">
+        <dt id='tpi01'>
           Test tpi01 error if @version is json-ld-1.0 for property-valued index
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpi01</dd>
             <dt>Type</dt>
@@ -8226,7 +8226,7 @@
             <dd>Expanding index maps where index is a property.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pi01-in.jsonld">expand/pi01-in.jsonld</a>
+              <a href='expand/pi01-in.jsonld'>expand/pi01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8234,7 +8234,7 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
                 <dt>processingMode</dt>
@@ -8243,11 +8243,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="tpi02">
+        <dt id='tpi02'>
           Test tpi02 error if @container does not include @index for property-valued index
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpi02</dd>
             <dt>Type</dt>
@@ -8256,7 +8256,7 @@
             <dd>Expanding index maps where index is a property.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pi02-in.jsonld">expand/pi02-in.jsonld</a>
+              <a href='expand/pi02-in.jsonld'>expand/pi02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8264,18 +8264,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpi03">
+        <dt id='tpi03'>
           Test tpi03 error if @index is a keyword for property-valued index
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpi03</dd>
             <dt>Type</dt>
@@ -8284,7 +8284,7 @@
             <dd>Expanding index maps where index is a property.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pi03-in.jsonld">expand/pi03-in.jsonld</a>
+              <a href='expand/pi03-in.jsonld'>expand/pi03-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8292,18 +8292,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpi04">
+        <dt id='tpi04'>
           Test tpi04 error if @index is not a string for property-valued index
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpi04</dd>
             <dt>Type</dt>
@@ -8312,7 +8312,7 @@
             <dd>Expanding index maps where index is a property.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pi04-in.jsonld">expand/pi04-in.jsonld</a>
+              <a href='expand/pi04-in.jsonld'>expand/pi04-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8320,18 +8320,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpi05">
+        <dt id='tpi05'>
           Test tpi05 error if attempting to add property to value object for property-valued index
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpi05</dd>
             <dt>Type</dt>
@@ -8340,7 +8340,7 @@
             <dd>Expanding index maps where index is a property.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pi05-in.jsonld">expand/pi05-in.jsonld</a>
+              <a href='expand/pi05-in.jsonld'>expand/pi05-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8348,18 +8348,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpi06">
+        <dt id='tpi06'>
           Test tpi06 property-valued index expands to property value, instead of @index (value)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpi06</dd>
             <dt>Type</dt>
@@ -8368,26 +8368,26 @@
             <dd>Expanding index maps where index is a property.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pi06-in.jsonld">expand/pi06-in.jsonld</a>
+              <a href='expand/pi06-in.jsonld'>expand/pi06-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pi06-out.jsonld">expand/pi06-out.jsonld</a>
+              <a href='expand/pi06-out.jsonld'>expand/pi06-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpi07">
+        <dt id='tpi07'>
           Test tpi07 property-valued index appends to property value, instead of @index (value)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpi07</dd>
             <dt>Type</dt>
@@ -8396,26 +8396,26 @@
             <dd>Expanding index maps where index is a property.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pi07-in.jsonld">expand/pi07-in.jsonld</a>
+              <a href='expand/pi07-in.jsonld'>expand/pi07-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pi07-out.jsonld">expand/pi07-out.jsonld</a>
+              <a href='expand/pi07-out.jsonld'>expand/pi07-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpi08">
+        <dt id='tpi08'>
           Test tpi08 property-valued index expands to property value, instead of @index (node)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpi08</dd>
             <dt>Type</dt>
@@ -8424,26 +8424,26 @@
             <dd>Expanding index maps where index is a property.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pi08-in.jsonld">expand/pi08-in.jsonld</a>
+              <a href='expand/pi08-in.jsonld'>expand/pi08-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pi08-out.jsonld">expand/pi08-out.jsonld</a>
+              <a href='expand/pi08-out.jsonld'>expand/pi08-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpi09">
+        <dt id='tpi09'>
           Test tpi09 property-valued index appends to property value, instead of @index (node)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpi09</dd>
             <dt>Type</dt>
@@ -8452,26 +8452,26 @@
             <dd>Expanding index maps where index is a property.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pi09-in.jsonld">expand/pi09-in.jsonld</a>
+              <a href='expand/pi09-in.jsonld'>expand/pi09-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pi09-out.jsonld">expand/pi09-out.jsonld</a>
+              <a href='expand/pi09-out.jsonld'>expand/pi09-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpi10">
+        <dt id='tpi10'>
           Test tpi10 property-valued index does not output property for @none
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpi10</dd>
             <dt>Type</dt>
@@ -8480,26 +8480,26 @@
             <dd>Expanding index maps where index is a property.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pi10-in.jsonld">expand/pi10-in.jsonld</a>
+              <a href='expand/pi10-in.jsonld'>expand/pi10-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pi10-out.jsonld">expand/pi10-out.jsonld</a>
+              <a href='expand/pi10-out.jsonld'>expand/pi10-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpi11">
+        <dt id='tpi11'>
           Test tpi11 property-valued index adds property to graph object
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpi11</dd>
             <dt>Type</dt>
@@ -8508,26 +8508,26 @@
             <dd>Expanding index maps where index is a property.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pi11-in.jsonld">expand/pi11-in.jsonld</a>
+              <a href='expand/pi11-in.jsonld'>expand/pi11-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pi11-out.jsonld">expand/pi11-out.jsonld</a>
+              <a href='expand/pi11-out.jsonld'>expand/pi11-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr01">
+        <dt id='tpr01'>
           Test tpr01 Protect a term
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr01</dd>
             <dt>Type</dt>
@@ -8536,7 +8536,7 @@
             <dd>Check error when overriding a protected term.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr01-in.jsonld">expand/pr01-in.jsonld</a>
+              <a href='expand/pr01-in.jsonld'>expand/pr01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8544,18 +8544,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr02">
+        <dt id='tpr02'>
           Test tpr02 Set a term to not be protected
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr02</dd>
             <dt>Type</dt>
@@ -8564,26 +8564,26 @@
             <dd>A term with @protected: false is not protected.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr02-in.jsonld">expand/pr02-in.jsonld</a>
+              <a href='expand/pr02-in.jsonld'>expand/pr02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pr02-out.jsonld">expand/pr02-out.jsonld</a>
+              <a href='expand/pr02-out.jsonld'>expand/pr02-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr03">
+        <dt id='tpr03'>
           Test tpr03 Protect all terms in context
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr03</dd>
             <dt>Type</dt>
@@ -8592,7 +8592,7 @@
             <dd>A protected context protects all term definitions.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr03-in.jsonld">expand/pr03-in.jsonld</a>
+              <a href='expand/pr03-in.jsonld'>expand/pr03-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8600,18 +8600,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr04">
+        <dt id='tpr04'>
           Test tpr04 Do not protect term with @protected: false
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr04</dd>
             <dt>Type</dt>
@@ -8620,7 +8620,7 @@
             <dd>A protected context does not protect terms with @protected: false.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr04-in.jsonld">expand/pr04-in.jsonld</a>
+              <a href='expand/pr04-in.jsonld'>expand/pr04-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8628,18 +8628,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr05">
+        <dt id='tpr05'>
           Test tpr05 Clear active context with protected terms from an embedded context
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr05</dd>
             <dt>Type</dt>
@@ -8648,7 +8648,7 @@
             <dd>The Active context be set to null from an embedded context.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr05-in.jsonld">expand/pr05-in.jsonld</a>
+              <a href='expand/pr05-in.jsonld'>expand/pr05-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8656,18 +8656,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr06">
+        <dt id='tpr06'>
           Test tpr06 Clear active context of protected terms from a term.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr06</dd>
             <dt>Type</dt>
@@ -8676,26 +8676,26 @@
             <dd>The Active context may be set to null from a scoped context of a term.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr06-in.jsonld">expand/pr06-in.jsonld</a>
+              <a href='expand/pr06-in.jsonld'>expand/pr06-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pr06-out.jsonld">expand/pr06-out.jsonld</a>
+              <a href='expand/pr06-out.jsonld'>expand/pr06-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr08">
+        <dt id='tpr08'>
           Test tpr08 Term with protected scoped context.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr08</dd>
             <dt>Type</dt>
@@ -8704,7 +8704,7 @@
             <dd>A scoped context can protect terms.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr08-in.jsonld">expand/pr08-in.jsonld</a>
+              <a href='expand/pr08-in.jsonld'>expand/pr08-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8712,18 +8712,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr09">
+        <dt id='tpr09'>
           Test tpr09 Attempt to redefine term in other protected context.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr09</dd>
             <dt>Type</dt>
@@ -8732,7 +8732,7 @@
             <dd>A protected term cannot redefine another protected term.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr09-in.jsonld">expand/pr09-in.jsonld</a>
+              <a href='expand/pr09-in.jsonld'>expand/pr09-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8740,18 +8740,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr10">
+        <dt id='tpr10'>
           Test tpr10 Simple protected and unprotected terms.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr10</dd>
             <dt>Type</dt>
@@ -8760,26 +8760,26 @@
             <dd>Simple protected and unprotected terms.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr10-in.jsonld">expand/pr10-in.jsonld</a>
+              <a href='expand/pr10-in.jsonld'>expand/pr10-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pr10-out.jsonld">expand/pr10-out.jsonld</a>
+              <a href='expand/pr10-out.jsonld'>expand/pr10-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr11">
+        <dt id='tpr11'>
           Test tpr11 Fail to override protected term.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr11</dd>
             <dt>Type</dt>
@@ -8788,7 +8788,7 @@
             <dd>Fail to override protected term.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr11-in.jsonld">expand/pr11-in.jsonld</a>
+              <a href='expand/pr11-in.jsonld'>expand/pr11-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8796,18 +8796,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr12">
+        <dt id='tpr12'>
           Test tpr12 Scoped context fail to override protected term.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr12</dd>
             <dt>Type</dt>
@@ -8816,7 +8816,7 @@
             <dd>Scoped context fail to override protected term.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr12-in.jsonld">expand/pr12-in.jsonld</a>
+              <a href='expand/pr12-in.jsonld'>expand/pr12-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8824,18 +8824,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr13">
+        <dt id='tpr13'>
           Test tpr13 Override unprotected term.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr13</dd>
             <dt>Type</dt>
@@ -8844,26 +8844,26 @@
             <dd>Override unprotected term.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr13-in.jsonld">expand/pr13-in.jsonld</a>
+              <a href='expand/pr13-in.jsonld'>expand/pr13-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pr13-out.jsonld">expand/pr13-out.jsonld</a>
+              <a href='expand/pr13-out.jsonld'>expand/pr13-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr14">
+        <dt id='tpr14'>
           Test tpr14 Clear protection with null context.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr14</dd>
             <dt>Type</dt>
@@ -8872,26 +8872,26 @@
             <dd>Clear protection with null context.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr14-in.jsonld">expand/pr14-in.jsonld</a>
+              <a href='expand/pr14-in.jsonld'>expand/pr14-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pr14-out.jsonld">expand/pr14-out.jsonld</a>
+              <a href='expand/pr14-out.jsonld'>expand/pr14-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr15">
+        <dt id='tpr15'>
           Test tpr15 Clear protection with array with null context
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr15</dd>
             <dt>Type</dt>
@@ -8900,26 +8900,26 @@
             <dd>Clear protection with array with null context</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr15-in.jsonld">expand/pr15-in.jsonld</a>
+              <a href='expand/pr15-in.jsonld'>expand/pr15-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pr15-out.jsonld">expand/pr15-out.jsonld</a>
+              <a href='expand/pr15-out.jsonld'>expand/pr15-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr16">
+        <dt id='tpr16'>
           Test tpr16 Override protected terms after null.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr16</dd>
             <dt>Type</dt>
@@ -8928,26 +8928,26 @@
             <dd>Override protected terms after null.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr16-in.jsonld">expand/pr16-in.jsonld</a>
+              <a href='expand/pr16-in.jsonld'>expand/pr16-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pr16-out.jsonld">expand/pr16-out.jsonld</a>
+              <a href='expand/pr16-out.jsonld'>expand/pr16-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr17">
+        <dt id='tpr17'>
           Test tpr17 Fail to override protected terms with type.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr17</dd>
             <dt>Type</dt>
@@ -8956,7 +8956,7 @@
             <dd>Fail to override protected terms with type.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr17-in.jsonld">expand/pr17-in.jsonld</a>
+              <a href='expand/pr17-in.jsonld'>expand/pr17-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8964,18 +8964,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr18">
+        <dt id='tpr18'>
           Test tpr18 Fail to override protected terms with type+null+ctx.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr18</dd>
             <dt>Type</dt>
@@ -8984,7 +8984,7 @@
             <dd>Fail to override protected terms with type+null+ctx.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr18-in.jsonld">expand/pr18-in.jsonld</a>
+              <a href='expand/pr18-in.jsonld'>expand/pr18-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -8992,18 +8992,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr19">
+        <dt id='tpr19'>
           Test tpr19 Mix of protected and unprotected terms.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr19</dd>
             <dt>Type</dt>
@@ -9012,26 +9012,26 @@
             <dd>Mix of protected and unprotected terms.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr19-in.jsonld">expand/pr19-in.jsonld</a>
+              <a href='expand/pr19-in.jsonld'>expand/pr19-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pr19-out.jsonld">expand/pr19-out.jsonld</a>
+              <a href='expand/pr19-out.jsonld'>expand/pr19-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr20">
+        <dt id='tpr20'>
           Test tpr20 Fail with mix of protected and unprotected terms with type+null+ctx.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr20</dd>
             <dt>Type</dt>
@@ -9040,7 +9040,7 @@
             <dd>Fail with mix of protected and unprotected terms with type+null+ctx.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr20-in.jsonld">expand/pr20-in.jsonld</a>
+              <a href='expand/pr20-in.jsonld'>expand/pr20-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9048,18 +9048,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr21">
+        <dt id='tpr21'>
           Test tpr21 Fail with mix of protected and unprotected terms with type+null.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr21</dd>
             <dt>Type</dt>
@@ -9068,7 +9068,7 @@
             <dd>Fail with mix of protected and unprotected terms with type+null.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr21-in.jsonld">expand/pr21-in.jsonld</a>
+              <a href='expand/pr21-in.jsonld'>expand/pr21-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9076,18 +9076,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr22">
+        <dt id='tpr22'>
           Test tpr22 Check legal overriding of type-scoped protected term from nested node.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr22</dd>
             <dt>Type</dt>
@@ -9096,26 +9096,26 @@
             <dd>Check legal overriding of type-scoped protected term from nested node.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr22-in.jsonld">expand/pr22-in.jsonld</a>
+              <a href='expand/pr22-in.jsonld'>expand/pr22-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pr22-out.jsonld">expand/pr22-out.jsonld</a>
+              <a href='expand/pr22-out.jsonld'>expand/pr22-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr23">
+        <dt id='tpr23'>
           Test tpr23 Allows redefinition of protected alias term with same definition.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr23</dd>
             <dt>Type</dt>
@@ -9124,26 +9124,26 @@
             <dd>Allows redefinition of protected alias term with same definition.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr23-in.jsonld">expand/pr23-in.jsonld</a>
+              <a href='expand/pr23-in.jsonld'>expand/pr23-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pr23-out.jsonld">expand/pr23-out.jsonld</a>
+              <a href='expand/pr23-out.jsonld'>expand/pr23-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr24">
+        <dt id='tpr24'>
           Test tpr24 Allows redefinition of protected prefix term with same definition.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr24</dd>
             <dt>Type</dt>
@@ -9152,26 +9152,26 @@
             <dd>Allows redefinition of protected prefix term with same definition.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr24-in.jsonld">expand/pr24-in.jsonld</a>
+              <a href='expand/pr24-in.jsonld'>expand/pr24-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pr24-out.jsonld">expand/pr24-out.jsonld</a>
+              <a href='expand/pr24-out.jsonld'>expand/pr24-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr25">
+        <dt id='tpr25'>
           Test tpr25 Allows redefinition of terms with scoped contexts using same definitions.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr25</dd>
             <dt>Type</dt>
@@ -9180,26 +9180,26 @@
             <dd>Allows redefinition of terms with scoped contexts using same definitions.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr25-in.jsonld">expand/pr25-in.jsonld</a>
+              <a href='expand/pr25-in.jsonld'>expand/pr25-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pr25-out.jsonld">expand/pr25-out.jsonld</a>
+              <a href='expand/pr25-out.jsonld'>expand/pr25-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr26">
+        <dt id='tpr26'>
           Test tpr26 Fails on redefinition of terms with scoped contexts using different definitions.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr26</dd>
             <dt>Type</dt>
@@ -9208,7 +9208,7 @@
             <dd>Fails on redefinition of terms with scoped contexts using different definitions.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr26-in.jsonld">expand/pr26-in.jsonld</a>
+              <a href='expand/pr26-in.jsonld'>expand/pr26-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9216,18 +9216,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr27">
+        <dt id='tpr27'>
           Test tpr27 Allows redefinition of protected alias term with same definition modulo protected flag.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr27</dd>
             <dt>Type</dt>
@@ -9236,26 +9236,26 @@
             <dd>Allows redefinition of protected alias term with same definition modulo protected flag.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr27-in.jsonld">expand/pr27-in.jsonld</a>
+              <a href='expand/pr27-in.jsonld'>expand/pr27-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pr27-out.jsonld">expand/pr27-out.jsonld</a>
+              <a href='expand/pr27-out.jsonld'>expand/pr27-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr28">
+        <dt id='tpr28'>
           Test tpr28 Fails if trying to redefine a protected null term.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr28</dd>
             <dt>Type</dt>
@@ -9264,7 +9264,7 @@
             <dd>A protected term with a null IRI mapping cannot be redefined.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr28-in.jsonld">expand/pr28-in.jsonld</a>
+              <a href='expand/pr28-in.jsonld'>expand/pr28-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9272,18 +9272,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr29">
+        <dt id='tpr29'>
           Test tpr29 Does not expand a Compact IRI using a non-prefix term.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr29</dd>
             <dt>Type</dt>
@@ -9292,26 +9292,26 @@
             <dd>Expansion of Compact IRIs considers if the term can be used as a prefix.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr29-in.jsonld">expand/pr29-in.jsonld</a>
+              <a href='expand/pr29-in.jsonld'>expand/pr29-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pr29-out.jsonld">expand/pr29-out.jsonld</a>
+              <a href='expand/pr29-out.jsonld'>expand/pr29-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr30">
+        <dt id='tpr30'>
           Test tpr30 Keywords may be protected.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr30</dd>
             <dt>Type</dt>
@@ -9320,26 +9320,26 @@
             <dd>Keywords may not be redefined other than to protect them.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr30-in.jsonld">expand/pr30-in.jsonld</a>
+              <a href='expand/pr30-in.jsonld'>expand/pr30-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pr30-out.jsonld">expand/pr30-out.jsonld</a>
+              <a href='expand/pr30-out.jsonld'>expand/pr30-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr31">
+        <dt id='tpr31'>
           Test tpr31 Protected keyword aliases cannot be overridden.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr31</dd>
             <dt>Type</dt>
@@ -9348,7 +9348,7 @@
             <dd>Keywords may not be redefined other than to protect them.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr31-in.jsonld">expand/pr31-in.jsonld</a>
+              <a href='expand/pr31-in.jsonld'>expand/pr31-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9356,18 +9356,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr32">
+        <dt id='tpr32'>
           Test tpr32 Protected @type cannot be overridden.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr32</dd>
             <dt>Type</dt>
@@ -9376,7 +9376,7 @@
             <dd>Keywords may not be redefined other than to protect them.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr32-in.jsonld">expand/pr32-in.jsonld</a>
+              <a href='expand/pr32-in.jsonld'>expand/pr32-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9384,18 +9384,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr33">
+        <dt id='tpr33'>
           Test tpr33 Fails if trying to declare a keyword alias as prefix.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr33</dd>
             <dt>Type</dt>
@@ -9404,7 +9404,7 @@
             <dd>Keyword aliases can not be used as prefixes.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr33-in.jsonld">expand/pr33-in.jsonld</a>
+              <a href='expand/pr33-in.jsonld'>expand/pr33-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9412,18 +9412,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr34">
+        <dt id='tpr34'>
           Test tpr34 Ignores a non-keyword term starting with &#39;@&#39;
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr34</dd>
             <dt>Type</dt>
@@ -9432,26 +9432,26 @@
             <dd>Terms in the form of a keyword, which are not keywords, are ignored.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr34-in.jsonld">expand/pr34-in.jsonld</a>
+              <a href='expand/pr34-in.jsonld'>expand/pr34-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pr34-out.jsonld">expand/pr34-out.jsonld</a>
+              <a href='expand/pr34-out.jsonld'>expand/pr34-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr35">
+        <dt id='tpr35'>
           Test tpr35 Ignores a non-keyword term starting with &#39;@&#39; (with @vocab)
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr35</dd>
             <dt>Type</dt>
@@ -9460,26 +9460,26 @@
             <dd>Terms in the form of a keyword, which are not keywords, are ignored.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr35-in.jsonld">expand/pr35-in.jsonld</a>
+              <a href='expand/pr35-in.jsonld'>expand/pr35-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pr35-out.jsonld">expand/pr35-out.jsonld</a>
+              <a href='expand/pr35-out.jsonld'>expand/pr35-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr36">
+        <dt id='tpr36'>
           Test tpr36 Ignores a term mapping to a value in the form of a keyword.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr36</dd>
             <dt>Type</dt>
@@ -9488,26 +9488,26 @@
             <dd>Terms in the form of a keyword, which are not keywords, are ignored.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr36-in.jsonld">expand/pr36-in.jsonld</a>
+              <a href='expand/pr36-in.jsonld'>expand/pr36-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pr36-out.jsonld">expand/pr36-out.jsonld</a>
+              <a href='expand/pr36-out.jsonld'>expand/pr36-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr37">
+        <dt id='tpr37'>
           Test tpr37 Ignores a term mapping to a value in the form of a keyword (with @vocab).
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr37</dd>
             <dt>Type</dt>
@@ -9516,26 +9516,26 @@
             <dd>Terms in the form of a keyword, which are not keywords, are ignored.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr37-in.jsonld">expand/pr37-in.jsonld</a>
+              <a href='expand/pr37-in.jsonld'>expand/pr37-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pr37-out.jsonld">expand/pr37-out.jsonld</a>
+              <a href='expand/pr37-out.jsonld'>expand/pr37-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr38">
+        <dt id='tpr38'>
           Test tpr38 Ignores a term mapping to a value in the form of a keyword (@reverse).
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr38</dd>
             <dt>Type</dt>
@@ -9544,26 +9544,26 @@
             <dd>Terms in the form of a keyword, which are not keywords, are ignored.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr38-in.jsonld">expand/pr38-in.jsonld</a>
+              <a href='expand/pr38-in.jsonld'>expand/pr38-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pr38-out.jsonld">expand/pr38-out.jsonld</a>
+              <a href='expand/pr38-out.jsonld'>expand/pr38-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr39">
+        <dt id='tpr39'>
           Test tpr39 Ignores a term mapping to a value in the form of a keyword (@reverse with @vocab).
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr39</dd>
             <dt>Type</dt>
@@ -9572,26 +9572,26 @@
             <dd>Terms in the form of a keyword, which are not keywords, are ignored.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr39-in.jsonld">expand/pr39-in.jsonld</a>
+              <a href='expand/pr39-in.jsonld'>expand/pr39-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pr39-out.jsonld">expand/pr39-out.jsonld</a>
+              <a href='expand/pr39-out.jsonld'>expand/pr39-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr40">
+        <dt id='tpr40'>
           Test tpr40 Protected terms and property-scoped contexts
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr40</dd>
             <dt>Type</dt>
@@ -9600,26 +9600,26 @@
             <dd>Check overriding of protected term from property-scoped context.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr40-in.jsonld">expand/pr40-in.jsonld</a>
+              <a href='expand/pr40-in.jsonld'>expand/pr40-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pr40-out.jsonld">expand/pr40-out.jsonld</a>
+              <a href='expand/pr40-out.jsonld'>expand/pr40-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr41">
+        <dt id='tpr41'>
           Test tpr41 Allows protected redefinition of equivalent id terms
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr41</dd>
             <dt>Type</dt>
@@ -9628,26 +9628,26 @@
             <dd>Check protected redefinition of equivalent id terms in different forms.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr41-in.jsonld">expand/pr41-in.jsonld</a>
+              <a href='expand/pr41-in.jsonld'>expand/pr41-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pr41-out.jsonld">expand/pr41-out.jsonld</a>
+              <a href='expand/pr41-out.jsonld'>expand/pr41-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr42">
+        <dt id='tpr42'>
           Test tpr42 Fail if protected flag not retained during redefinition
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr42</dd>
             <dt>Type</dt>
@@ -9656,7 +9656,7 @@
             <dd>Check protected redefinition retains protected flag.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr42-in.jsonld">expand/pr42-in.jsonld</a>
+              <a href='expand/pr42-in.jsonld'>expand/pr42-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9664,18 +9664,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tpr43">
+        <dt id='tpr43'>
           Test tpr43 Clear protection in @graph @container with null context.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tpr43</dd>
             <dt>Type</dt>
@@ -9684,26 +9684,26 @@
             <dd>Clear protection in @graph @container with null context.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/pr43-in.jsonld">expand/pr43-in.jsonld</a>
+              <a href='expand/pr43-in.jsonld'>expand/pr43-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/pr43-out.jsonld">expand/pr43-out.jsonld</a>
+              <a href='expand/pr43-out.jsonld'>expand/pr43-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tso01">
+        <dt id='tso01'>
           Test tso01 @import is invalid in 1.0.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tso01</dd>
             <dt>Type</dt>
@@ -9712,7 +9712,7 @@
             <dd>@import is invalid in 1.0.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/so01-in.jsonld">expand/so01-in.jsonld</a>
+              <a href='expand/so01-in.jsonld'>expand/so01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9720,7 +9720,7 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
                 <dt>processingMode</dt>
@@ -9729,11 +9729,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="tso02">
+        <dt id='tso02'>
           Test tso02 @import must be a string
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tso02</dd>
             <dt>Type</dt>
@@ -9742,7 +9742,7 @@
             <dd>@import must be a string.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/so02-in.jsonld">expand/so02-in.jsonld</a>
+              <a href='expand/so02-in.jsonld'>expand/so02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9750,18 +9750,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tso03">
+        <dt id='tso03'>
           Test tso03 @import overflow
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tso03</dd>
             <dt>Type</dt>
@@ -9770,7 +9770,7 @@
             <dd>Processors must detect source contexts that include @import.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/so03-in.jsonld">expand/so03-in.jsonld</a>
+              <a href='expand/so03-in.jsonld'>expand/so03-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9778,18 +9778,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tso05">
+        <dt id='tso05'>
           Test tso05 @propagate: true on type-scoped context with @import
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tso05</dd>
             <dt>Type</dt>
@@ -9798,26 +9798,26 @@
             <dd>type-scoped context with @propagate: true survive node-objects (with @import)</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/so05-in.jsonld">expand/so05-in.jsonld</a>
+              <a href='expand/so05-in.jsonld'>expand/so05-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/so05-out.jsonld">expand/so05-out.jsonld</a>
+              <a href='expand/so05-out.jsonld'>expand/so05-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tso06">
+        <dt id='tso06'>
           Test tso06 @propagate: false on property-scoped context with @import
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tso06</dd>
             <dt>Type</dt>
@@ -9826,26 +9826,26 @@
             <dd>property-scoped context with @propagate: false do not survive node-objects (with @import)</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/so06-in.jsonld">expand/so06-in.jsonld</a>
+              <a href='expand/so06-in.jsonld'>expand/so06-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/so06-out.jsonld">expand/so06-out.jsonld</a>
+              <a href='expand/so06-out.jsonld'>expand/so06-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tso07">
+        <dt id='tso07'>
           Test tso07 Protect all terms in sourced context
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tso07</dd>
             <dt>Type</dt>
@@ -9854,7 +9854,7 @@
             <dd>A protected context protects all term definitions.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/so07-in.jsonld">expand/so07-in.jsonld</a>
+              <a href='expand/so07-in.jsonld'>expand/so07-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9862,18 +9862,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tso08">
+        <dt id='tso08'>
           Test tso08 Override term defined in sourced context
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tso08</dd>
             <dt>Type</dt>
@@ -9882,26 +9882,26 @@
             <dd>The containing context is merged into the source context.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/so08-in.jsonld">expand/so08-in.jsonld</a>
+              <a href='expand/so08-in.jsonld'>expand/so08-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/so08-out.jsonld">expand/so08-out.jsonld</a>
+              <a href='expand/so08-out.jsonld'>expand/so08-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tso09">
+        <dt id='tso09'>
           Test tso09 Override @vocab defined in sourced context
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tso09</dd>
             <dt>Type</dt>
@@ -9910,26 +9910,26 @@
             <dd>The containing context is merged into the source context.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/so09-in.jsonld">expand/so09-in.jsonld</a>
+              <a href='expand/so09-in.jsonld'>expand/so09-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/so09-out.jsonld">expand/so09-out.jsonld</a>
+              <a href='expand/so09-out.jsonld'>expand/so09-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tso10">
+        <dt id='tso10'>
           Test tso10 Protect terms in sourced context
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tso10</dd>
             <dt>Type</dt>
@@ -9938,7 +9938,7 @@
             <dd>The containing context is merged into the source context.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/so10-in.jsonld">expand/so10-in.jsonld</a>
+              <a href='expand/so10-in.jsonld'>expand/so10-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -9946,18 +9946,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tso11">
+        <dt id='tso11'>
           Test tso11 Override protected terms in sourced context
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tso11</dd>
             <dt>Type</dt>
@@ -9966,26 +9966,26 @@
             <dd>The containing context is merged into the source context.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/so11-in.jsonld">expand/so11-in.jsonld</a>
+              <a href='expand/so11-in.jsonld'>expand/so11-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/so11-out.jsonld">expand/so11-out.jsonld</a>
+              <a href='expand/so11-out.jsonld'>expand/so11-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tso12">
+        <dt id='tso12'>
           Test tso12 @import may not be used in an imported context.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tso12</dd>
             <dt>Type</dt>
@@ -9994,7 +9994,7 @@
             <dd>@import only valid within a term definition.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/so12-in.jsonld">expand/so12-in.jsonld</a>
+              <a href='expand/so12-in.jsonld'>expand/so12-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -10002,18 +10002,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="tso13">
+        <dt id='tso13'>
           Test tso13 @import can only reference a single context
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#tso13</dd>
             <dt>Type</dt>
@@ -10022,7 +10022,7 @@
             <dd>@import can only reference a single context.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/so13-in.jsonld">expand/so13-in.jsonld</a>
+              <a href='expand/so13-in.jsonld'>expand/so13-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -10030,18 +10030,18 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>
             </dd>
           </dl>
         </dd>
-        <dt id="ttn01">
+        <dt id='ttn01'>
           Test ttn01 @type: @none is illegal in 1.0.
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ttn01</dd>
             <dt>Type</dt>
@@ -10050,7 +10050,7 @@
             <dd>@type: @none is illegal in json-ld-1.0.</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/tn01-in.jsonld">expand/tn01-in.jsonld</a>
+              <a href='expand/tn01-in.jsonld'>expand/tn01-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
@@ -10058,7 +10058,7 @@
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
                 <dt>processingMode</dt>
@@ -10067,11 +10067,11 @@
             </dd>
           </dl>
         </dd>
-        <dt id="ttn02">
+        <dt id='ttn02'>
           Test ttn02 @type: @none expands strings as value objects
         </dt>
         <dd>
-          <dl class="entry">
+          <dl class='entry'>
             <dt>id</dt>
             <dd>#ttn02</dd>
             <dt>Type</dt>
@@ -10080,15 +10080,15 @@
             <dd>@type: @none leaves inputs other than strings alone</dd>
             <dt>input</dt>
             <dd>
-              <a href="expand/tn02-in.jsonld">expand/tn02-in.jsonld</a>
+              <a href='expand/tn02-in.jsonld'>expand/tn02-in.jsonld</a>
             </dd>
             <dt>expect</dt>
             <dd>
-              <a href="expand/tn02-out.jsonld">expand/tn02-out.jsonld</a>
+              <a href='expand/tn02-out.jsonld'>expand/tn02-out.jsonld</a>
             </dd>
             <dt>Options</dt>
             <dd>
-              <dl class="options">
+              <dl class='options'>
                 <dt>specVersion</dt>
                 <dd>json-ld-1.1</dd>
               </dl>

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -991,7 +991,7 @@
       "@id": "#t0132",
       "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "@base does not expand property keys",
-      "purpose": "Property keys are expanded vocabulary-relative (@vocab, term definitions, compact IRIs with a defined prefix). @base is for document-relative IRI resolution where the algorithms pass that flag (e.g. certain @id and @type values), not for unmapped simple keys. With only @base set, an unmapped key like name has no vocabulary mapping and must be dropped; a relative @type token still resolves against the base. See IRI Expansion in the JSON-LD 1.1 Processing Algorithms and API.",
+      "purpose": "Property keys are expanded vocabulary-relative (`@vocab`, term definitions, compact IRIs with a defined prefix). `@base` is for document-relative IRI resolution where the algorithms pass that flag (e.g., certain `@id` and `@type` values), not for unmapped simple keys. With only `@base` set, an unmapped key like `name` has no vocabulary mapping and must be dropped; a relative `@type` token still resolves against the base. See IRI Expansion in the JSON-LD 1.1 Processing Algorithms and API.",
       "input": "expand/0132-in.jsonld",
       "expect": "expand/0132-out.jsonld",
       "option": {"specVersion": "json-ld-1.1"}

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -988,6 +988,14 @@
       "expect": "expand/0131-out.jsonld",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#t0132",
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
+      "name": "@base does not expand property keys",
+      "purpose": "Property keys are expanded vocabulary-relative (`@vocab`, term definitions, compact IRIs with a defined prefix). `@base` is for document-relative IRI resolution where the algorithms pass that flag (e.g., certain `@id` and `@type` values), not for unmapped simple keys. With only `@base` set, an unmapped key like `name` has no vocabulary mapping and must be dropped; a relative `@type` token still resolves against the base. See IRI Expansion in the JSON-LD 1.1 Processing Algorithms and API.",
+      "input": "expand/0132-in.jsonld",
+      "expect": "expand/0132-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tc001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "adding new term",

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -988,6 +988,14 @@
       "expect": "expand/0131-out.jsonld",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#t0132",
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
+      "name": "@base does not expand property keys",
+      "purpose": "Property keys are expanded vocabulary-relative (@vocab, term definitions, compact IRIs with a defined prefix). @base is for document-relative IRI resolution where the algorithms pass that flag (e.g. certain @id and @type values), not for unmapped simple keys. With only @base set, an unmapped key like name has no vocabulary mapping and must be dropped; a relative @type token still resolves against the base. See IRI Expansion in the JSON-LD 1.1 Processing Algorithms and API.",
+      "input": "expand/0132-in.jsonld",
+      "expect": "expand/0132-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tc001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "adding new term",

--- a/tests/expand/0132-in.jsonld
+++ b/tests/expand/0132-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@base": "https://example.org/vocab/base/"
+  },
+  "@id": "https://example.org/doc",
+  "@type": "Thing",
+  "name": "value"
+}

--- a/tests/expand/0132-out.jsonld
+++ b/tests/expand/0132-out.jsonld
@@ -1,0 +1,4 @@
+[{
+  "@id": "https://example.org/doc",
+  "@type": ["https://example.org/vocab/base/Thing"]
+}]

--- a/tests/fromRdf-manifest.html
+++ b/tests/fromRdf-manifest.html
@@ -676,6 +676,34 @@
             </dd>
           </dl>
         </dd>
+        <dt id='t0028'>
+          Test t0028 use native types flag with non-native values
+        </dt>
+        <dd>
+          <dl class='entry'>
+            <dt>id</dt>
+            <dd>#t0028</dd>
+            <dt>Type</dt>
+            <dd>jld:PositiveEvaluationTest, jld:FromRDFTest</dd>
+            <dt>Purpose</dt>
+            <dd>Ensure that useNativeTypes flag being true does not interfere with values that cannot be serialized into a native value.</dd>
+            <dt>input</dt>
+            <dd>
+              <a href='fromRdf/0028-in.nq'>fromRdf/0028-in.nq</a>
+            </dd>
+            <dt>expect</dt>
+            <dd>
+              <a href='fromRdf/0028-out.jsonld'>fromRdf/0028-out.jsonld</a>
+            </dd>
+            <dt>Options</dt>
+            <dd>
+              <dl class='options'>
+                <dt>useNativeTypes</dt>
+                <dd>true</dd>
+              </dl>
+            </dd>
+          </dl>
+        </dd>
         <dt id='tdi01'>
           Test tdi01 rdfDirection: null with i18n literal with direction and no language
         </dt>


### PR DESCRIPTION
## Summary

Adds **ExpandTest** `#t0132`: with a context that sets only `@base` (and `@version` 1.1), an unmapped simple property key like `name` is **dropped**, while a relative `@type` token still resolves against that base ([IRI Expansion](https://www.w3.org/TR/json-ld11-api/#iri-expansion)).

## Files

- `tests/expand/0132-in.jsonld`, `tests/expand/0132-out.jsonld`
- `tests/expand-manifest.jsonld` — new sequence entry after `#t0131`
- `tests/expand-manifest.html` — regenerated (Haml + HtmlBeautifier; `bundle exec rake` was not runnable here without libyaml-dev; same pipeline as `tests/Rakefile`)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/pull/686.html" title="Last updated on Apr 17, 2026, 7:40 AM UTC (8fbed33)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-api/686/590f78d...8fbed33.html" title="Last updated on Apr 17, 2026, 7:40 AM UTC (8fbed33)">Diff</a>