### PR TITLE
compaction: empty array and candidate selection

### DIFF
--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -967,6 +967,15 @@
       "expect": "compact/0114-out.jsonld",
       "option": {"base": "https://example.org/", "specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#t0115",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Empty array is significant for candidate selection",
+      "purpose": "Candidate selection in IRI compaction is influenced by the presence of the empty array value",
+      "input": "compact/0115-in.jsonld",
+      "context": "compact/0115-context.jsonld",
+      "expect": "compact/0115-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tc001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "adding new term",

--- a/tests/compact/0115-context.jsonld
+++ b/tests/compact/0115-context.jsonld
@@ -1,0 +1,4 @@
+{
+  "ex": "http://example.org/",
+  "ex:prop": { "@id": "http://example.org/prop", "@container": "@list" }
+}

--- a/tests/compact/0115-in.jsonld
+++ b/tests/compact/0115-in.jsonld
@@ -1,0 +1,4 @@
+{
+  "@id": "http://example.org/id",
+  "http://example.org/prop": []
+}

--- a/tests/compact/0115-out.jsonld
+++ b/tests/compact/0115-out.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "ex": "http://example.org/",
+    "ex:prop": { "@id": "http://example.org/prop", "@container": "@list" }
+  },
+  "@id": "ex:id",
+  "http://example.org/prop": []
+}


### PR DESCRIPTION
This ensures that in 12.7 in value compaction the empty array is passed through, as it affects candidate selection in step 7.3 of IRI compaction.