### PR TITLE
Add Ruby RDF JSON-LD conformance validation

### DIFF
--- a/.github/workflows/ruby-rdf-json-ld-conformance.yml
+++ b/.github/workflows/ruby-rdf-json-ld-conformance.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   conformance:
@@ -70,7 +71,53 @@ jobs:
             sq --json -f earl/affected-tests.rq > "$RUNNER_TEMP/affected-tests.json"
             sq --json -f earl/reports-populated.rq > "$RUNNER_TEMP/reports-populated.json"
           )
+          set +e
           python3 "$GITHUB_WORKSPACE/candidate/validation/render-earl-comparison.py" \
             "$RUNNER_TEMP/affected-tests.json" \
             "$RUNNER_TEMP/reports-populated.json" \
-            "$GITHUB_STEP_SUMMARY"
+            "$RUNNER_TEMP/earl-comparison.md"
+          comparison_status=$?
+          set -e
+          cat "$RUNNER_TEMP/earl-comparison.md" >> "$GITHUB_STEP_SUMMARY"
+          exit "$comparison_status"
+
+      - name: Publish EARL report comment
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@v7
+        env:
+          REPORT_PATH: ${{ runner.temp }}/earl-comparison.md
+        with:
+          script: |
+            const fs = require("node:fs");
+            const marker = "<!-- ruby-rdf-json-ld-conformance -->";
+            const report = fs.existsSync(process.env.REPORT_PATH)
+              ? fs.readFileSync(process.env.REPORT_PATH, "utf8")
+              : "The EARL report could not be generated; inspect the workflow log.";
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const body = `${marker}\n[View workflow run](${runUrl})\n\n${report}`;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(
+              (comment) =>
+                comment.user.login === "github-actions[bot]" &&
+                comment.body.includes(marker),
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/ruby-rdf-json-ld-conformance.yml
+++ b/.github/workflows/ruby-rdf-json-ld-conformance.yml
@@ -1,0 +1,76 @@
+name: Ruby RDF JSON-LD conformance
+
+on:
+  pull_request:
+    branches: ['**']
+
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    name: JSON-LD API compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out pull request
+        uses: actions/checkout@v4
+        with:
+          path: candidate
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Clone Ruby RDF JSON-LD
+        id: implementation
+        run: |
+          implementation_dir="$RUNNER_TEMP/ruby-rdf-json-ld"
+          git clone --depth 1 --branch develop https://github.com/ruby-rdf/json-ld.git "$implementation_dir"
+          echo "directory=$implementation_dir" >> "$GITHUB_OUTPUT"
+          echo "commit=$(git -C "$implementation_dir" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Install Ruby RDF JSON-LD dependencies
+        working-directory: ${{ steps.implementation.outputs.directory }}
+        run: bundle install --jobs 4 --retry 3
+
+      - name: Generate candidate EARL report
+        run: |
+          candidate_report="$RUNNER_TEMP/ruby-rdf-json-ld-candidate.ttl"
+          python3 candidate/validation/run-ruby-rdf-json-ld-earl.py \
+            "${{ steps.implementation.outputs.directory }}" \
+            "$GITHUB_WORKSPACE/candidate/tests" \
+            "$candidate_report"
+          echo "candidate_report=$candidate_report" >> "$GITHUB_ENV"
+
+      - name: Install SPARQL tools
+        run: |
+          cargo install sparqld --version 0.1.4
+          cargo install --git https://github.com/ktk/sq
+
+      - name: Install Python dependencies
+        run: python3 -m pip install "$GITHUB_WORKSPACE/candidate/validation"
+
+      - name: Compare EARL reports with SPARQL
+        env:
+          IMPLEMENTATION_COMMIT: ${{ steps.implementation.outputs.commit }}
+        run: |
+          reports_dir="$RUNNER_TEMP/earl-reports"
+          mkdir "$reports_dir"
+          cp "$GITHUB_WORKSPACE"/candidate/reports/*.ttl "$reports_dir"
+          cp "$candidate_report" "$reports_dir/candidate.ttl"
+
+          sparqld --no-watch "$reports_dir" > "$RUNNER_TEMP/sparqld.log" 2>&1 &
+          sparqld_pid=$!
+          trap 'kill "$sparqld_pid" || true' EXIT
+          sleep 1
+
+          (
+            cd "$GITHUB_WORKSPACE/candidate/validation"
+            sq --json -f earl/affected-tests.rq > "$RUNNER_TEMP/affected-tests.json"
+            sq --json -f earl/reports-populated.rq > "$RUNNER_TEMP/reports-populated.json"
+          )
+          python3 "$GITHUB_WORKSPACE/candidate/validation/render-earl-comparison.py" \
+            "$RUNNER_TEMP/affected-tests.json" \
+            "$RUNNER_TEMP/reports-populated.json" \
+            "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ruby-rdf-json-ld-conformance.yml
+++ b/.github/workflows/ruby-rdf-json-ld-conformance.yml
@@ -34,6 +34,9 @@ jobs:
         working-directory: ${{ steps.implementation.outputs.directory }}
         run: bundle install --jobs 4 --retry 3
 
+      - name: Install Python dependencies
+        run: python3 -m pip install "$GITHUB_WORKSPACE/candidate/validation"
+
       - name: Generate candidate EARL report
         run: |
           candidate_report="$RUNNER_TEMP/ruby-rdf-json-ld-candidate.ttl"
@@ -47,9 +50,6 @@ jobs:
         run: |
           cargo install sparqld --version 0.1.4
           cargo install --git https://github.com/ktk/sq
-
-      - name: Install Python dependencies
-        run: python3 -m pip install "$GITHUB_WORKSPACE/candidate/validation"
 
       - name: Compare EARL reports with SPARQL
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # pyenv version file
 .python-version
+
+# Python bytecode
+__pycache__/

--- a/validation/.sq.toml
+++ b/validation/.sq.toml
@@ -1,0 +1,7 @@
+default = "sparqld"
+
+[endpoints.sparqld]
+url = "http://127.0.0.1:7737/"
+
+[prefixes]
+earl = "http://www.w3.org/ns/earl#"

--- a/validation/earl/affected-tests.rq
+++ b/validation/earl/affected-tests.rq
@@ -1,0 +1,79 @@
+PREFIX earl: <http://www.w3.org/ns/earl#>
+
+SELECT ?category ?test ?baselineOutcome ?candidateOutcome WHERE {
+  {
+    BIND("Regressed" AS ?category)
+    GRAPH <sparqld:ruby-json-ld-earl.ttl> {
+      [] a earl:Assertion;
+        earl:test ?test;
+        earl:result [ earl:outcome earl:passed ] .
+    }
+    GRAPH <sparqld:candidate.ttl> {
+      [] a earl:Assertion;
+        earl:test ?test;
+        earl:result [ earl:outcome earl:failed ] .
+    }
+    BIND("passed" AS ?baselineOutcome)
+    BIND("failed" AS ?candidateOutcome)
+  }
+  UNION
+  {
+    BIND("Improved" AS ?category)
+    GRAPH <sparqld:ruby-json-ld-earl.ttl> {
+      [] a earl:Assertion;
+        earl:test ?test;
+        earl:result [ earl:outcome ?baselineEarlOutcome ] .
+      VALUES ?baselineEarlOutcome { earl:failed earl:untested }
+    }
+    GRAPH <sparqld:candidate.ttl> {
+      [] a earl:Assertion;
+        earl:test ?test;
+        earl:result [ earl:outcome earl:passed ] .
+    }
+    BIND(
+      STRAFTER(STR(?baselineEarlOutcome), "http://www.w3.org/ns/earl#")
+      AS ?baselineOutcome
+    )
+    BIND("passed" AS ?candidateOutcome)
+  }
+  UNION
+  {
+    BIND("New assertion" AS ?category)
+    GRAPH <sparqld:candidate.ttl> {
+      [] a earl:Assertion;
+        earl:test ?test;
+        earl:result [ earl:outcome ?candidateEarlOutcome ] .
+    }
+    FILTER NOT EXISTS {
+      GRAPH <sparqld:ruby-json-ld-earl.ttl> {
+        [] a earl:Assertion; earl:test ?test .
+      }
+    }
+    BIND("Not asserted" AS ?baselineOutcome)
+    BIND(
+      STRAFTER(STR(?candidateEarlOutcome), "http://www.w3.org/ns/earl#")
+      AS ?candidateOutcome
+    )
+  }
+  UNION
+  {
+    BIND("No longer asserted" AS ?category)
+    GRAPH <sparqld:ruby-json-ld-earl.ttl> {
+      [] a earl:Assertion;
+        earl:test ?test;
+        earl:result [ earl:outcome ?baselineEarlOutcome ] .
+    }
+    FILTER NOT EXISTS {
+      GRAPH <sparqld:candidate.ttl> {
+        [] a earl:Assertion; earl:test ?test .
+      }
+    }
+    BIND(
+      STRAFTER(STR(?baselineEarlOutcome), "http://www.w3.org/ns/earl#")
+      AS ?baselineOutcome
+    )
+    BIND("Not asserted" AS ?candidateOutcome)
+  }
+  FILTER STRSTARTS(STR(?test), "https://w3c.github.io/json-ld-api/tests/")
+}
+ORDER BY ?category ?test

--- a/validation/earl/reports-populated.rq
+++ b/validation/earl/reports-populated.rq
@@ -1,0 +1,10 @@
+PREFIX earl: <http://www.w3.org/ns/earl#>
+
+ASK {
+  GRAPH <sparqld:ruby-json-ld-earl.ttl> {
+    [] a earl:Assertion .
+  }
+  GRAPH <sparqld:candidate.ttl> {
+    [] a earl:Assertion .
+  }
+}

--- a/validation/earl_comparison.py
+++ b/validation/earl_comparison.py
@@ -1,0 +1,111 @@
+"""Typed EARL comparison data built from SPARQL JSON results."""
+
+from enum import Enum
+from pathlib import Path
+from urllib.parse import urlparse
+
+from pydantic import AnyHttpUrl, BaseModel
+
+
+class ChangeCategory(str, Enum):
+    REGRESSED = "Regressed"
+    IMPROVED = "Improved"
+    NEW_ASSERTION = "New assertion"
+    NO_LONGER_ASSERTED = "No longer asserted"
+
+
+class Outcome(str, Enum):
+    PASSED = "passed"
+    FAILED = "failed"
+    UNTESTED = "untested"
+    NOT_ASSERTED = "Not asserted"
+
+
+class SparqlTerm(BaseModel):
+    value: str
+
+
+class SparqlBinding(BaseModel):
+    category: SparqlTerm
+    test: SparqlTerm
+    baselineOutcome: SparqlTerm
+    candidateOutcome: SparqlTerm
+
+
+class SparqlResults(BaseModel):
+    bindings: list[SparqlBinding]
+
+
+class SparqlSelectResponse(BaseModel):
+    results: SparqlResults
+
+
+class SparqlAskResponse(BaseModel):
+    boolean: bool
+
+
+class AffectedTest(BaseModel):
+    category: ChangeCategory
+    test: AnyHttpUrl
+    published_outcome: Outcome
+    candidate_outcome: Outcome
+
+    @property
+    def label(self) -> str:
+        parsed = urlparse(str(self.test))
+        return f"{Path(parsed.path).name}#{parsed.fragment}"
+
+
+class ComparisonReport(BaseModel):
+    implementation_commit: str
+    affected_tests: list[AffectedTest]
+
+    @property
+    def has_regressions(self) -> bool:
+        return any(
+            change.category is ChangeCategory.REGRESSED
+            for change in self.affected_tests
+        )
+
+    @property
+    def regressions(self) -> list[AffectedTest]:
+        return [
+            change
+            for change in self.affected_tests
+            if change.category is ChangeCategory.REGRESSED
+        ]
+
+
+CATEGORY_ORDER = {category: index for index, category in enumerate(ChangeCategory)}
+
+
+def read_comparison(
+    comparison_path: Path,
+    populated_path: Path,
+    implementation_commit: str,
+) -> ComparisonReport:
+    populated = SparqlAskResponse.model_validate_json(
+        populated_path.read_text(encoding="utf-8")
+    )
+    if not populated.boolean:
+        raise ValueError("The published or candidate EARL report has no assertions")
+
+    response = SparqlSelectResponse.model_validate_json(
+        comparison_path.read_text(encoding="utf-8")
+    )
+    affected_tests = [
+        AffectedTest(
+            category=binding.category.value,
+            test=binding.test.value,
+            published_outcome=binding.baselineOutcome.value,
+            candidate_outcome=binding.candidateOutcome.value,
+        )
+        for binding in response.results.bindings
+    ]
+    affected_tests.sort(
+        key=lambda change: (CATEGORY_ORDER[change.category], str(change.test))
+    )
+    return ComparisonReport(
+        implementation_commit=implementation_commit,
+        affected_tests=affected_tests,
+    )

--- a/validation/pyproject.toml
+++ b/validation/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "json-ld-api-earl-comparison"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+  "pydantic>=2,<3",
+  "sh>=2,<3",
+]

--- a/validation/render-earl-comparison.py
+++ b/validation/render-earl-comparison.py
@@ -64,18 +64,6 @@ def main() -> int:
     with summary_path.open("a", encoding="utf-8") as summary:
         summary.write(render_markdown(report))
 
-    run_url = "/".join(
-        [
-            os.environ["GITHUB_SERVER_URL"],
-            os.environ["GITHUB_REPOSITORY"],
-            "actions/runs",
-            os.environ["GITHUB_RUN_ID"],
-        ]
-    )
-    print(
-        "::notice title=EARL comparison report::"
-        f"View the full report in the run Summary: {run_url}"
-    )
     for regression in report.regressions:
         print(
             "::error title=Ruby RDF JSON-LD regression::"

--- a/validation/render-earl-comparison.py
+++ b/validation/render-earl-comparison.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Render a Markdown job summary from a typed EARL comparison report."""
+
+import os
+import sys
+from pathlib import Path
+
+from earl_comparison import AffectedTest, ComparisonReport, read_comparison
+
+
+def markdown_row(change: AffectedTest) -> str:
+    return (
+        f"| {change.category.value} | [{change.label}]({change.test}) | "
+        f"`{change.published_outcome.value}` | `{change.candidate_outcome.value}` |"
+    )
+
+
+def render_markdown(report: ComparisonReport) -> str:
+    lines = [
+        "## Ruby RDF JSON-LD conformance",
+        "",
+        f"Implementation commit: `{report.implementation_commit}`",
+        "",
+    ]
+    if report.affected_tests:
+        lines.extend(
+            [
+                "| Change | Test | Published report | Candidate report |",
+                "| --- | --- | --- | --- |",
+                *(markdown_row(change) for change in report.affected_tests),
+            ]
+        )
+    else:
+        lines.append("No affected tests.")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        raise SystemExit(
+            "usage: render-earl-comparison.py COMPARISON.json POPULATED.json SUMMARY.md"
+        )
+
+    comparison_path, populated_path, summary_path = map(Path, sys.argv[1:])
+    report = read_comparison(
+        comparison_path,
+        populated_path,
+        os.environ["IMPLEMENTATION_COMMIT"],
+    )
+
+    with summary_path.open("a", encoding="utf-8") as summary:
+        summary.write(render_markdown(report))
+
+    for regression in report.regressions:
+        print(
+            "::error title=Ruby RDF JSON-LD regression::"
+            f"{regression.test} changed from passed to failed"
+        )
+    return int(report.has_regressions)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/validation/render-earl-comparison.py
+++ b/validation/render-earl-comparison.py
@@ -8,10 +8,23 @@ from pathlib import Path
 from earl_comparison import AffectedTest, ComparisonReport, read_comparison
 
 
+OUTCOME_ICONS = {
+    "passed": "✅",
+    "failed": "❌",
+    "untested": "⚪",
+    "Not asserted": "➖",
+}
+
+
+def outcome_cell(outcome: str) -> str:
+    return f"{OUTCOME_ICONS[outcome]} {outcome}"
+
+
 def markdown_row(change: AffectedTest) -> str:
     return (
         f"| {change.category.value} | [{change.label}]({change.test}) | "
-        f"`{change.published_outcome.value}` | `{change.candidate_outcome.value}` |"
+        f"{outcome_cell(change.published_outcome.value)} | "
+        f"{outcome_cell(change.candidate_outcome.value)} |"
     )
 
 
@@ -51,6 +64,18 @@ def main() -> int:
     with summary_path.open("a", encoding="utf-8") as summary:
         summary.write(render_markdown(report))
 
+    run_url = "/".join(
+        [
+            os.environ["GITHUB_SERVER_URL"],
+            os.environ["GITHUB_REPOSITORY"],
+            "actions/runs",
+            os.environ["GITHUB_RUN_ID"],
+        ]
+    )
+    print(
+        "::notice title=EARL comparison report::"
+        f"View the full report in the run Summary: {run_url}"
+    )
     for regression in report.regressions:
         print(
             "::error title=Ruby RDF JSON-LD regression::"

--- a/validation/ruby-rdf-json-ld-earl.rb
+++ b/validation/ruby-rdf-json-ld-earl.rb
@@ -1,0 +1,230 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Copied from https://github.com/ruby-rdf/json-ld/blob/develop/script/tc.
+#
+# Adaptations for this repository:
+# - resolves implementation files through RUBY_RDF_JSON_LD_DIR, the CI clone;
+# - runs only the JSON-LD API manifests maintained in this repository;
+# - omits the upstream streaming, framing, and JSON-LD-star manifest groups.
+
+require 'rubygems'
+require 'bundler/setup'
+require 'logger'
+
+IMPLEMENTATION_DIR = ENV.fetch('RUBY_RDF_JSON_LD_DIR')
+$LOAD_PATH.unshift(File.join(IMPLEMENTATION_DIR, 'lib'))
+require 'json/ld'
+require 'rdf/isomorphic'
+require 'getoptlong'
+require File.join(IMPLEMENTATION_DIR, 'spec/spec_helper')
+require File.join(IMPLEMENTATION_DIR, 'spec/suite_helper')
+
+ASSERTOR = 'http://greggkellogg.net/foaf#me'
+RUN_TIME = Time.now
+
+MultiJson.use(:json_gem)
+
+def earl_preamble(options)
+  implementation_dir = ENV.fetch('RUBY_RDF_JSON_LD_DIR')
+  options[:output].write File.read(File.join(implementation_dir, 'etc/doap.ttl'))
+  options[:output].puts %(
+<https://rubygems.org/gems/json-ld> doap:release [
+  doap:name "json-ld-#{JSON::LD::VERSION}";
+  doap:revision "#{JSON::LD::VERSION}";
+  doap:created "#{File.mtime(File.join(implementation_dir, 'VERSION')).strftime('%Y-%m-%d')}"^^xsd:date;
+] .
+<> foaf:primaryTopic <https://rubygems.org/gems/json-ld>;
+  dc:issued "#{RUN_TIME.xmlschema}"^^xsd:dateTime;
+  foaf:maker <#{ASSERTOR}> .
+
+<#{ASSERTOR}> a earl:Assertor;
+  foaf:title "Implementor" .
+)
+end
+
+def compare_results(tc, result, expected)
+  if tc.evaluationTest?
+    if tc.testType == 'jld:ToRDFTest'
+      expected.equivalent_graph?(result) ? 'passed' : 'failed'
+    elsif tc.options[:ordered]
+      expected == result ? 'passed' : 'failed'
+    elsif !expected.equivalent_jsonld?(result)
+      'failed'
+    elsif result.to_s.include?('@context')
+      exp_expected = JSON::LD::API.expand(expected, **tc.options.merge(logger: false))
+      exp_result = JSON::LD::API.expand(result, **tc.options.merge(logger: false))
+      exp_expected.equivalent_jsonld?(exp_result) ? 'passed' : 'failed'
+    else
+      'passed'
+    end
+  else
+    result.nil? ? 'failed' : 'passed'
+  end
+end
+
+def run_tc(man, tc, options)
+  tc.options[:logger] = options[:logger]
+  tc.options[:documentLoader] ||= Fixtures::SuiteTest.method(:documentLoader)
+  tc.options[:lowercaseLanguage] = true
+
+  if tc.options[:specVersion] == 'json-ld-1.0'
+    STDERR.puts "skip #{tc.property('input')} (1.0 test)" if options[:verbose]
+    return
+  end
+
+  STDERR.write "run #{tc.property('input')}"
+  if options[:verbose]
+    puts "\nTestCase: #{tc.inspect}"
+    puts "\nInput:\n#{tc.input}"
+    puts "\nContext:\n#{tc.context}" if tc.context
+    puts "\nFrame:\n#{tc.frame}" if tc.frame
+    puts "\nExpected:\n#{tc.expect}" if tc.expect && tc.positiveTest?
+    puts "\nExpected:\n#{tc.expectErrorCode}" if tc.negativeTest?
+  end
+
+  output = ''
+  begin
+    puts "open #{tc.input_loc}" if options[:verbose]
+    result = case tc.testType
+    when 'jld:CompactTest'
+      output = JSON::LD::API.compact(tc.input_loc, tc.context_json['@context'], validate: true, **tc.options)
+      expected = JSON.load(tc.expect) if tc.evaluationTest? && tc.positiveTest?
+      compare_results(tc, output, expected)
+    when 'jld:ExpandTest'
+      output = JSON::LD::API.expand(tc.input_loc, validate: true, **tc.options)
+      expected = JSON.load(tc.expect) if tc.evaluationTest? && tc.positiveTest?
+      compare_results(tc, output, expected)
+    when 'jld:FlattenTest'
+      output = JSON::LD::API.flatten(tc.input_loc, (tc.context_json['@context'] if tc.context_loc), validate: true, **tc.options)
+      expected = JSON.load(tc.expect) if tc.evaluationTest? && tc.positiveTest?
+      compare_results(tc, output, expected)
+    when 'jld:FrameTest'
+      output = JSON::LD::API.frame(tc.input_loc, tc.frame_loc, validate: true, **tc.options)
+      expected = JSON.load(tc.expect) if tc.evaluationTest? && tc.positiveTest?
+      compare_results(tc, output, expected)
+    when 'jld:FromRDFTest'
+      repo = RDF::Repository.load(tc.input_loc, format: :nquads, rdfstar: tc.options[:rdfstar])
+      output = if options[:stream]
+        JSON.parse(JSON::LD::Writer.buffer(stream: true, validate: true, **tc.options) { |writer| writer << repo })
+      else
+        JSON::LD::API.fromRdf(repo, validate: true, **tc.options)
+      end
+      expected = JSON.load(tc.expect) if tc.evaluationTest? && tc.positiveTest?
+      compare_results(tc, output, expected)
+    when 'jld:ToRDFTest'
+      output = RDF::Repository.new.extend(RDF::Isomorphic)
+      if options[:stream]
+        JSON::LD::Reader.open(tc.input_loc, stream: true, **tc.options.merge(logger: false)) { |statement| output << statement }
+      else
+        JSON::LD::API.toRdf(tc.input_loc, **tc.options) { |statement| output << statement }
+      end
+      if tc.evaluationTest? && tc.positiveTest?
+        begin
+          if tc.options[:produceGeneralizedRdf]
+            quads = JSON::LD::API.toRdf(tc.input_loc, **tc.options.merge(validate: false)).map { |statement| tc.to_quad(statement) }
+            output = quads.sort.uniq.join('')
+            output == tc.expect ? 'passed' : (tc.input_loc.include?('e075') ? 'passed' : 'failed')
+          else
+            expected = RDF::Repository.new << RDF::NQuads::Reader.new(tc.expect, rdfstar: tc.options[:rdfstar], validate: false, logger: [])
+            output.isomorphic?(expected) ? 'passed' : 'failed'
+          end
+        rescue RDF::ReaderError, JSON::LD::JsonLdError
+          quads = JSON::LD::API.toRdf(tc.input_loc, rdfstar: tc.options[:rdfstar], **tc.options.merge(validate: false)).map { |statement| tc.to_quad(statement) }
+          output = quads.sort.uniq.join('')
+          output == tc.expect ? 'passed' : (tc.input_loc.include?('e075') ? 'passed' : 'failed')
+        end
+      else
+        output.count > 0 ? 'passed' : 'failed'
+      end
+    end || 'untested'
+
+    output = output.dump(:nquads, validate: false) rescue output.to_s if output.is_a?(RDF::Enumerable)
+    puts "\nOutput:\n#{tc.testType == 'jld:ToRDFTest' ? output : output.to_json(JSON::LD::JSON_STATE)}" if !tc.syntaxTest? && options[:verbose]
+    result = result ? 'failed' : 'passed' unless tc.positiveTest?
+    options[:results][result] = options[:results].fetch(result, 0) + 1
+  rescue Interrupt
+    $stderr.puts '(interrupt)'
+    exit 1
+  rescue StandardError => e
+    result = if tc.positiveTest?
+      STDERR.puts " exception: #{e}" unless options[:quiet]
+      raise unless options[:quiet] || !options[:verbose]
+
+      options[:results]['failed'] = options[:results].fetch('failed', 0) + 1
+      'failed'
+    elsif e.message.include?(tc.property('expectErrorCode'))
+      options[:results]['passed'] = options[:results].fetch('passed', 0) + 1
+      'passed'
+    else
+      STDERR.puts("Expected exception: '#{tc.property('expectErrorCode')}' not '#{e}'") unless options[:quiet]
+      options[:results]['failed'] = options[:results].fetch('failed', 0) + 1
+      'failed'
+    end
+  end
+
+  if options[:earl]
+    options[:output].puts %(
+[ a earl:Assertion;
+  earl:assertedBy <#{ASSERTOR}>;
+  earl:subject <https://rubygems.org/gems/json-ld>;
+  earl:test <#{man}#{tc.id}>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:#{result};
+    dc:date "#{RUN_TIME.xmlschema}"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+)
+  end
+
+  puts "#{' test result:' unless options[:quiet]} #{result}"
+end
+
+logger = Logger.new($stderr)
+logger.level = Logger::WARN
+logger.formatter = ->(severity, _datetime, _progname, message) { "#{severity}: #{message}\n" }
+options = { output: $stdout, results: {}, logger: logger }
+
+opts = GetoptLong.new(
+  ['--help', '-?', GetoptLong::NO_ARGUMENT],
+  ['--debug', GetoptLong::NO_ARGUMENT],
+  ['--earl', GetoptLong::NO_ARGUMENT],
+  ['--quiet', '-q', GetoptLong::NO_ARGUMENT],
+  ['--output', '-o', GetoptLong::REQUIRED_ARGUMENT],
+  ['--verbose', '-v', GetoptLong::NO_ARGUMENT]
+)
+
+def help
+  puts "Usage: #{$PROGRAM_NAME} [options] [test-number ...]"
+  puts '      --earl: Generate an EARL report'
+  puts '      --output: Write to the specified file'
+  exit 0
+end
+
+opts.each do |opt, arg|
+  case opt
+  when '--help' then help
+  when '--debug' then logger.level = Logger::DEBUG
+  when '--earl' then options[:quiet] = options[:earl] = true; logger.level = Logger::FATAL
+  when '--output' then options[:output] = File.open(arg, 'w')
+  when '--quiet' then options[:quiet] = true; logger.level = Logger::FATAL
+  when '--verbose' then options[:verbose] = true
+  end
+end
+
+manifests = %w[expand compact flatten fromRdf html remote-doc toRdf].map do |manifest|
+  "#{Fixtures::SuiteTest::SUITE}#{manifest}-manifest.jsonld"
+end
+
+earl_preamble(options) if options[:earl]
+manifests.each do |manifest|
+  Fixtures::SuiteTest::Manifest.open(manifest) do |loaded_manifest|
+    loaded_manifest.entries.each do |tc|
+      next unless ARGV.empty? || ARGV.any? { |number| tc.property('@id').match(/#{number}/) || tc.property('input').match(/#{number}/) }
+
+      run_tc(manifest.sub('.jsonld', ''), tc, options)
+    end
+  end
+end
+
+options[:results].each { |result, count| puts "#{result}: #{count}" }

--- a/validation/run-ruby-rdf-json-ld-earl.py
+++ b/validation/run-ruby-rdf-json-ld-earl.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Generate a Ruby RDF JSON-LD EARL report for this test suite."""
+
+import os
+import sys
+from pathlib import Path
+
+import sh
+
+
+def directory(path: str) -> Path:
+    resolved = Path(path).resolve()
+    if not resolved.is_dir():
+        raise ValueError(f"Expected a directory: {resolved}")
+    return resolved
+
+
+def main() -> None:
+    if len(sys.argv) != 4:
+        raise SystemExit(
+            "usage: run-ruby-rdf-json-ld-earl.py IMPLEMENTATION_DIR TESTS_DIR OUTPUT_FILE"
+        )
+
+    implementation_dir = directory(sys.argv[1])
+    tests_dir = directory(sys.argv[2])
+    output_file = Path(sys.argv[3]).resolve()
+    suite_parent = implementation_dir / "spec" / "json-ld-api"
+    suite_link = suite_parent / "tests"
+    if suite_link.exists() or suite_link.is_symlink():
+        raise ValueError(f"Expected a fresh implementation clone; {suite_link} already exists")
+
+    suite_parent.mkdir(parents=True, exist_ok=True)
+    suite_link.symlink_to(tests_dir)
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+
+    sh.Command("bundle")(
+        "exec",
+        "ruby",
+        str(Path(__file__).with_name("ruby-rdf-json-ld-earl.rb")),
+        "--earl",
+        "--output",
+        str(output_file),
+        _cwd=str(implementation_dir),
+        _env={
+            **os.environ,
+            "RUBY_RDF_JSON_LD_DIR": str(implementation_dir),
+        },
+        _out=sys.stdout,
+        _err=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds CI validation for Ruby RDF JSON-LD against this repository’s JSON-LD API suite.

The job generates an EARL report, compares it with the checked-in report through sparqld and sq, publishes affected test links in the GitHub Actions summary, and fails only on passed-to-failed regressions.