### PR TITLE
Reenable example testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,15 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    # - name: Set up Ruby
-    #   uses: ruby/setup-ruby@v1
-    #   with:
-    #     ruby-version: 3.2
-    # - name: Install dependencies
-    #   run: bundle install
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.2
+    - name: Install dependencies
+      run: bundle install
 
-    # - name: Verify examples are consistent
-    #   run: bundle exec rake test
+    - name: Verify examples are consistent
+      run: bundle exec rake test
 
     - name: Echidna Auto-publish WD
       uses: w3c/spec-prod@v2

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,22 @@
 require 'bundler/setup'
+require 'shellwords'
+require 'tmpdir'
 task default: :test
 
 desc "Test examples in spec files"
 task :test do
-  sh %(wget https://w3c.github.io/json-ld-wg/common/extract-examples.rb)
-  sh %(bundle exec extract-examples.rb index.html)
+  # Ruby RDF supports JSON-LD 1.1, so validate a temporary 1.1-compatible copy.
+  Dir.mktmpdir('json-ld-api-examples') do |directory|
+    source = File.read('index.html')
+    document = File.join(directory, 'index.html')
+    compatible_source = source.gsub(/("@version"\s*:\s*)1\.2\b/) { "#{$1}1.1" }
+    abort 'No JSON-LD 1.2 version entry found in index.html' if compatible_source == source
+    File.write(document, compatible_source)
+
+    extractor = File.join(directory, 'extract-examples.rb')
+    sh "wget -q -O #{Shellwords.escape(extractor)} https://w3c.github.io/json-ld-wg/common/extract-examples.rb"
+    sh "bundle exec ruby #{Shellwords.escape(extractor)} #{Shellwords.escape(document)}"
+  end
 end
 
 desc "Extract Examples"


### PR DESCRIPTION
# Why

We are using `ruby-rdf` to test examples. One of the examples says, in its context, that

```json
{
  "@context": {
    "@version": "1.2"
  }
}
```

which crashes `ruby-rdf`.

# What

Closes #698

Reenables the example-validation workflow and runs it against a temporary JSON-LD 1.1-compatible copy, preserving the JSON-LD 1.2 source document.