### PR TITLE
compaction: empty array and candidate selection

### DIFF
--- a/tests/compact-manifest.html
+++ b/tests/compact-manifest.html
@@ -3235,6 +3235,38 @@
             </dd>
           </dl>
         </dd>
+        <dt id='t0115'>
+          Test t0115 Empty array is significant for candidate selection
+        </dt>
+        <dd>
+          <dl class='entry'>
+            <dt>id</dt>
+            <dd>#t0115</dd>
+            <dt>Type</dt>
+            <dd>jld:PositiveEvaluationTest, jld:CompactTest</dd>
+            <dt>Purpose</dt>
+            <dd>Candidate selection in IRI compaction is influenced by the presence of the empty array value</dd>
+            <dt>input</dt>
+            <dd>
+              <a href='compact/0115-in.jsonld'>compact/0115-in.jsonld</a>
+            </dd>
+            <dt>context</dt>
+            <dd>
+              <a href='compact/0115-context.jsonld'>compact/0115-context.jsonld</a>
+            </dd>
+            <dt>expect</dt>
+            <dd>
+              <a href='compact/0115-out.jsonld'>compact/0115-out.jsonld</a>
+            </dd>
+            <dt>Options</dt>
+            <dd>
+              <dl class='options'>
+                <dt>specVersion</dt>
+                <dd>json-ld-1.1</dd>
+              </dl>
+            </dd>
+          </dl>
+        </dd>
         <dt id='tc001'>
           Test tc001 adding new term
         </dt>

--- a/tests/compact-manifest.jsonld
+++ b/tests/compact-manifest.jsonld
@@ -967,6 +967,15 @@
       "expect": "compact/0114-out.jsonld",
       "option": {"base": "https://example.org/", "specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#t0115",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Empty array is significant for candidate selection",
+      "purpose": "Candidate selection in IRI compaction is influenced by the presence of the empty array value",
+      "input": "compact/0115-in.jsonld",
+      "context": "compact/0115-context.jsonld",
+      "expect": "compact/0115-out.jsonld",
+      "option": {"specVersion": "json-ld-1.1"}
+    }, {
       "@id": "#tc001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "adding new term",

--- a/tests/compact/0115-context.jsonld
+++ b/tests/compact/0115-context.jsonld
@@ -1,4 +1,6 @@
 {
-  "ex": "http://example.org/",
-  "ex:prop": { "@id": "http://example.org/prop", "@container": "@list" }
+  "@context": {
+    "ex": "http://example.org/",
+    "ex:prop": { "@id": "http://example.org/prop", "@container": "@list" }
+  }
 }

--- a/tests/compact/0115-context.jsonld
+++ b/tests/compact/0115-context.jsonld
@@ -1,0 +1,4 @@
+{
+  "ex": "http://example.org/",
+  "ex:prop": { "@id": "http://example.org/prop", "@container": "@list" }
+}

--- a/tests/compact/0115-in.jsonld
+++ b/tests/compact/0115-in.jsonld
@@ -1,0 +1,4 @@
+{
+  "@id": "http://example.org/id",
+  "http://example.org/prop": []
+}

--- a/tests/compact/0115-out.jsonld
+++ b/tests/compact/0115-out.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "ex": "http://example.org/",
+    "ex:prop": { "@id": "http://example.org/prop", "@container": "@list" }
+  },
+  "@id": "ex:id",
+  "http://example.org/prop": []
+}

--- a/tests/fromRdf-manifest.html
+++ b/tests/fromRdf-manifest.html
@@ -676,6 +676,34 @@
             </dd>
           </dl>
         </dd>
+        <dt id='t0028'>
+          Test t0028 use native types flag with non-native values
+        </dt>
+        <dd>
+          <dl class='entry'>
+            <dt>id</dt>
+            <dd>#t0028</dd>
+            <dt>Type</dt>
+            <dd>jld:PositiveEvaluationTest, jld:FromRDFTest</dd>
+            <dt>Purpose</dt>
+            <dd>Ensure that useNativeTypes flag being true does not interfere with values that cannot be serialized into a native value.</dd>
+            <dt>input</dt>
+            <dd>
+              <a href='fromRdf/0028-in.nq'>fromRdf/0028-in.nq</a>
+            </dd>
+            <dt>expect</dt>
+            <dd>
+              <a href='fromRdf/0028-out.jsonld'>fromRdf/0028-out.jsonld</a>
+            </dd>
+            <dt>Options</dt>
+            <dd>
+              <dl class='options'>
+                <dt>useNativeTypes</dt>
+                <dd>true</dd>
+              </dl>
+            </dd>
+          </dl>
+        </dd>
         <dt id='tdi01'>
           Test tdi01 rdfDirection: null with i18n literal with direction and no language
         </dt>


### PR DESCRIPTION
This ensures that in 12.7 in value compaction the empty array is passed
through, as it affects candidate selection in step 7.3 of IRI
compaction.

---

This is a "redo" of #703 which got closed accidently (with another apology to @daenney)
