### PR TITLE
expansion: add test for default language

### DIFF
--- a/tests/expand-manifest.jsonld
+++ b/tests/expand-manifest.jsonld
@@ -988,6 +988,14 @@
       "expect": "expand/0131-out.jsonld",
       "option": {"specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#t0133",
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
+      "name": "String value with type mapping and default @language",
+      "purpose": "Verify that in the presence of a type mapping a string value does not receive the default @language from context",
+      "input": "expand/0133-in.jsonld",
+      "expect": "expand/0133-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tc001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "adding new term",

--- a/tests/expand/0133-in.jsonld
+++ b/tests/expand/0133-in.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "typed": { "@id": "https://example.org/typed", "@type": "https://example.com/dt" },
+    "@language": "und"
+  },
+  "typed": "v"
+}

--- a/tests/expand/0133-out.jsonld
+++ b/tests/expand/0133-out.jsonld
@@ -1,0 +1,10 @@
+[
+  {
+    "https://example.org/typed": [
+      {
+        "@type": "https://example.com/dt",
+        "@value": "v"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This adds a test to check that when the context has a default language and we're expanding a string value that has a type mapping, the default language is not added.

It ensures Step 5 in Value Expansion is only performed for string values in the absence of a type mapping.

Fixes: #700