### PR TITLE
Add nested scoped context expansion test

### DIFF
--- a/tests/expand-manifest.html
+++ b/tests/expand-manifest.html
@@ -9671,6 +9671,34 @@
             </dd>
           </dl>
         </dd>
+        <dt id='tpr44'>
+          Test tpr44 Property-scoped context on @nest applies before nested type-scoped context.
+        </dt>
+        <dd>
+          <dl class='entry'>
+            <dt>id</dt>
+            <dd>#tpr44</dd>
+            <dt>Type</dt>
+            <dd>jld:PositiveEvaluationTest, jld:ExpandTest</dd>
+            <dt>Purpose</dt>
+            <dd>A property-scoped context on an @nest term applies before expanding @type and type-scoped terms in the nested node.</dd>
+            <dt>input</dt>
+            <dd>
+              <a href='expand/pr44-in.jsonld'>expand/pr44-in.jsonld</a>
+            </dd>
+            <dt>expect</dt>
+            <dd>
+              <a href='expand/pr44-out.jsonld'>expand/pr44-out.jsonld</a>
+            </dd>
+            <dt>Options</dt>
+            <dd>
+              <dl class='options'>
+                <dt>specVersion</dt>
+                <dd>json-ld-1.1</dd>
+              </dl>
+            </dd>
+          </dl>
+        </dd>
         <dt id='tso01'>
           Test tso01 @import is invalid in 1.0.
         </dt>

--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -2868,6 +2868,14 @@
       "input": "expand/pr43-in.jsonld",
       "expect": "expand/pr43-out.jsonld"
     }, {
+      "@id": "#tpr44",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Property-scoped context on @nest applies before nested type-scoped context.",
+      "purpose": "A property-scoped context on an @nest term applies before expanding @type and type-scoped terms in the nested node.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand/pr44-in.jsonld",
+      "expect": "expand/pr44-out.jsonld"
+    }, {
       "@id": "#tso01",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "@import is invalid in 1.0.",

--- a/tests/expand/pr44-in.jsonld
+++ b/tests/expand/pr44-in.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/outer#",
+    "p1": {
+      "@id": "@nest",
+      "@context": {
+        "Type": {
+          "@id": "http://example.org/ns#Type",
+          "@context": {
+            "p2": "http://example.org/ns#P2"
+          }
+        }
+      }
+    }
+  },
+  "p1": {
+    "@type": "Type",
+    "p2": "foo"
+  }
+}

--- a/tests/expand/pr44-out.jsonld
+++ b/tests/expand/pr44-out.jsonld
@@ -1,0 +1,12 @@
+[
+  {
+    "@type": [
+      "http://example.org/ns#Type"
+    ],
+    "http://example.org/ns#P2": [
+      {
+        "@value": "foo"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Adds an expansion test covering an @nest term with a property-scoped context that defines a type with its own type-scoped context.\n\nThis test was propagated from digitalbazaar/pyld#263 to cover nested node expansion where the @nest scoped context must be active before @type and type-scoped terms are expanded.