### PR TITLE
Skip report auto-commit for fork PRs

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -26,8 +26,8 @@ jobs:
       #- name: Generate Report
       #  run:  (cd reports; rake)
       - uses: stefanzweifel/git-auto-commit-action@v4
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           commit_message: Automated report generation
           commit_user_name: Report generation bot
           commit_user_email: <>
-


### PR DESCRIPTION
Keep report and manifest generation running for all pull requests, but skip the auto-commit action when the PR head is a fork. This prevents the action from attempting to check out a fork-only branch in the base repository.